### PR TITLE
docs: improve readme and project profile

### DIFF
--- a/.github/profile/README.md
+++ b/.github/profile/README.md
@@ -1,0 +1,11 @@
+## AutoDream OS
+
+AutoDream OS is an open-source framework for assembling V2 standards compliant agent systems.
+It offers modular components, command line entrypoints, and robust testing utilities.
+
+### Highlights
+- Enforces strict V2 coding standards
+- CLI interfaces for all modules
+- Smoke tests and CI/CD templates
+
+For full documentation see the [main README](../../README.md).

--- a/README.md
+++ b/README.md
@@ -1,296 +1,54 @@
-# 🚀 Agent_Cellphone_V2 - V2 Standards Compliant System
+# AutoDream OS
 
-**Version**: 2.0.0  
-**Status**: ACTIVE - V2 STANDARDS COMPLIANT  
-**Last Updated**: 2024-08-19  
+AutoDream OS is a modular, V2 standards compliant platform for building agent-driven applications.
+It enforces strict coding standards and provides convenient command line interfaces for development and testing.
 
----
+## Features
+- **V2 coding standards** with line-count limits and object-oriented design
+- **Modular architecture** for core systems, services, launchers, utilities and web components
+- **CLI interfaces** for every module to assist quick experimentation
+- **Smoke tests and test suites** to validate components
+- **Structured logging and error handling**
+- **CI/CD templates** for Jenkins, GitLab CI and Docker
 
-## 📋 **EXECUTIVE SUMMARY**
-
-This is the **single source of truth** for the Agent_Cellphone_V2 system, following strict V2 coding standards to ensure code quality, maintainability, and agent usability.
-
-## 🏗️ **V2 CODING STANDARDS ENFORCEMENT**
-
-### **📏 LINE COUNT LIMITS**
-- **Standard Files**: **300 LOC** (Lines of Code) ✅
-- **GUI Components**: **500 LOC** (250 logic + 250 GUI) ✅
-- **Enforcement**: **STRICT** - All files must comply
-
-### **🎯 OBJECT-ORIENTED DESIGN (OOP)**
-- **All code must be properly OOP** ✅
-- **Classes must have clear responsibilities** ✅
-- **Proper inheritance and composition** ✅
-- **Interface segregation principles** ✅
-
-### **🔒 SINGLE RESPONSIBILITY PRINCIPLE (SRP)**
-- **One class = one responsibility** ✅
-- **Clear separation of concerns** ✅
-- **No mixed functionality** ✅
-- **Focused, purpose-driven classes** ✅
-
-### **🖥️ CLI INTERFACE REQUIREMENTS**
-- **Every module must have CLI interface for testing** ✅
-- **Comprehensive argument parsing** ✅
-- **Help documentation for all flags** ✅
-- **Easy testing for agents** ✅
-
-### **🧪 SMOKE TESTS**
-- **Every component must have working smoke tests** ✅
-- **Basic functionality validation** ✅
-- **CLI interface testing** ✅
-- **Error handling validation** ✅
-
----
-
-## 📁 **REPOSITORY STRUCTURE**
-
-```
-Agent_Cellphone_V2_Repository/
-├── src/                          # Main source code
-│   ├── __init__.py              # Main package with CLI interface ✅
-│   ├── core/                    # Core systems (≤300 LOC each) ✅
-│   │   ├── __init__.py          # Core module CLI interface ✅
-│   │   ├── performance_tracker.py
-│   │   ├── performance_profiler.py
-│   │   ├── performance_dashboard.py
-│   │   ├── api_gateway.py
-│   │   ├── agent_communication.py
-│   │   ├── health_monitor_core.py
-│   │   ├── agent_health_monitor.py
-│   │   ├── health_metrics_collector.py
-│   │   ├── health_alert_manager.py
-│   │   ├── health_threshold_manager.py
-│   │   └── health_score_calculator.py
-│   ├── services/                # Business logic (≤300 LOC each) ✅
-│   │   ├── __init__.py          # Services module CLI interface ✅
-│   │   └── agent_cell_phone.py
-│   ├── launchers/               # Entry points (≤300 LOC each) ✅
-│   │   ├── __init__.py          # Launchers module CLI interface ✅
-│   │   ├── unified_launcher_v2.py
-│   │   ├── launcher_core.py
-│   │   ├── launcher_modes.py
-│   │   ├── workspace_management_launcher.py
-│   │   ├── contract_management_launcher.py
-│   │   ├── onboarding_system_launcher.py
-│   │   └── sprint_management_launcher.py
-│   ├── utils/                   # Utilities (≤300 LOC each) ✅
-│   │   ├── __init__.py          # Utils module CLI interface ✅
-│   │   ├── config_loader.py
-│   │   ├── logging_setup.py
-│   │   ├── system_info.py
-│   │   ├── performance_monitor.py
-│   │   ├── dependency_checker.py
-│   │   ├── cli_utils.py
-│   │   ├── file_utils.py
-│   │   ├── message_builder.py
-│   │   ├── onboarding_utils.py
-│   │   ├── onboarding_coordinator.py
-│   │   ├── onboarding_orchestrator.py
-│   │   ├── config_utils_coordinator.py
-│   │   ├── system_utils_coordinator.py
-│   │   └── environment_overrides.py
-│   └── web/                     # Web components (≤500 LOC each) ✅
-│       ├── __init__.py          # Web module CLI interface ✅
-│       └── health_monitor_web.py
-├── tests/                       # Testing infrastructure ✅
-│   ├── smoke/                   # Smoke tests for each component
-│   ├── unit/                    # Unit tests
-│   └── integration/             # Integration tests
-├── examples/                    # Example usage and demos ✅
-├── docs/                       # Documentation ✅
-├── config/                     # Configuration files ✅
-├── scripts/                    # Utility scripts ✅
-├── requirements.txt            # Consolidated dependencies ✅
-├── V2_CODING_STANDARDS.md     # V2 standards documentation ✅
-├── pytest.ini                 # Testing configuration ✅
-├── .coveragerc                # Coverage configuration ✅
-├── .pre-commit-config.yaml    # Pre-commit hooks ✅
-├── .gitlab-ci.yml             # CI/CD pipeline ✅
-├── Jenkinsfile                # Jenkins pipeline ✅
-├── docker-compose.ci.yml      # Docker CI configuration ✅
-├── Makefile                   # Build automation ✅
-└── nginx.conf                 # Web server configuration ✅
+## Getting Started
+### Installation
+```bash
+pip install -r requirements.txt
 ```
 
----
-
-## 🚀 **QUICK START**
-
-### **1. System Status Check**
+### Quick status check
 ```bash
 python -m src --status
 ```
 
-### **2. Run All Tests**
+### Launch web module
 ```bash
-python -m src --test
+python -m src.web --start
 ```
 
-### **3. Run Demo**
+## Running Tests
 ```bash
-python -m src --demo
+pytest
 ```
 
-### **4. Validate V2 Standards**
-```bash
-python -m src --validate
+## Repository Structure
 ```
+src/      # application source
+tests/    # test suites
+docs/     # additional documentation
+examples/ # examples and demos
+```
+
+## Contributing
+- Follow the [V2 coding standards](V2_CODING_STANDARDS.md)
+- Keep files within the specified line-count limits
+- Provide CLI entrypoints and smoke tests for new modules
+
+## Links
+- [Examples](examples/)
+- [Tests](tests/)
+- [Configuration](config/)
 
 ---
-
-## 🔧 **MODULE USAGE**
-
-### **Core Module**
-```bash
-python -m src.core --help           # Show core module help
-python -m src.core --test           # Run core tests
-python -m src.core --status         # Show core status
-python -m src.core --demo           # Run core demo
-```
-
-### **Services Module**
-```bash
-python -m src.services --help       # Show services help
-python -m src.services --test       # Run services tests
-python -m src.services --demo       # Run services demo
-```
-
-### **Launchers Module**
-```bash
-python -m src.launchers --help      # Show launchers help
-python -m src.launchers --test      # Run launcher tests
-python -m src.launchers --launch unified  # Launch unified system
-```
-
-### **Utils Module**
-```bash
-python -m src.utils --help          # Show utils help
-python -m src.utils --test          # Run utils tests
-python -m src.utils --check-deps    # Check dependencies
-python -m src.utils --system-info   # Show system information
-```
-
-### **Web Module**
-```bash
-python -m src.web --help            # Show web module help
-python -m src.web --test            # Run web tests
-python -m src.web --start           # Start web server
-```
-
----
-
-## 🧪 **TESTING INFRASTRUCTURE**
-
-### **Smoke Tests**
-Every component has smoke tests for basic functionality validation:
-```bash
-# Test specific component
-python -m src.core.performance_tracker --test
-
-# Test entire module
-python -m src.core --test
-```
-
-### **Test Coverage**
-```bash
-# Run with coverage
-pytest --cov=src tests/
-
-# Generate HTML report
-pytest --cov=src --cov-report=html tests/
-```
-
----
-
-## 📊 **QUALITY ASSURANCE**
-
-### **Code Formatting**
-```bash
-# Format code with black
-black src/ tests/
-
-# Sort imports
-isort src/ tests/
-```
-
-### **Linting**
-```bash
-# Run flake8
-flake8 src/ tests/
-
-# Type checking with mypy
-mypy src/
-```
-
-### **Pre-commit Hooks**
-```bash
-# Install pre-commit hooks
-pre-commit install
-
-# Run all hooks
-pre-commit run --all-files
-```
-
----
-
-## 🔄 **CI/CD PIPELINE**
-
-- **GitLab CI**: Automated testing and deployment
-- **Jenkins**: Build and integration testing
-- **Docker**: Containerized CI environment
-- **Pre-commit**: Code quality enforcement
-
----
-
-## 📚 **DOCUMENTATION**
-
-- **V2_CODING_STANDARDS.md**: Complete coding standards
-- **API Documentation**: Auto-generated from code
-- **Examples**: Working demos and usage patterns
-- **Component Guides**: Individual component documentation
-
----
-
-## 🎯 **AGENT USABILITY FEATURES**
-
-- **CLI Interfaces**: Every component has command-line testing
-- **Help Systems**: Comprehensive help for all commands
-- **Smoke Tests**: Simple validation for agents
-- **Error Handling**: Clear error messages and recovery
-- **Logging**: Structured logging for debugging
-
----
-
-## 🚨 **STANDARDS COMPLIANCE STATUS**
-
-| Standard | Status | Compliance |
-|----------|--------|------------|
-| Line Count Limits | ✅ ENFORCED | 100% |
-| OOP Design | ✅ ENFORCED | 100% |
-| Single Responsibility | ✅ ENFORCED | 100% |
-| CLI Interfaces | ✅ ENFORCED | 100% |
-| Smoke Tests | ✅ ENFORCED | 100% |
-| Agent Usability | ✅ ENFORCED | 100% |
-
----
-
-## 🔗 **LINKS**
-
-- **V2 Coding Standards**: [V2_CODING_STANDARDS.md](V2_CODING_STANDARDS.md)
-- **Testing Framework**: [tests/](tests/)
-- **Examples**: [examples/](examples/)
-- **Configuration**: [config/](config/)
-
----
-
-## 📞 **SUPPORT**
-
-For questions about V2 standards compliance or system usage:
-1. Check the V2 coding standards documentation
-2. Run the validation command: `python -m src --validate`
-3. Review component-specific help: `python -m src.<module> --help`
-
----
-
-**🎯 This repository is the single source of truth for Agent_Cellphone_V2, following strict V2 coding standards for optimal code quality and agent usability.**
+This repository is the single source of truth for AutoDream OS. It maintains V2 standards to ensure high-quality, agent-friendly code.


### PR DESCRIPTION
## Summary
- Simplify and reorganize README with features, quick start, testing, and contribution guidelines
- Add `.github/profile/README.md` to present a concise project overview on the GitHub profile

## Testing
- `pre-commit run --files README.md .github/profile/README.md` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest` *(fails: No module named 'pyautogui')*

------
https://chatgpt.com/codex/tasks/task_e_68a731aa623c83299fbb8ba74a47eccb