### PR TITLE
Expand compliance tracker with new contracts

### DIFF
--- a/V2_COMPLIANCE_PROGRESS_TRACKER.md
+++ b/V2_COMPLIANCE_PROGRESS_TRACKER.md
@@ -67,7 +67,7 @@
 
 ## 📋 AVAILABLE CONTRACTS FOR CLAIMING
 
-### CRIT-007: Autonomous Development System
+### CRIT-007: Autonomous Development Orchestrator
 - **File**: `src/autonomous_development_system.py`
 - **Current Lines**: 773
 - **Target Lines**: 300
@@ -84,7 +84,7 @@
 
 ### CRIT-008: Error Analytics System
 - **File**: `src/services/error_analytics_system.py`
-- **Current Lines**: 936
+ - **Current Lines**: 979
 - **Target Lines**: 300
 - **Priority**: Immediate
 - **Estimated Effort**: 2-3 days
@@ -99,11 +99,12 @@
 
 ### CRIT-009: Health Reporting Generator
 - **File**: `src/core/health/reporting/generator.py`
-- **Current Lines**: 1252
+ - **Current Lines**: 1313
 - **Target Lines**: 300
 - **Priority**: Immediate
 - **Estimated Effort**: 2-3 days
 - **Status**: Available
+ - **Assigned To**: Unassigned
 - **Refactoring Goals**:
   - Apply SRP - Separate report generation, data formatting, and output concerns
   - Improve maintainability through better code organization
@@ -113,11 +114,12 @@
 
 ### CRIT-010: Portfolio Tracking Service
 - **File**: `src/services/financial/portfolio/tracking.py`
-- **Current Lines**: 883
+ - **Current Lines**: 936
 - **Target Lines**: 300
 - **Priority**: Immediate
 - **Estimated Effort**: 2-3 days
 - **Status**: Available
+ - **Assigned To**: Unassigned
 - **Refactoring Goals**:
   - Apply SRP - Separate tracking logic, data management, and reporting concerns
   - Improve maintainability through better code organization
@@ -127,11 +129,12 @@
 
 ### CRIT-011: Compliance Audit System
 - **File**: `src/security/compliance_audit.py`
-- **Current Lines**: 845
+ - **Current Lines**: 994
 - **Target Lines**: 300
 - **Priority**: Immediate
 - **Estimated Effort**: 2-3 days
 - **Status**: Available
+ - **Assigned To**: Unassigned
 - **Refactoring Goals**:
   - Apply SRP - Separate audit logic, compliance checking, and reporting concerns
   - Improve maintainability through better code organization
@@ -139,11 +142,116 @@
   - Create production-ready modules with proper error handling
   - Reduce cognitive complexity of individual modules
 
+### CRIT-012: Performance Validation Backup Module
+- **File**: `src/core/performance_validation_system_backup.py`
+- **Current Lines**: 1088
+- **Target Lines**: 300
+- **Priority**: Immediate
+- **Estimated Effort**: 2-3 days
+- **Status**: Available
+- **Assigned To**: Unassigned
+- **Refactoring Goals**:
+  - Apply SRP - Separate metrics collection, validation, reporting, and alerting concerns
+  - Improve maintainability through better code organization
+  - Enhance testability by isolating different responsibilities
+  - Create production-ready modules with proper error handling
+  - Reduce cognitive complexity of individual modules
+
+### CRIT-013: Trading Intelligence Service
+- **File**: `src/services/financial/trading_intelligence_service.py`
+- **Current Lines**: 941
+- **Target Lines**: 300
+- **Priority**: Immediate
+- **Estimated Effort**: 2-3 days
+- **Status**: Available
+- **Assigned To**: Unassigned
+- **Refactoring Goals**:
+  - Apply SRP - Separate market data processing, strategy analysis, execution, and reporting concerns
+  - Improve maintainability through better code organization
+  - Enhance testability by isolating different responsibilities
+  - Create production-ready modules with proper error handling
+  - Reduce cognitive complexity of individual modules
+
+### CRIT-014: Code Crafter Engine
+- **File**: `src/ai_ml/code_crafter.py`
+- **Current Lines**: 937
+- **Target Lines**: 300
+- **Priority**: Immediate
+- **Estimated Effort**: 2-3 days
+- **Status**: Available
+- **Assigned To**: Unassigned
+- **Refactoring Goals**:
+  - Apply SRP - Separate template generation, code synthesis, validation, and deployment concerns
+  - Improve maintainability through better code organization
+  - Enhance testability by isolating different responsibilities
+  - Create production-ready modules with proper error handling
+  - Reduce cognitive complexity of individual modules
+
+### CRIT-015: Health Alerting Manager
+- **File**: `src/core/health/alerting/manager.py`
+- **Current Lines**: 909
+- **Target Lines**: 300
+- **Priority**: Immediate
+- **Estimated Effort**: 2-3 days
+- **Status**: Available
+- **Assigned To**: Unassigned
+- **Refactoring Goals**:
+  - Apply SRP - Separate alert generation, channel dispatch, escalation, and logging concerns
+  - Improve maintainability through better code organization
+  - Enhance testability by isolating different responsibilities
+  - Create production-ready modules with proper error handling
+  - Reduce cognitive complexity of individual modules
+
+### CRIT-016: Cross-Agent Protocol
+- **File**: `src/web/integration/cross_agent_protocol.py`
+- **Current Lines**: 892
+- **Target Lines**: 300
+- **Priority**: Immediate
+- **Estimated Effort**: 2-3 days
+- **Status**: Available
+- **Assigned To**: Unassigned
+- **Refactoring Goals**:
+  - Apply SRP - Separate handshake negotiation, message routing, authentication, and logging concerns
+  - Improve maintainability through better code organization
+  - Enhance testability by isolating different responsibilities
+  - Create production-ready modules with proper error handling
+  - Reduce cognitive complexity of individual modules
+
+### CRIT-017: Unified Financial API
+- **File**: `src/services/financial/unified_financial_api.py`
+- **Current Lines**: 872
+- **Target Lines**: 300
+- **Priority**: Immediate
+- **Estimated Effort**: 2-3 days
+- **Status**: Available
+- **Assigned To**: Unassigned
+- **Refactoring Goals**:
+  - Apply SRP - Separate data aggregation, normalization, request handling, and response formatting concerns
+  - Improve maintainability through better code organization
+  - Enhance testability by isolating different responsibilities
+  - Create production-ready modules with proper error handling
+  - Reduce cognitive complexity of individual modules
+
+### CRIT-018: AI Testing Suite
+- **File**: `src/ai_ml/testing.py`
+- **Current Lines**: 857
+- **Target Lines**: 300
+- **Priority**: Immediate
+- **Estimated Effort**: 2-3 days
+- **Status**: Available
+- **Assigned To**: Unassigned
+- **Refactoring Goals**:
+  - Apply SRP - Separate dataset preparation, model evaluation, reporting, and cleanup concerns
+  - Improve maintainability through better code organization
+  - Enhance testability by isolating different responsibilities
+  - Create production-ready modules with proper error handling
+  - Reduce cognitive complexity of individual modules
+
 ## 🚨 IMMEDIATE ACTIONS REQUIRED
 
-1. **Complete CRIT-007**: Autonomous Development System refactoring (In Progress - Agent-5)
+1. **Complete CRIT-007**: Autonomous Development Orchestrator refactoring (In Progress - Agent-5)
 2. **Complete CRIT-008**: Error Analytics System refactoring (Assigned - Agent-4)
-3. **Claim Available Critical Tasks**: CRIT-009 through CRIT-011 are available for immediate work
+3. **Claim Available Critical Tasks**: CRIT-009 through CRIT-018 are available for immediate work
 4. **Address Major Violations**: 84 files need immediate attention
 5. **Address Moderate Violations**: 169 files need attention
 6. **Continue Critical Phase**: 12 remaining critical violations need refactoring
@@ -172,12 +280,17 @@
 
 ### Critical Violations (800+ lines): 12 files remaining
 - `src/autonomous_development_system.py` (773 lines) - In Progress (Agent-5)
-- `src/services/error_analytics_system.py` (936 lines) - Assigned (Agent-4)
-- `src/core/health/reporting/generator.py` (1252 lines) - Available
-- `src/core/performance_validation_system_backup.py` (900 lines) - Available
-- `src/services/financial/portfolio/tracking.py` (883 lines) - Available
-- `src/security/compliance_audit.py` (845 lines) - Available
-- Additional 6 files requiring immediate attention...
+- `src/services/error_analytics_system.py` (979 lines) - Assigned (Agent-4)
+- `src/core/health/reporting/generator.py` (1313 lines) - Available
+- `src/core/performance_validation_system_backup.py` (1088 lines) - Available
+- `src/services/financial/portfolio/tracking.py` (936 lines) - Available
+- `src/security/compliance_audit.py` (994 lines) - Available
+- `src/services/financial/trading_intelligence_service.py` (941 lines) - Available
+- `src/ai_ml/code_crafter.py` (937 lines) - Available
+- `src/core/health/alerting/manager.py` (909 lines) - Available
+- `src/web/integration/cross_agent_protocol.py` (892 lines) - Available
+- `src/services/financial/unified_financial_api.py` (872 lines) - Available
+- `src/ai_ml/testing.py` (857 lines) - Available
 
 ### Major Violations (500-799 lines): 84 files
 - Various service and core modules requiring immediate attention


### PR DESCRIPTION
## Summary
- rename CRIT-007 to Autonomous Development Orchestrator
- add contracts CRIT-012 through CRIT-018 for high line-count modules
- standardize contract metadata with explicit assignees and update violation list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0e014a5483298873531c7878fc46