### PR TITLE
Refactor testing workflow into modular components

### DIFF
--- a/src/ai_ml/__init__.py
+++ b/src/ai_ml/__init__.py
@@ -66,8 +66,8 @@ from .integrations import OpenAIIntegration, AnthropicIntegration, PyTorchIntegr
 # Utilities and helpers (existing implementations)
 from .utils import config_loader, logger_setup, performance_monitor
 
-# Testing and validation (existing implementations)
-from .testing import AITestRunner, ModelValidator, QualityAssurance
+# Testing and validation
+from .testing import DatasetPreparer, ModelEvaluator, TestReporter, CleanupManager
 
 # API key management (existing implementation)
 from .api_key_manager import (
@@ -118,9 +118,10 @@ __all__ = [
     "logger_setup",
     "performance_monitor",
     # Testing
-    "AITestRunner",
-    "ModelValidator",
-    "QualityAssurance",
+    "DatasetPreparer",
+    "ModelEvaluator",
+    "TestReporter",
+    "CleanupManager",
     # API key management
     "APIKeyManager",
     "get_api_key_manager",

--- a/src/ai_ml/testing/__init__.py
+++ b/src/ai_ml/testing/__init__.py
@@ -1,0 +1,11 @@
+from .dataset_preparation import DatasetPreparer
+from .model_evaluation import ModelEvaluator
+from .reporting import TestReporter
+from .cleanup import CleanupManager
+
+__all__ = [
+    "DatasetPreparer",
+    "ModelEvaluator",
+    "TestReporter",
+    "CleanupManager",
+]

--- a/src/ai_ml/testing/cleanup.py
+++ b/src/ai_ml/testing/cleanup.py
@@ -1,0 +1,16 @@
+import os
+from typing import Iterable
+
+
+class CleanupManager:
+    """Remove generated test files and other artifacts."""
+
+    def cleanup(self, paths: Iterable[str]) -> int:
+        removed = 0
+        for path in paths:
+            try:
+                os.remove(path)
+                removed += 1
+            except FileNotFoundError:
+                continue
+        return removed

--- a/src/ai_ml/testing/dataset_preparation.py
+++ b/src/ai_ml/testing/dataset_preparation.py
@@ -1,0 +1,28 @@
+import logging
+from pathlib import Path
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+class DatasetPreparer:
+    """Prepare test datasets by discovering and generating test files."""
+
+    def __init__(self, test_dir: str):
+        self.test_dir = Path(test_dir)
+        self.generated_tests: List[str] = []
+
+    def discover_tests(self) -> List[str]:
+        """Return a list of discovered test files."""
+        tests = [str(p) for p in self.test_dir.rglob('test_*.py') if p.is_file()]
+        logger.info("Discovered %d test files", len(tests))
+        return tests
+
+    def generate_test_file(self, name: str = "test_generated.py") -> str:
+        """Generate a simple passing test file for evaluation."""
+        path = self.test_dir / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("""import pytest\n\n\ndef test_placeholder():\n    assert True\n""")
+        self.generated_tests.append(str(path))
+        logger.info("Generated test file: %s", path)
+        return str(path)

--- a/src/ai_ml/testing/model_evaluation.py
+++ b/src/ai_ml/testing/model_evaluation.py
@@ -1,0 +1,63 @@
+import logging
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ModelEvaluator:
+    """Evaluate models by running test suites."""
+
+    def __init__(self, project_path: str = ".", test_dir: str = "tests"):
+        self.project_path = Path(project_path)
+        self.test_dir = Path(test_dir)
+
+    def run_tests(self, test_path: Optional[str] = None) -> Dict[str, Optional[str]]:
+        """Execute pytest on the given path and return raw results."""
+        cmd = [sys.executable, "-m", "pytest"]
+        if test_path:
+            cmd.append(test_path)
+        else:
+            cmd.append(str(self.test_dir))
+        logger.info("Running tests with command: %s", " ".join(cmd))
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=self.project_path
+        )
+        output = {
+            "return_code": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "timestamp": datetime.now().isoformat(),
+        }
+        output.update(self._parse_pytest_output(result.stdout))
+        return output
+
+    def _parse_pytest_output(self, output: str) -> Dict[str, int]:
+        """Parse pytest output to extract statistics."""
+        stats: Dict[str, int] = {}
+        for line in output.splitlines():
+            if "collected" in line and "items" in line:
+                parts = line.split()
+                for i, part in enumerate(parts):
+                    if part == "collected" and i + 1 < len(parts):
+                        stats["total"] = int(parts[i + 1])
+            if "passed" in line:
+                parts = line.split()
+                for i, part in enumerate(parts):
+                    if part == "passed" and i > 0:
+                        try:
+                            stats["passed"] = int(parts[i - 1])
+                        except ValueError:
+                            pass
+            if "failed" in line:
+                parts = line.split()
+                for i, part in enumerate(parts):
+                    if part == "failed" and i > 0:
+                        try:
+                            stats["failed"] = int(parts[i - 1])
+                        except ValueError:
+                            pass
+        return stats

--- a/src/ai_ml/testing/reporting.py
+++ b/src/ai_ml/testing/reporting.py
@@ -1,0 +1,16 @@
+from typing import Dict, List
+
+
+class TestReporter:
+    """Generate summaries of test execution results."""
+
+    def summarize(self, results: List[Dict[str, int]]) -> Dict[str, int]:
+        summary = {
+            "total_runs": len(results),
+            "successful_runs": sum(1 for r in results if r.get("return_code", 1) == 0),
+            "failed_runs": sum(1 for r in results if r.get("return_code", 1) != 0),
+            "total_tests": sum(r.get("total", 0) for r in results),
+            "passed": sum(r.get("passed", 0) for r in results),
+            "failed": sum(r.get("failed", 0) for r in results),
+        }
+        return summary

--- a/tests/unit/test_cleanup_module.py
+++ b/tests/unit/test_cleanup_module.py
@@ -1,0 +1,21 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_cleanup():
+    spec = importlib.util.spec_from_file_location(
+        "cleanup", Path(__file__).resolve().parents[2] / "src/ai_ml/testing/cleanup.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.CleanupManager
+
+
+def test_cleanup(tmp_path):
+    file_path = tmp_path / "temp.txt"
+    file_path.write_text("data")
+    CleanupManager = load_cleanup()
+    cleaner = CleanupManager()
+    removed = cleaner.cleanup([str(file_path)])
+    assert removed == 1
+    assert not file_path.exists()

--- a/tests/unit/test_dataset_preparation_module.py
+++ b/tests/unit/test_dataset_preparation_module.py
@@ -1,0 +1,20 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_dataset_preparer():
+    spec = importlib.util.spec_from_file_location(
+        "dataset_preparation", Path(__file__).resolve().parents[2] / "src/ai_ml/testing/dataset_preparation.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.DatasetPreparer
+
+
+def test_generate_and_discover(tmp_path):
+    DatasetPreparer = load_dataset_preparer()
+    preparer = DatasetPreparer(tmp_path)
+    created = preparer.generate_test_file("test_sample.py")
+    assert Path(created).exists()
+    discovered = preparer.discover_tests()
+    assert created in discovered

--- a/tests/unit/test_model_evaluation_module.py
+++ b/tests/unit/test_model_evaluation_module.py
@@ -1,0 +1,22 @@
+import importlib.util
+from pathlib import Path
+
+
+def load(name, file):
+    spec = importlib.util.spec_from_file_location(
+        name, Path(__file__).resolve().parents[2] / f"src/ai_ml/testing/{file}"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_tests(tmp_path):
+    DatasetPreparer = load("dataset_preparation", "dataset_preparation.py").DatasetPreparer
+    ModelEvaluator = load("model_evaluation", "model_evaluation.py").ModelEvaluator
+    preparer = DatasetPreparer(tmp_path)
+    preparer.generate_test_file("test_eval.py")
+    evaluator = ModelEvaluator(project_path=tmp_path, test_dir=tmp_path)
+    result = evaluator.run_tests()
+    assert result["return_code"] == 0
+    assert result.get("passed", 0) == 1

--- a/tests/unit/test_reporting_module.py
+++ b/tests/unit/test_reporting_module.py
@@ -1,0 +1,26 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_reporter():
+    spec = importlib.util.spec_from_file_location(
+        "reporting", Path(__file__).resolve().parents[2] / "src/ai_ml/testing/reporting.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.TestReporter
+
+
+def test_summarize():
+    TestReporter = load_reporter()
+    reporter = TestReporter()
+    results = [
+        {"return_code": 0, "passed": 1, "failed": 0, "total": 1},
+        {"return_code": 1, "passed": 0, "failed": 1, "total": 1},
+    ]
+    summary = reporter.summarize(results)
+    assert summary["total_runs"] == 2
+    assert summary["successful_runs"] == 1
+    assert summary["failed_runs"] == 1
+    assert summary["passed"] == 1
+    assert summary["failed"] == 1

--- a/tests/unit/test_testing_workflow_integration.py
+++ b/tests/unit/test_testing_workflow_integration.py
@@ -1,0 +1,34 @@
+import importlib.util
+from pathlib import Path
+
+
+def load(name, file):
+    spec = importlib.util.spec_from_file_location(
+        name, Path(__file__).resolve().parents[2] / f"src/ai_ml/testing/{file}"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_full_workflow(tmp_path):
+    DatasetPreparer = load("dataset_preparation", "dataset_preparation.py").DatasetPreparer
+    ModelEvaluator = load("model_evaluation", "model_evaluation.py").ModelEvaluator
+    TestReporter = load("reporting", "reporting.py").TestReporter
+    CleanupManager = load("cleanup", "cleanup.py").CleanupManager
+
+    preparer = DatasetPreparer(tmp_path)
+    test_file = preparer.generate_test_file("test_workflow.py")
+
+    evaluator = ModelEvaluator(project_path=tmp_path, test_dir=tmp_path)
+    result = evaluator.run_tests()
+
+    reporter = TestReporter()
+    summary = reporter.summarize([result])
+
+    cleaner = CleanupManager()
+    removed = cleaner.cleanup(preparer.generated_tests)
+
+    assert summary["successful_runs"] == 1
+    assert removed == 1
+    assert not Path(test_file).exists()


### PR DESCRIPTION
## Summary
- Split monolithic testing implementation into dataset preparation, model evaluation, reporting, and cleanup modules
- Expose new modules via `ai_ml` package
- Add unit and integration tests validating modular testing workflow

## Testing
- `pytest tests/unit/test_dataset_preparation_module.py tests/unit/test_model_evaluation_module.py tests/unit/test_reporting_module.py tests/unit/test_cleanup_module.py tests/unit/test_testing_workflow_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab178048f88329a063206e946e3603