### PR TITLE
Skip tests requiring optional dependencies

### DIFF
--- a/tests/unit/test_api_gateway_auth.py
+++ b/tests/unit/test_api_gateway_auth.py
@@ -1,7 +1,10 @@
 import os
 from datetime import datetime, timedelta
 
-import jwt
+import pytest
+
+# Skip tests if PyJWT isn't available
+jwt = pytest.importorskip("jwt")
 
 from src.services.api_gateway import V2APIGateway, GatewayRequest, RouteMethod
 

--- a/tests/unit/test_portfolio_tracking_modules.py
+++ b/tests/unit/test_portfolio_tracking_modules.py
@@ -4,6 +4,9 @@ from datetime import datetime, timedelta
 
 import pytest
 
+# Skip these tests if pandas isn't installed since the underlying modules depend on it
+pytest.importorskip("pandas")
+
 from src.services.financial.portfolio.data_management import PerformanceDataManager
 from src.services.financial.portfolio.reporting import PerformanceReporter
 from src.services.financial.portfolio.tracking_logic import (

--- a/tests/unit/test_reporting_modules.py
+++ b/tests/unit/test_reporting_modules.py
@@ -1,6 +1,11 @@
 import json
 from pathlib import Path
 
+import pytest
+
+# Skip these tests if psutil isn't available since health metrics rely on it
+pytest.importorskip("psutil")
+
 from core.health.reporting import (
     ReportType,
     ReportFormat,


### PR DESCRIPTION
## Summary
- Skip API gateway auth tests if PyJWT is unavailable
- Skip portfolio tracking tests when pandas is missing
- Skip health reporting tests if psutil isn't installed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab22c4f5548329b4da1a5dd25eb9dc