### PR TITLE
Modular health metrics collection with thread-safe scheduler

### DIFF
--- a/src/core/health/metrics/__init__.py
+++ b/src/core/health/metrics/__init__.py
@@ -10,8 +10,12 @@ from .collector import (
     MetricCollectionMethod,
     MetricCollectionConfig,
     CollectedMetric,
-    MetricCollectionResult
+    MetricCollectionResult,
 )
+from .adapters import MetricSourceAdapter, SystemMetricsAdapter, Metric
+from .aggregation import MetricAggregator
+from .scheduler import AsyncScheduler
+from .collector_facade import CollectorFacade
 
 __all__ = [
     "HealthMetricsCollector",
@@ -19,5 +23,11 @@ __all__ = [
     "MetricCollectionMethod",
     "MetricCollectionConfig",
     "CollectedMetric",
-    "MetricCollectionResult"
+    "MetricCollectionResult",
+    "MetricSourceAdapter",
+    "SystemMetricsAdapter",
+    "Metric",
+    "MetricAggregator",
+    "AsyncScheduler",
+    "CollectorFacade",
 ]

--- a/src/core/health/metrics/adapters.py
+++ b/src/core/health/metrics/adapters.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Metric source adapters.
+
+These adapters provide a small interface for fetching metrics from different
+sources.  They are intentionally light weight so they can be tested in
+isolation and composed by higher level components.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List
+
+import psutil
+import time
+
+
+@dataclass
+class Metric:
+    """Simple representation of a collected metric."""
+
+    source: str
+    name: str
+    value: float
+    timestamp: float
+
+
+class MetricSourceAdapter(ABC):
+    """Base class for metric source adapters."""
+
+    def __init__(self, interval: float = 1.0) -> None:
+        self.interval = interval
+
+    @abstractmethod
+    def collect(self) -> List[Metric]:
+        """Collect metrics from the underlying source."""
+
+
+class SystemMetricsAdapter(MetricSourceAdapter):
+    """Collect a handful of system level metrics using ``psutil``."""
+
+    def collect(self) -> List[Metric]:
+        now = time.time()
+        cpu = psutil.cpu_percent(interval=None)
+        memory = psutil.virtual_memory().percent
+        return [
+            Metric("system", "cpu_percent", cpu, now),
+            Metric("system", "memory_percent", memory, now),
+        ]

--- a/src/core/health/metrics/aggregation.py
+++ b/src/core/health/metrics/aggregation.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Metric aggregation utilities."""
+
+from collections import defaultdict
+from typing import Dict, Iterable, List
+import threading
+
+from .adapters import Metric
+
+
+class MetricAggregator:
+    """Aggregate metrics in a thread safe manner."""
+
+    def __init__(self) -> None:
+        self._metrics: List[Metric] = []
+        self._lock = threading.Lock()
+
+    def add(self, metrics: Iterable[Metric]) -> None:
+        """Store metrics for later aggregation."""
+        with self._lock:
+            self._metrics.extend(list(metrics))
+
+    def summary(self) -> Dict[str, float]:
+        """Return the average value for each metric name."""
+        with self._lock:
+            totals: Dict[str, float] = defaultdict(float)
+            counts: Dict[str, int] = defaultdict(int)
+            for metric in self._metrics:
+                totals[metric.name] += metric.value
+                counts[metric.name] += 1
+
+        return {name: totals[name] / counts[name] for name in totals}

--- a/src/core/health/metrics/collector_facade.py
+++ b/src/core/health/metrics/collector_facade.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Facade for coordinating metric collection components."""
+
+from typing import Dict
+import asyncio
+
+from .adapters import MetricSourceAdapter
+from .aggregation import MetricAggregator
+from .scheduler import AsyncScheduler
+
+
+class CollectorFacade:
+    """High level interface used by the rest of the system.
+
+    The facade wires together metric adapters, the aggregator and the async
+    scheduler.  It exposes ``start``/``shutdown`` methods and a simple
+    ``get_summary`` API used in tests.
+    """
+
+    def __init__(self, adapters: Dict[str, MetricSourceAdapter]):
+        self.adapters = adapters
+        self.aggregator = MetricAggregator()
+        self.scheduler = AsyncScheduler()
+        self._started = False
+        self._lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        async with self._lock:
+            if self._started:
+                return
+            self._started = True
+            for adapter in self.adapters.values():
+                await self.scheduler.schedule(lambda a=adapter: self._run_adapter(a), adapter.interval)
+
+    async def _run_adapter(self, adapter: MetricSourceAdapter) -> None:
+        metrics = adapter.collect()
+        self.aggregator.add(metrics)
+
+    async def shutdown(self) -> None:
+        async with self._lock:
+            if not self._started:
+                return
+            self._started = False
+        await self.scheduler.shutdown()
+
+    def get_summary(self):
+        return self.aggregator.summary()

--- a/src/core/health/metrics/scheduler.py
+++ b/src/core/health/metrics/scheduler.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Asynchronous scheduling helpers."""
+
+from typing import Awaitable, Callable, List
+import asyncio
+
+
+class AsyncScheduler:
+    """Schedule coroutines at fixed intervals."""
+
+    def __init__(self) -> None:
+        self._tasks: List[asyncio.Task] = []
+        self._lock = asyncio.Lock()
+        self._running = False
+
+    async def schedule(self, coro_factory: Callable[[], Awaitable[None]], interval: float) -> None:
+        """Schedule ``coro_factory`` to run repeatedly every ``interval`` seconds."""
+
+        async def _runner() -> None:
+            try:
+                while self._running:
+                    await coro_factory()
+                    await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                pass
+
+        async with self._lock:
+            if not self._running:
+                self._running = True
+            task = asyncio.create_task(_runner())
+            self._tasks.append(task)
+
+    async def shutdown(self) -> None:
+        """Cancel all scheduled tasks in a thread safe way."""
+        async with self._lock:
+            tasks = list(self._tasks)
+            self._tasks.clear()
+            self._running = False
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/test_collector_facade.py
+++ b/tests/test_collector_facade.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import pytest
+
+from src.core.health.metrics import CollectorFacade, SystemMetricsAdapter
+
+
+@pytest.mark.asyncio
+async def test_collector_facade_collects_metrics():
+    adapter = SystemMetricsAdapter(interval=0.05)
+    facade = CollectorFacade({"system": adapter})
+    await facade.start()
+    await asyncio.sleep(0.15)
+    await facade.shutdown()
+    summary = facade.get_summary()
+    assert "cpu_percent" in summary
+    assert "memory_percent" in summary
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_thread_safe():
+    adapter = SystemMetricsAdapter(interval=0.05)
+    facade = CollectorFacade({"system": adapter})
+    await facade.start()
+    await asyncio.sleep(0.1)
+    await facade.shutdown()
+    # second shutdown should not raise
+    await facade.shutdown()


### PR DESCRIPTION
## Summary
- add metric-source adapters and async scheduler modules
- implement thread-safe collector facade and aggregation logic
- cover facade behavior and shutdown with new tests

## Testing
- `pytest tests/test_collector_facade.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab592dd39c83299c71627869992e69