### PR TITLE
Refactor financial services into modular architecture

### DIFF
--- a/src/services/financial/__init__.py
+++ b/src/services/financial/__init__.py
@@ -10,9 +10,13 @@ __version__ = "1.0.0"
 __author__ = "Business Intelligence Agent"
 __status__ = "ACTIVE"
 
-# Intentionally leave __all__ empty to prevent eager imports that may rely on
-# unavailable external packages. Consumers can import the required services
-# explicitly, e.g. ``from src.services.financial.trading_intelligence_v2 import
-# TradingIntelligenceService``.
-__all__: list[str] = []
+# Intentionally avoid eager imports that may rely on optional third-party
+# packages. The orchestrator is exposed lazily so that basic package imports
+# remain lightweight during tests.
+try:  # pragma: no cover - optional dependencies may not be present
+    from .orchestrator import FinancialServicesOrchestrator
+
+    __all__ = ["FinancialServicesOrchestrator"]
+except Exception:  # pragma: no cover
+    __all__: list[str] = []
 

--- a/src/services/financial/market_data.py
+++ b/src/services/financial/market_data.py
@@ -1,0 +1,16 @@
+"""Market data service wrapper."""
+from __future__ import annotations
+
+from .market_data_service import MarketDataService, MarketData
+
+
+class MarketDataModule:
+    """Expose simplified market data access methods."""
+
+    def __init__(self) -> None:
+        self.service = MarketDataService()
+
+    def get_mock_price(self, symbol: str) -> MarketData | None:
+        """Return mock real-time data for the given symbol."""
+        data = self.service.get_real_time_data([symbol], source="mock")
+        return data.get(symbol.upper())

--- a/src/services/financial/options_service.py
+++ b/src/services/financial/options_service.py
@@ -1,0 +1,20 @@
+"""Options trading service wrapper."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .options_trading_service import OptionsTradingService
+from .options.pricing import OptionType
+from .market_data import MarketDataModule
+
+
+class OptionsService:
+    """Thin wrapper around the options trading service."""
+
+    def __init__(self, market_data: Optional[MarketDataModule] = None) -> None:
+        md_service = market_data.service if market_data else None
+        self.service = OptionsTradingService(market_data_service=md_service)
+
+    def price_option(self, S: float, K: float, T: float, r: float, sigma: float, option_type: OptionType):
+        """Price an option using Black-Scholes via the underlying service."""
+        return self.service.calculate_black_scholes(S, K, T, r, sigma, option_type)

--- a/src/services/financial/orchestrator.py
+++ b/src/services/financial/orchestrator.py
@@ -1,0 +1,19 @@
+"""Simple orchestrator composing core financial services."""
+from __future__ import annotations
+
+from .portfolio_service import PortfolioService
+from .risk import RiskService
+from .market_data import MarketDataModule
+from .trading import TradingService
+from .options_service import OptionsService
+
+
+class FinancialServicesOrchestrator:
+    """Compose individual financial service modules for external use."""
+
+    def __init__(self) -> None:
+        self.market_data = MarketDataModule()
+        self.portfolio = PortfolioService()
+        self.risk = RiskService(self.portfolio)
+        self.trading = TradingService(self.market_data)
+        self.options = OptionsService(self.market_data)

--- a/src/services/financial/portfolio_service.py
+++ b/src/services/financial/portfolio_service.py
@@ -1,0 +1,34 @@
+"""Lightweight portfolio service wrapper."""
+from __future__ import annotations
+
+from .portfolio_management_service import PortfolioManager, PortfolioPosition
+
+
+class PortfolioService:
+    """Expose basic portfolio management operations."""
+
+    def __init__(self) -> None:
+        self.manager = PortfolioManager()
+
+    def add_position(
+        self, symbol: str, quantity: float, price: float, sector: str = ""
+    ) -> bool:
+        """Add or update a position via the underlying manager."""
+        position = PortfolioPosition(
+            symbol=symbol,
+            quantity=quantity,
+            avg_price=price,
+            current_price=price,
+            market_value=quantity * price,
+            unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0,
+            sector=sector,
+        )
+        self.manager.positions[symbol] = position
+        self.manager.save_portfolio()
+        self.manager.calculate_metrics()
+        return True
+
+    def get_portfolio(self):
+        """Return the current portfolio representation."""
+        return self.manager.get_portfolio()

--- a/src/services/financial/risk.py
+++ b/src/services/financial/risk.py
@@ -1,0 +1,19 @@
+"""Risk service wrapper."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .risk_management_service import RiskManager
+from .portfolio_service import PortfolioService
+
+
+class RiskService:
+    """Provide access to risk management features."""
+
+    def __init__(self, portfolio: Optional[PortfolioService] = None) -> None:
+        portfolio_manager = portfolio.manager if portfolio else None
+        self.manager = RiskManager(portfolio_manager=portfolio_manager)
+
+    def get_risk_profile(self):
+        """Return a fresh risk profile."""
+        return self.manager.get_risk_profile()

--- a/src/services/financial/trading.py
+++ b/src/services/financial/trading.py
@@ -1,0 +1,19 @@
+"""Trading intelligence service wrapper."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .trading_intelligence_service import TradingIntelligenceService
+from .market_data import MarketDataModule
+
+
+class TradingService:
+    """Wrapper around the trading intelligence service."""
+
+    def __init__(self, market_data: Optional[MarketDataModule] = None) -> None:
+        md_service = market_data.service if market_data else None
+        self.service = TradingIntelligenceService(market_data_service=md_service)
+
+    def available_strategies(self) -> list:
+        """Return the list of configured strategy types."""
+        return list(self.service.strategies.keys())

--- a/tests/unit/test_financial_service_modules.py
+++ b/tests/unit/test_financial_service_modules.py
@@ -1,0 +1,46 @@
+"""Unit tests for standalone financial service modules."""
+
+import pytest
+
+pytest.importorskip("pandas")
+
+from src.services.financial.portfolio_service import PortfolioService
+from src.services.financial.risk import RiskService
+from src.services.financial.market_data import MarketDataModule
+from src.services.financial.trading import TradingService
+from src.services.financial.options_service import OptionsService
+from src.services.financial.options.pricing import OptionType
+
+
+def test_portfolio_service_add_and_get():
+    service = PortfolioService()
+    assert service.add_position("AAPL", 1, 150.0)
+    portfolio = service.get_portfolio()
+    assert "AAPL" in portfolio["positions"]
+
+
+def test_risk_service_profile():
+    portfolio = PortfolioService()
+    risk = RiskService(portfolio)
+    profile = risk.get_risk_profile()
+    assert profile is not None
+
+
+def test_market_data_mock_price():
+    md = MarketDataModule()
+    data = md.get_mock_price("AAPL")
+    assert data is not None
+    assert data.symbol == "AAPL"
+
+
+def test_trading_service_strategies():
+    md = MarketDataModule()
+    trading = TradingService(md)
+    assert trading.available_strategies()
+
+
+def test_options_service_pricing():
+    md = MarketDataModule()
+    options = OptionsService(md)
+    result = options.price_option(100, 100, 0.5, 0.01, 0.2, OptionType.CALL)
+    assert "price" in result and result["price"] > 0


### PR DESCRIPTION
## Summary
- Add lightweight wrappers for portfolio, risk, market data, trading, and options services
- Introduce `FinancialServicesOrchestrator` to compose core financial modules
- Provide unit tests covering each new financial module

## Testing
- `pytest tests/unit/test_financial_service_modules.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab5914b66c832994cb932cbbe7b130