### PR TITLE
Add shared game environment fixtures and domain-specific tests

### DIFF
--- a/tests/gaming/conftest.py
+++ b/tests/gaming/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+@pytest.fixture(scope="module")
+def game_environment():
+    """Provide a shared game environment for gaming tests."""
+    return {
+        "skills": {"attack": 1, "defense": 1},
+        "state": {"health": 100, "mana": 50},
+        "anti_detection": {"stealth": True, "logging": False},
+        "automation": {"enabled": True, "macro_slots": 3},
+    }

--- a/tests/gaming/test_anti_detection.py
+++ b/tests/gaming/test_anti_detection.py
@@ -1,0 +1,6 @@
+"""Tests for anti-detection mechanisms."""
+
+
+def test_anti_detection(game_environment):
+    anti_detection = game_environment["anti_detection"]
+    assert anti_detection["stealth"] is True and anti_detection["logging"] is False

--- a/tests/gaming/test_automation.py
+++ b/tests/gaming/test_automation.py
@@ -1,0 +1,6 @@
+"""Tests for automation features."""
+
+
+def test_automation(game_environment):
+    automation = game_environment["automation"]
+    assert automation["enabled"] is True and automation["macro_slots"] > 0

--- a/tests/gaming/test_skill_systems.py
+++ b/tests/gaming/test_skill_systems.py
@@ -1,0 +1,6 @@
+"""Tests for game skill systems."""
+
+
+def test_skill_systems(game_environment):
+    skills = game_environment["skills"]
+    assert "attack" in skills and skills["attack"] >= 0

--- a/tests/gaming/test_state_analysis.py
+++ b/tests/gaming/test_state_analysis.py
@@ -1,0 +1,6 @@
+"""Tests for state analysis systems."""
+
+
+def test_state_analysis(game_environment):
+    state = game_environment["state"]
+    assert state["health"] > 0 and state["mana"] >= 0


### PR DESCRIPTION
## Summary
- add shared `game_environment` fixture for gaming tests
- test skill systems, state analysis, anti-detection, and automation separately

## Testing
- `pytest tests/gaming/test_skill_systems.py tests/gaming/test_state_analysis.py tests/gaming/test_anti_detection.py tests/gaming/test_automation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab593efff883299f4fbab41af1b690