### PR TITLE
Integrate ServiceRegistry into API health endpoint and tests

### DIFF
--- a/tests/integration/test_api_health_with_service_registry.py
+++ b/tests/integration/test_api_health_with_service_registry.py
@@ -1,0 +1,59 @@
+import pytest
+
+import src.services.api_manager as api_manager_module
+from src.services.service_registry import (
+    ServiceRegistry,
+    ServiceInfo,
+    ServiceType,
+    ServiceStatus,
+    ServiceEndpoint,
+    ServiceMetadata,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_api_manager():
+    api_manager_module.api_manager.endpoints.clear()
+    yield
+    api_manager_module.api_manager.endpoints.clear()
+    api_manager_module.service_registry = ServiceRegistry()
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_lists_registered_services():
+    registry = ServiceRegistry()
+    api_manager_module.setup_example_endpoints(registry)
+
+    service = ServiceInfo(
+        id="svc-1",
+        name="test-service",
+        service_type=ServiceType.API,
+        endpoints=[ServiceEndpoint(host="localhost", port=80)],
+        metadata=ServiceMetadata(),
+        status=ServiceStatus.HEALTHY,
+    )
+    registry.register_service(service)
+
+    response = await api_manager_module.api_manager.process_request(
+        method="GET", path="/api/health", client_id="test"
+    )
+    await registry.stop()
+
+    assert response["success"]
+    services = response["data"]["services"]
+    assert any(
+        s["name"] == "test-service" and s["status"] == "healthy" for s in services
+    )
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_handles_missing_registry():
+    api_manager_module.service_registry = None
+    api_manager_module.setup_example_endpoints(None)
+
+    response = await api_manager_module.api_manager.process_request(
+        method="GET", path="/api/health", client_id="test"
+    )
+
+    assert response["success"]
+    assert response["data"]["services"] == []


### PR DESCRIPTION
## Summary
- Integrate ServiceRegistry with API Manager's example endpoints and expose healthy service statuses
- Add integration tests verifying service registry results and handling of missing registry

## Testing
- `PYTHONPATH=$(pwd)/src pre-commit run --files src/services/api_manager.py tests/integration/test_api_health_with_service_registry.py` *(fails: ModuleNotFoundError: No module named 'src'; duplication-detector: can't open file '/workspace/AutoDream.Os/tools/duplication_detector.py')*
- `pytest tests/integration/test_api_health_with_service_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab5a8e94e0832984fbf3bcf7152feb