### PR TITLE
Expand work item markers for file analysis

### DIFF
--- a/src/services/file_analysis_utils.py
+++ b/src/services/file_analysis_utils.py
@@ -4,6 +4,7 @@ File Analysis Utilities - Agent Cellphone V2
 ============================================
 
 Utility functions for file analysis operations.
+Recognizes comment markers like TODO, FIXME, BUG, NOTE, HACK, and XXX.
 Follows V2 standards: ≤200 LOC, SRP, OOP principles.
 """
 
@@ -51,12 +52,15 @@ class FileAnalysisUtils:
 
     @staticmethod
     def extract_work_items(content: str) -> List[Dict[str, Any]]:
-        """Extract TODO, FIXME, BUG comments from code."""
+        """Extract TODO, FIXME, BUG, NOTE, HACK and XXX comments from code."""
         work_items = []
         patterns = {
             "TODO": r"#\s*TODO:?\s*(.+)",
             "FIXME": r"#\s*FIXME:?\s*(.+)",
             "BUG": r"#\s*BUG:?\s*(.+)",
+            "NOTE": r"#\s*NOTE:?\s*(.+)",
+            "HACK": r"#\s*HACK:?\s*(.+)",
+            "XXX": r"#\s*XXX:?\s*(.+)",
         }
         for line_num, line in enumerate(content.splitlines(), 1):
             for item_type, pattern in patterns.items():

--- a/tests/test_file_processor_service.py
+++ b/tests/test_file_processor_service.py
@@ -15,8 +15,8 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 import json
 
-# Import will be created after tests pass (TDD RED phase)
-# from src.services.file_processor_service import FileProcessorService
+# Import service for testing
+from src.services.file_processor_service import FileProcessorService
 
 
 class TestFileProcessorService:
@@ -260,21 +260,23 @@ import json as js
         assert "os" in [imp["module"] for imp in result["imports"]]
         assert "pathlib.Path" in [imp["name"] for imp in result["imports"]]
 
-    def test_detect_todo_fixme_comments(self):
-        """Test detection of TODO and FIXME comments."""
+    def test_detect_work_item_comments(self):
+        """Test detection of TODO, FIXME, BUG, NOTE and HACK comments."""
         processor = FileProcessorService()
 
-        # Create file with TODO/FIXME comments
+        # Create file with various work item comments
         todo_file = self.test_dir / "todo.py"
         todo_file.write_text(
             """
 def function():
     # TODO: Implement this function
+    # NOTE: Important note here
     pass
 
 def another_function():
     # FIXME: This has a bug
     # BUG: Another issue here
+    # HACK: Temporary workaround
     return None
 """
         )
@@ -282,11 +284,8 @@ def another_function():
         result = processor.process_file(todo_file)
 
         assert "work_items" in result
-        assert len(result["work_items"]) >= 3
-        todo_types = [item["type"] for item in result["work_items"]]
-        assert "TODO" in todo_types
-        assert "FIXME" in todo_types
-        assert "BUG" in todo_types
+        types = [item["type"] for item in result["work_items"]]
+        assert {"TODO", "FIXME", "BUG", "NOTE", "HACK"}.issubset(set(types))
 
     def test_process_file_with_encoding_issues(self):
         """Test processing files with encoding issues."""


### PR DESCRIPTION
## Summary
- detect additional comment markers like NOTE, HACK, and XXX in file analysis
- test FileProcessorService work item extraction for new markers

## Testing
- `pytest tests/test_file_processor_service.py::TestFileProcessorService::test_detect_work_item_comments -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab5a8d91788329a635d2bf005c2a51