### PR TITLE
Refactor performance alerting system into modules and update tracker

### DIFF
--- a/V2_COMPLIANCE_PROGRESS_TRACKER.md
+++ b/V2_COMPLIANCE_PROGRESS_TRACKER.md
@@ -169,16 +169,23 @@
 - **Completion Date**: 2025-08-24
 - **Summary**: Refactored from 722 to 55 lines by extracting manager, AI processor, coordinator, and config modules. New orchestrator coordinates components and maintains functionality.
 
+### MODERATE-010: Performance Alerting System Refactor ✅
+- **File**: `src/services/performance_alerting.py`
+- **Status**: Completed
+- **Assigned To**: Agent-1
+- **Completion Date**: 2025-08-24
+- **Summary**: Refactored monolithic alerting logic into monitor, generator, notifier, and config modules. Main file now orchestrates these components while preserving functionality.
+
 ## 📋 AVAILABLE CONTRACTS FOR CLAIMING
 
 > **Note:** Remaining contract descriptions include current line counts for context only. There is no strict LOC target—deliver clean, production-ready, tested modules that honor SRP and SOLID principles.
 
 ### 🎉 **CRITICAL PRIORITY - COMPLETED! (0 files over 800 lines)**
-**All critical violations have been successfully resolved!** 
+**All critical violations have been successfully resolved!**
 
 **Previously resolved files:**
 1. **`src/services/financial/portfolio/tracking.py`** - ✅ **REFACTORED** (937 → 32 lines)
-2. **`src/core/health/alerting/manager.py`** - ✅ **REFACTORED** (910 → 233 lines)  
+2. **`src/core/health/alerting/manager.py`** - ✅ **REFACTORED** (910 → 233 lines)
 3. **`src/services/financial/unified_financial_api.py`** - ✅ **REFACTORED** (872 → 730 lines)
 4. **`src/services/integrated_agent_coordinator.py`** - ✅ **REFACTORED** (846 → 84 lines)
 5. **`src/core/health/metrics/collector.py`** - ✅ **CONSOLIDATED** (839 → consolidated)


### PR DESCRIPTION
## Summary
- keep lightweight orchestrator in `performance_alerting.py` to coordinate new monitor, generator, notifier, and config modules
- document completion of performance alerting refactor in `V2_COMPLIANCE_PROGRESS_TRACKER.md`

## Testing
- `pre-commit run --files V2_COMPLIANCE_PROGRESS_TRACKER.md`
- `pytest tests/smoke/test_performance_monitoring_smoke.py -k test_basic_imports -q`
- `pytest tests/test_performance_monitoring_standalone.py::test_alerting_system_standalone -q --asyncio-mode=auto`


------
https://chatgpt.com/codex/tasks/task_e_68ab974d04948329a6f183695a6c9ffa