### PR TITLE
Refactor learner into modular components

### DIFF
--- a/V2_COMPLIANCE_PROGRESS_TRACKER.md
+++ b/V2_COMPLIANCE_PROGRESS_TRACKER.md
@@ -195,6 +195,13 @@
 - **Completion Date**: 2025-08-24
 - **Summary**: Refactored from 680 to 200 lines by extracting core, collector, analyzer, and config modules. Main orchestrator now imports these modules while preserving functionality.
 
+### MODERATE-048: AI Agent Learner Modularization ✅
+- **File**: `src/ai_ml/ai_agent_learner.py`
+- **Status**: Completed
+- **Assigned To**: Agent-2
+- **Completion Date**: 2025-08-24
+- **Summary**: Split learner into core, knowledge, and skills modules with a lightweight orchestrator for improved maintainability.
+
 
 ## 📋 AVAILABLE CONTRACTS FOR CLAIMING
 

--- a/src/ai_ml/__init__.py
+++ b/src/ai_ml/__init__.py
@@ -68,6 +68,18 @@ from .ml_robot_processor import MLRobotProcessor
 from .ml_robot_validator import validate_blueprint_config
 from .ml_robot_maker import MLRobotMaker, get_ml_robot_maker
 
+# AI Agent learner (modular implementation)
+from .ai_agent_learner import (
+    AIAgentLearner,
+    LearnerCore,
+    LearningGoal,
+    LearningProgress,
+    KnowledgeBase,
+    KnowledgeItem,
+    Skill,
+    SkillManager,
+)
+
 # API integrations (existing implementations)
 from .integrations import OpenAIIntegration, AnthropicIntegration, PyTorchIntegration
 
@@ -136,6 +148,15 @@ __all__ = [
     "MLModelBlueprint",
     "MLExperiment",
     "get_ml_robot_maker",
+    # AI Agent learner
+    "AIAgentLearner",
+    "LearnerCore",
+    "LearningGoal",
+    "LearningProgress",
+    "KnowledgeBase",
+    "KnowledgeItem",
+    "Skill",
+    "SkillManager",
     # API integrations
     "OpenAIIntegration",
     "AnthropicIntegration",

--- a/src/ai_ml/ai_agent_knowledge.py
+++ b/src/ai_ml/ai_agent_knowledge.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Knowledge management utilities for the AI agent learner."""
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass
+class KnowledgeItem:
+    """Simple container for a piece of knowledge."""
+
+    topic: str
+    content: str
+
+
+class KnowledgeBase:
+    """In-memory store of :class:`KnowledgeItem` objects."""
+
+    def __init__(self) -> None:
+        self._items: Dict[str, KnowledgeItem] = {}
+
+    # CRUD operations -----------------------------------------------------
+    def add(self, topic: str, content: str) -> KnowledgeItem:
+        item = KnowledgeItem(topic, content)
+        self._items[topic] = item
+        return item
+
+    def get(self, topic: str) -> Optional[KnowledgeItem]:
+        return self._items.get(topic)
+
+    def remove(self, topic: str) -> None:
+        self._items.pop(topic, None)
+
+    # Search utilities ----------------------------------------------------
+    def search(self, keyword: str) -> List[KnowledgeItem]:
+        keyword = keyword.lower()
+        return [
+            item for item in self._items.values() if keyword in item.content.lower()
+        ]
+
+    def topics(self) -> Iterable[str]:
+        """Iterate over available knowledge topics."""
+
+        return self._items.keys()
+
+
+__all__ = ["KnowledgeItem", "KnowledgeBase"]

--- a/src/ai_ml/ai_agent_learner.py
+++ b/src/ai_ml/ai_agent_learner.py
@@ -1,0 +1,48 @@
+"""Orchestrator for AI agent learning components."""
+
+from .ai_agent_learner_core import LearningGoal, LearningProgress, LearnerCore
+from .ai_agent_knowledge import KnowledgeBase, KnowledgeItem
+from .ai_agent_skills import Skill, SkillManager
+
+
+class AIAgentLearner:
+    """High level façade combining learning, knowledge and skills."""
+
+    def __init__(self) -> None:
+        self.core = LearnerCore()
+        self.knowledge = KnowledgeBase()
+        self.skills = SkillManager()
+
+    # Convenience wrappers -------------------------------------------------
+    def learn_topic(self, topic: str, content: str, description: str = "") -> None:
+        """Register new knowledge and a learning goal."""
+
+        self.knowledge.add(topic, content)
+        self.core.add_goal(LearningGoal(topic, description))
+
+    def practise_skill(self, name: str, improvement: int = 1) -> int:
+        """Improve a skill by the given ``improvement`` amount."""
+
+        return self.skills.update_skill(name, improvement)
+
+    def record_progress(self, topic: str, progress: float) -> float:
+        """Update progress for a learning goal."""
+
+        return self.core.update_progress(topic, progress)
+
+    def overall_progress(self) -> float:
+        """Return average progress across all goals."""
+
+        return self.core.overall_progress()
+
+
+__all__ = [
+    "LearningGoal",
+    "LearningProgress",
+    "LearnerCore",
+    "KnowledgeBase",
+    "KnowledgeItem",
+    "Skill",
+    "SkillManager",
+    "AIAgentLearner",
+]

--- a/src/ai_ml/ai_agent_learner_core.py
+++ b/src/ai_ml/ai_agent_learner_core.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Core learning utilities for the AI agent.
+
+This module contains lightweight dataclasses and a small manager used by
+:mod:`ai_agent_learner`. It keeps track of learning goals and progress
+without any external dependencies so it can be easily tested.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+
+@dataclass
+class LearningGoal:
+    """Represents a single learning objective."""
+
+    name: str
+    description: str = ""
+
+
+@dataclass
+class LearningProgress:
+    """Tracks progress toward a :class:`LearningGoal`."""
+
+    goal: LearningGoal
+    progress: float = 0.0  # value between 0 and 1
+
+    def update(self, value: float) -> float:
+        """Update progress ensuring it stays within ``0`` and ``1``."""
+
+        self.progress = max(0.0, min(1.0, value))
+        return self.progress
+
+
+class LearnerCore:
+    """Central manager coordinating learning goals."""
+
+    def __init__(self) -> None:
+        self._goals: Dict[str, LearningProgress] = {}
+
+    # Goal management -----------------------------------------------------
+    def add_goal(self, goal: LearningGoal) -> None:
+        """Register a new learning goal."""
+
+        self._goals[goal.name] = LearningProgress(goal)
+
+    def update_progress(self, goal_name: str, value: float) -> float:
+        """Update progress for a given goal.
+
+        Raises
+        ------
+        KeyError
+            If the goal does not exist.
+        """
+
+        if goal_name not in self._goals:
+            raise KeyError(f"Unknown goal: {goal_name}")
+        return self._goals[goal_name].update(value)
+
+    def progress_report(self) -> Dict[str, float]:
+        """Return a mapping of goal names to progress values."""
+
+        return {name: lp.progress for name, lp in self._goals.items()}
+
+    def overall_progress(self) -> float:
+        """Average progress across all goals."""
+
+        if not self._goals:
+            return 0.0
+        return sum(lp.progress for lp in self._goals.values()) / len(self._goals)
+
+    def goals(self) -> Iterable[LearningGoal]:
+        """Iterate over registered goals."""
+
+        return (lp.goal for lp in self._goals.values())
+
+
+__all__ = [
+    "LearningGoal",
+    "LearningProgress",
+    "LearnerCore",
+]

--- a/src/ai_ml/ai_agent_skills.py
+++ b/src/ai_ml/ai_agent_skills.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Skill tracking utilities for the AI agent learner."""
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Skill:
+    """Represents a skill and its proficiency level."""
+
+    name: str
+    level: int = 0  # 0-100 scale
+
+    def adjust(self, delta: int) -> int:
+        """Adjust the skill level by ``delta`` clamped to ``0-100``."""
+
+        self.level = max(0, min(100, self.level + delta))
+        return self.level
+
+
+class SkillManager:
+    """Manage a collection of :class:`Skill` instances."""
+
+    def __init__(self) -> None:
+        self._skills: Dict[str, Skill] = {}
+
+    def add_skill(self, name: str, level: int = 0) -> Skill:
+        skill = Skill(name, max(0, min(100, level)))
+        self._skills[name] = skill
+        return skill
+
+    def update_skill(self, name: str, delta: int) -> int:
+        skill = self._skills.get(name)
+        if not skill:
+            skill = self.add_skill(name)
+        return skill.adjust(delta)
+
+    def get_level(self, name: str) -> int:
+        return self._skills.get(name, Skill(name)).level
+
+
+__all__ = ["Skill", "SkillManager"]


### PR DESCRIPTION
## Summary
- Split learner into core, knowledge, and skills modules
- Added orchestrator to coordinate learner components
- Updated compliance tracker to mark MODERATE-048 complete

## Testing
- `pytest test_sentiment_modules.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68aba95ad99883299ce32320d250132c