### PR TITLE
refactor: remove default logging config

### DIFF
--- a/src/core/health/monitoring/health_monitoring_core.py
+++ b/src/core/health/monitoring/health_monitoring_core.py
@@ -17,7 +17,7 @@ from .health_monitoring_config import (
     HealthThreshold,
     initialize_default_thresholds,
 )
-logging.basicConfig(level=logging.INFO)
+
 logger = logging.getLogger(__name__)
 
 
@@ -523,11 +523,15 @@ class AgentHealthCoreMonitor:
 def main():
     """CLI testing function"""
     import argparse
+    import logging
 
     parser = argparse.ArgumentParser(description="Agent Health Core Monitor CLI")
     parser.add_argument("--test", action="store_true", help="Run smoke test")
 
     args = parser.parse_args()
+
+    # Configure basic logging if not already configured
+    logging.basicConfig(level=logging.INFO)
 
     if args.test:
         monitor = AgentHealthCoreMonitor()


### PR DESCRIPTION
## Summary
- remove module-level logging configuration from health monitoring core
- configure basic logging when running health monitor core CLI

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m src.core.health.monitoring.health_monitoring_core --test`
- `PYTHONDONTWRITEBYTECODE=1 pytest` *(fails: ModuleNotFoundError: No module named 'requests', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac590ea5348329be5d89d3f54fe827