### PR TITLE
refactor: remove unused thread executors

### DIFF
--- a/src/core/health/monitoring/health_monitoring_core.py
+++ b/src/core/health/monitoring/health_monitoring_core.py
@@ -3,7 +3,6 @@ import time
 import threading
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Set
-from concurrent.futures import ThreadPoolExecutor
 
 from ..alerting.models import AlertSeverity
 from .health_monitoring_metrics import (
@@ -38,7 +37,6 @@ class AgentHealthCoreMonitor:
         self.thresholds: Dict[HealthMetricType, HealthThreshold] = initialize_default_thresholds()
         self.health_callbacks: Set[Callable] = set()
         self.monitor_thread: Optional[threading.Thread] = None
-        self.executor = ThreadPoolExecutor(max_workers=4)
 
         # Health monitoring intervals
         self.metrics_interval = self.config.get("metrics_interval", 30)  # seconds
@@ -63,7 +61,6 @@ class AgentHealthCoreMonitor:
         self.monitoring_active = False
         if self.monitor_thread:
             self.monitor_thread.join(timeout=5)
-        self.executor.shutdown(wait=True)
         logger.info("Agent health monitoring stopped")
 
     def _monitor_loop(self):

--- a/src/core/health/monitoring_new/health_monitoring_new_core.py
+++ b/src/core/health/monitoring_new/health_monitoring_new_core.py
@@ -3,7 +3,6 @@
 import logging
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, Optional, Set, Callable
 
 from .health_monitoring_new_config import (
@@ -44,7 +43,6 @@ class AgentHealthCoreMonitor:
         )
         self.health_callbacks: Set[Callable] = set()
         self.monitor_thread: Optional[threading.Thread] = None
-        self.executor = ThreadPoolExecutor(max_workers=4)
         self.metrics_interval = self.config.get("metrics_interval", 30)
         self.health_check_interval = self.config.get("health_check_interval", 60)
         self.alert_check_interval = self.config.get("alert_check_interval", 15)
@@ -63,7 +61,6 @@ class AgentHealthCoreMonitor:
         self.monitoring_active = False
         if self.monitor_thread:
             self.monitor_thread.join(timeout=5)
-        self.executor.shutdown(wait=True)
         logger.info("Agent health monitoring stopped")
 
     def _monitor_loop(self) -> None:

--- a/src/core/health_monitor_core.py
+++ b/src/core/health_monitor_core.py
@@ -16,7 +16,6 @@ import time
 from src.utils.stability_improvements import stability_manager, safe_import
 from datetime import datetime
 from typing import Dict, Any, Set, Callable
-from concurrent.futures import ThreadPoolExecutor
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -34,7 +33,6 @@ class HealthMonitorCore:
         self.config = config or {}
         self.monitoring_active = False
         self.monitor_thread: threading.Thread = None
-        self.executor = ThreadPoolExecutor(max_workers=4)
         self.health_callbacks: Set[Callable] = set()
 
         # Monitoring intervals
@@ -64,7 +62,6 @@ class HealthMonitorCore:
         self.monitoring_active = False
         if self.monitor_thread:
             self.monitor_thread.join(timeout=5)
-        self.executor.shutdown(wait=True)
         logger.info("Health monitoring stopped")
 
     def _monitor_loop(self):
@@ -160,7 +157,6 @@ class HealthMonitorCore:
             if self.monitor_thread
             else False,
             "subscriber_count": len(self.health_callbacks),
-            "executor_active": not self.executor._shutdown,
         }
 
     def run_smoke_test(self) -> bool:

--- a/src/core/workflow/workflow_execution.py
+++ b/src/core/workflow/workflow_execution.py
@@ -17,7 +17,6 @@ import time
 from src.utils.stability_improvements import stability_manager, safe_import
 from typing import Dict, List, Optional, Any, Set
 from datetime import datetime, timedelta
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 # Import workflow types
 try:
@@ -40,7 +39,6 @@ class WorkflowExecutionEngine:
     
     def __init__(self, max_workers: int = 4):
         self.max_workers = max_workers
-        self.executor = ThreadPoolExecutor(max_workers=max_workers)
         self.active_executions: Dict[str, WorkflowExecution] = {}
         self.completed_executions: Dict[str, WorkflowExecution] = {}
         self.logger = logging.getLogger(f"{__name__}.WorkflowExecutionEngine")
@@ -235,7 +233,6 @@ class WorkflowExecutionEngine:
 
     def cleanup(self):
         """Cleanup resources"""
-        self.executor.shutdown(wait=True)
         self.logger.info("Workflow execution engine cleaned up")
 
 

--- a/src/core/workflow/workflow_executor.py
+++ b/src/core/workflow/workflow_executor.py
@@ -9,7 +9,6 @@ Author: Agent-4 (Quality Assurance)
 License: MIT
 """
 
-import asyncio
 import logging
 import time
 import uuid
@@ -17,7 +16,6 @@ import uuid
 from src.utils.stability_improvements import stability_manager, safe_import
 from datetime import datetime
 from typing import Dict, List, Optional, Any, Set
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 try:
     from .workflow_types import (
@@ -48,7 +46,6 @@ class WorkflowExecutor:
     def __init__(self, max_workers: int = 4):
         """Initialize the workflow executor"""
         self.max_workers = max_workers
-        self.executor = ThreadPoolExecutor(max_workers=max_workers)
         self.running_tasks: Set[str] = set()
         logger.info(f"Workflow Executor initialized with {max_workers} workers")
 
@@ -280,5 +277,4 @@ class WorkflowExecutor:
 
     def shutdown(self):
         """Shutdown the workflow executor"""
-        self.executor.shutdown(wait=True)
         logger.info("Workflow Executor shutdown complete")


### PR DESCRIPTION
## Summary
- remove unnecessary ThreadPoolExecutor initialization from health monitoring cores
- simplify workflow execution modules by dropping unused thread pools

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest` *(fails: ModuleNotFoundError: No module named 'flask'; 41 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ac59108ad08329941ea45263894706