### PR TITLE
refactor: modularize testing framework

### DIFF
--- a/src/core/testing_framework/__init__.py
+++ b/src/core/testing_framework/__init__.py
@@ -14,16 +14,24 @@ License: MIT
 """
 
 from .testing_types import (
-    TestStatus, TestType, TestPriority,
-    TestResult, TestScenario, TestEnvironment
+    TestStatus,
+    TestType,
+    TestPriority,
+    TestResult,
+    TestScenario,
+    TestEnvironment,
 )
-from .testing_core import (
-    BaseIntegrationTest, CrossSystemCommunicationTest,
-    ServiceIntegrationTest, DatabaseIntegrationTest
+from .base_test import BaseIntegrationTest
+from .integration_tests import (
+    CrossSystemCommunicationTest,
+    ServiceIntegrationTest,
+    DatabaseIntegrationTest,
 )
 from .testing_orchestration import (
-    IntegrationTestSuite, IntegrationTestRunner,
-    TestExecutor, TestOrchestrator
+    IntegrationTestSuite,
+    IntegrationTestRunner,
+    TestExecutor,
+    TestOrchestrator,
 )
 from .testing_cli import TestingFrameworkCLI, run_smoke_test
 

--- a/src/core/testing_framework/async_utils.py
+++ b/src/core/testing_framework/async_utils.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Asynchronous utility helpers for the testing framework."""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable
+
+
+async def run_phase(
+    phase: Callable[[], Awaitable[bool]],
+    name: str,
+    logger: logging.Logger,
+    logs: list[str],
+    *,
+    suppress_exceptions: bool = False,
+) -> bool:
+    """Execute a test phase coroutine with consistent logging.
+
+    Args:
+        phase: Coroutine function representing the phase.
+        name: Human readable phase name.
+        logger: Logger for emitting messages.
+        logs: List to append textual logs to.
+        suppress_exceptions: If True, swallow exceptions and report failure.
+
+    Returns:
+        Whether the phase succeeded.
+    """
+    try:
+        result = await phase()
+        if not result and not suppress_exceptions:
+            raise RuntimeError(f"{name} phase failed")
+        return result
+    except Exception as exc:  # pragma: no cover - defensive branch
+        message = f"{name.capitalize()} failed: {exc}"
+        logs.append(message)
+        logger.error(message)
+        if not suppress_exceptions:
+            raise
+        return False

--- a/src/core/testing_framework/base_test.py
+++ b/src/core/testing_framework/base_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Base test classes for the modular testing framework."""
+
+from __future__ import annotations
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+from .testing_types import TestPriority, TestResult, TestStatus, TestType
+from .async_utils import run_phase
+from .result_handler import create_test_result
+
+
+class BaseIntegrationTest(ABC):
+    """Abstract base class for integration tests."""
+
+    def __init__(self, test_name: str, test_type: TestType, priority: TestPriority = TestPriority.NORMAL):
+        self.test_name = test_name
+        self.test_type = test_type
+        self.priority = priority
+        self.status = TestStatus.PENDING
+        self.start_time: Optional[float] = None
+        self.end_time: Optional[float] = None
+        self.error_message: Optional[str] = None
+        self.error_traceback: Optional[str] = None
+        self.metrics: Dict[str, Any] = {}
+        self.logs: List[str] = []
+        self.assertions_passed = 0
+        self.assertions_failed = 0
+        self.test_data: Dict[str, Any] = {}
+
+        self.logger = logging.getLogger(f"test.{self.__class__.__name__}")
+        self.logger.setLevel(logging.INFO)
+
+    @abstractmethod
+    async def setup(self) -> bool:
+        """Setup test environment and dependencies."""
+
+    @abstractmethod
+    async def execute(self) -> bool:
+        """Execute the actual test logic."""
+
+    @abstractmethod
+    async def cleanup(self) -> bool:
+        """Cleanup test environment and resources."""
+
+    @abstractmethod
+    async def validate(self) -> bool:
+        """Validate test results and assertions."""
+
+    async def run(self) -> TestResult:
+        """Run the complete test lifecycle and return a result."""
+        self.status = TestStatus.RUNNING
+        self.start_time = time.time()
+
+        try:
+            self.logger.info("Starting test: %s", self.test_name)
+            self.logs.append(f"Test started at {time.strftime('%H:%M:%S')}")
+
+            await run_phase(self.setup, "setup", self.logger, self.logs)
+            await run_phase(self.execute, "execute", self.logger, self.logs)
+            await run_phase(self.validate, "validate", self.logger, self.logs)
+
+            self.status = TestStatus.PASSED
+            self.logs.append("Test completed successfully")
+        except Exception as exc:
+            self.status = TestStatus.FAILED
+            self.error_message = str(exc)
+            self.error_traceback = str(exc.__traceback__)
+            self.logs.append(f"Test failed: {exc}")
+            self.logger.error("Test failed: %s", exc)
+        finally:
+            await run_phase(self.cleanup, "cleanup", self.logger, self.logs, suppress_exceptions=True)
+            self.end_time = time.time()
+            duration = self.end_time - self.start_time
+            self.logs.append(f"Test finished at {time.strftime('%H:%M:%S')}")
+            self.logger.info("Test %s finished with status: %s", self.test_name, self.status.value)
+
+        return create_test_result(self, duration)

--- a/src/core/testing_framework/integration_tests.py
+++ b/src/core/testing_framework/integration_tests.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Concrete integration test implementations."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Dict, List
+
+from .base_test import BaseIntegrationTest
+from .testing_types import TestPriority, TestType
+
+
+class CrossSystemCommunicationTest(BaseIntegrationTest):
+    """Test for cross-system communication functionality."""
+
+    def __init__(self, test_name: str, priority: TestPriority = TestPriority.HIGH):
+        super().__init__(test_name, TestType.INTEGRATION, priority)
+        self.communication_systems: List[Dict[str, str]] = []
+        self.message_queue: List[Dict[str, str]] = []
+        self.connection_status: Dict[str, str] = {}
+
+    async def setup(self) -> bool:
+        try:
+            self.logs.append("Setting up communication test environment")
+            self.communication_systems = [
+                {"name": "system_a", "status": "active"},
+                {"name": "system_b", "status": "active"},
+                {"name": "system_c", "status": "active"},
+            ]
+            self.message_queue = []
+            self.connection_status = {sys["name"]: "connected" for sys in self.communication_systems}
+            self.logs.append(f"Setup {len(self.communication_systems)} communication systems")
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Setup failed: {exc}")
+            return False
+
+    async def execute(self) -> bool:
+        try:
+            self.logs.append("Executing communication test")
+            test_message = {"type": "test", "content": "Hello from system A", "timestamp": time.time()}
+            self.message_queue.append(test_message)
+            await asyncio.sleep(0.1)
+            if self.message_queue:
+                received = self.message_queue.pop(0)
+                if received["content"] == "Hello from system A":
+                    self.assertions_passed += 1
+                    self.logs.append("Message sending/receiving test passed")
+                else:
+                    self.assertions_failed += 1
+                    self.logs.append("Message sending/receiving test failed")
+            for system in self.communication_systems:
+                if self.connection_status.get(system["name"]) == "connected":
+                    self.assertions_passed += 1
+                else:
+                    self.assertions_failed += 1
+            self.logs.append(
+                f"Communication test completed: {self.assertions_passed} passed, {self.assertions_failed} failed"
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Execution failed: {exc}")
+            return False
+
+    async def cleanup(self) -> bool:
+        try:
+            self.logs.append("Cleaning up communication test environment")
+            self.message_queue.clear()
+            self.connection_status.clear()
+            self.communication_systems.clear()
+            self.logs.append("Cleanup completed successfully")
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Cleanup failed: {exc}")
+            return False
+
+    async def validate(self) -> bool:
+        try:
+            self.logs.append("Validating communication test results")
+            total = self.assertions_passed + self.assertions_failed
+            if total == 0:
+                self.logs.append("No assertions were made during test")
+                return False
+            success_rate = self.assertions_passed / total
+            self.metrics["success_rate"] = success_rate
+            self.metrics["total_assertions"] = total
+            self.logs.append(f"Validation completed: {success_rate:.2%} success rate")
+            return success_rate >= 0.8
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Validation failed: {exc}")
+            return False
+
+
+class ServiceIntegrationTest(BaseIntegrationTest):
+    """Test for service integration functionality."""
+
+    def __init__(self, test_name: str, priority: TestPriority = TestPriority.NORMAL):
+        super().__init__(test_name, TestType.INTEGRATION, priority)
+        self.services: List[Dict[str, str]] = []
+        self.service_status: Dict[str, str] = {}
+        self.api_calls: List[Dict[str, str]] = []
+
+    async def setup(self) -> bool:
+        try:
+            self.logs.append("Setting up service integration test environment")
+            self.services = [
+                {"name": "auth_service", "endpoint": "/auth", "status": "active"},
+                {"name": "user_service", "endpoint": "/users", "status": "active"},
+                {"name": "data_service", "endpoint": "/data", "status": "active"},
+            ]
+            self.service_status = {svc["name"]: "healthy" for svc in self.services}
+            self.api_calls = []
+            self.logs.append(f"Setup {len(self.services)} services")
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Setup failed: {exc}")
+            return False
+
+    async def execute(self) -> bool:
+        try:
+            self.logs.append("Executing service integration test")
+            for service in self.services:
+                if self.service_status.get(service["name"]) == "healthy":
+                    self.assertions_passed += 1
+                    self.logs.append(f"Service {service['name']} health check passed")
+                else:
+                    self.assertions_failed += 1
+                    self.logs.append(f"Service {service['name']} health check failed")
+            test_api_call = {
+                "service": "auth_service",
+                "endpoint": "/auth/login",
+                "method": "POST",
+                "status": 200,
+            }
+            self.api_calls.append(test_api_call)
+            if test_api_call["status"] == 200:
+                self.assertions_passed += 1
+                self.logs.append("API call test passed")
+            else:
+                self.assertions_failed += 1
+                self.logs.append("API call test failed")
+            self.logs.append(
+                f"Service integration test completed: {self.assertions_passed} passed, {self.assertions_failed} failed"
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Execution failed: {exc}")
+            return False
+
+    async def cleanup(self) -> bool:
+        try:
+            self.logs.append("Cleaning up service integration test environment")
+            self.services.clear()
+            self.service_status.clear()
+            self.api_calls.clear()
+            self.logs.append("Cleanup completed successfully")
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Cleanup failed: {exc}")
+            return False
+
+    async def validate(self) -> bool:
+        try:
+            self.logs.append("Validating service integration test results")
+            total = self.assertions_passed + self.assertions_failed
+            if total == 0:
+                self.logs.append("No assertions were made during test")
+                return False
+            success_rate = self.assertions_passed / total
+            self.metrics["success_rate"] = success_rate
+            self.metrics["total_assertions"] = total
+            self.metrics["services_tested"] = len(self.services)
+            self.logs.append(f"Validation completed: {success_rate:.2%} success rate")
+            return success_rate >= 0.8
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Validation failed: {exc}")
+            return False
+
+
+class DatabaseIntegrationTest(BaseIntegrationTest):
+    """Test for database integration functionality."""
+
+    def __init__(self, test_name: str, priority: TestPriority = TestPriority.NORMAL):
+        super().__init__(test_name, TestType.INTEGRATION, priority)
+        self.database_connections: List[Dict[str, str]] = []
+        self.test_queries: List[str] = []
+        self.query_results: Dict[str, Dict[str, str]] = {}
+
+    async def setup(self) -> bool:
+        try:
+            self.logs.append("Setting up database integration test environment")
+            self.database_connections = [
+                {"name": "main_db", "type": "postgresql", "status": "connected"},
+                {"name": "cache_db", "type": "redis", "status": "connected"},
+                {"name": "analytics_db", "type": "mongodb", "status": "connected"},
+            ]
+            self.test_queries = [
+                "SELECT COUNT(*) FROM users",
+                "SELECT * FROM users LIMIT 1",
+                "INSERT INTO test_table (name) VALUES ('test')",
+            ]
+            self.query_results = {}
+            self.logs.append(f"Setup {len(self.database_connections)} database connections")
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Setup failed: {exc}")
+            return False
+
+    async def execute(self) -> bool:
+        try:
+            self.logs.append("Executing database integration test")
+            for db in self.database_connections:
+                if db["status"] == "connected":
+                    self.assertions_passed += 1
+                    self.logs.append(f"Database {db['name']} connection test passed")
+                else:
+                    self.assertions_failed += 1
+                    self.logs.append(f"Database {db['name']} connection test failed")
+            for query in self.test_queries:
+                if "SELECT" in query:
+                    self.query_results[query] = {"status": "success", "rows": 1}
+                    self.assertions_passed += 1
+                    self.logs.append(f"Query '{query[:30]}...' executed successfully")
+                elif "INSERT" in query:
+                    self.query_results[query] = {"status": "success", "affected_rows": 1}
+                    self.assertions_passed += 1
+                    self.logs.append(f"Query '{query[:30]}...' executed successfully")
+                else:
+                    self.assertions_failed += 1
+                    self.logs.append(f"Query '{query[:30]}...' failed")
+            self.logs.append(
+                f"Database integration test completed: {self.assertions_passed} passed, {self.assertions_failed} failed"
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Execution failed: {exc}")
+            return False
+
+    async def cleanup(self) -> bool:
+        try:
+            self.logs.append("Cleaning up database integration test environment")
+            self.database_connections.clear()
+            self.test_queries.clear()
+            self.query_results.clear()
+            self.logs.append("Cleanup completed successfully")
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Cleanup failed: {exc}")
+            return False
+
+    async def validate(self) -> bool:
+        try:
+            self.logs.append("Validating database integration test results")
+            total = self.assertions_passed + self.assertions_failed
+            if total == 0:
+                self.logs.append("No assertions were made during test")
+                return False
+            success_rate = self.assertions_passed / total
+            self.metrics["success_rate"] = success_rate
+            self.metrics["total_assertions"] = total
+            self.metrics["databases_tested"] = len(self.database_connections)
+            self.metrics["queries_executed"] = len(self.test_queries)
+            self.logs.append(f"Validation completed: {success_rate:.2%} success rate")
+            return success_rate >= 0.8
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logs.append(f"Validation failed: {exc}")
+            return False

--- a/src/core/testing_framework/result_handler.py
+++ b/src/core/testing_framework/result_handler.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Utility functions for handling test results."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from .testing_types import TestResult
+
+
+def create_test_result(test: Any, duration: float) -> TestResult:
+    """Create a :class:`TestResult` from a finished test instance."""
+    return TestResult(
+        test_id=f"{test.__class__.__name__}_{int(time.time())}",
+        test_name=test.test_name,
+        test_type=test.test_type,
+        status=test.status,
+        start_time=test.start_time or 0,
+        end_time=test.end_time or 0,
+        duration=duration if test.start_time and test.end_time else 0,
+        error_message=getattr(test, "error_message", None),
+        error_traceback=getattr(test, "error_traceback", None),
+        metrics=getattr(test, "metrics", {}),
+        logs=getattr(test, "logs", []),
+        assertions_passed=getattr(test, "assertions_passed", 0),
+        assertions_failed=getattr(test, "assertions_failed", 0),
+        test_data=getattr(test, "test_data", {}),
+    )

--- a/src/core/testing_framework/testing_cli.py
+++ b/src/core/testing_framework/testing_cli.py
@@ -21,12 +21,34 @@ from typing import Dict, Any, List, Optional
 
 # Import our components
 try:
-    from .testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from .testing_core import CrossSystemCommunicationTest, ServiceIntegrationTest, DatabaseIntegrationTest
+    from .testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from .integration_tests import (
+        CrossSystemCommunicationTest,
+        ServiceIntegrationTest,
+        DatabaseIntegrationTest,
+    )
     from .testing_orchestration import IntegrationTestSuite, IntegrationTestRunner, TestOrchestrator
 except ImportError:
-    from testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from testing_core import CrossSystemCommunicationTest, ServiceIntegrationTest, DatabaseIntegrationTest
+    from testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from integration_tests import (
+        CrossSystemCommunicationTest,
+        ServiceIntegrationTest,
+        DatabaseIntegrationTest,
+    )
     from testing_orchestration import IntegrationTestSuite, IntegrationTestRunner, TestOrchestrator
 
 

--- a/src/core/testing_framework/testing_core.py
+++ b/src/core/testing_framework/testing_core.py
@@ -1,513 +1,61 @@
 #!/usr/bin/env python3
-"""
-Testing Core - V2 Testing Framework Core Classes
-================================================
+"""High-level orchestration for the testing framework."""
 
-Contains base classes and core test implementations for the testing framework.
-Follows V2 coding standards with clean OOP design and SRP compliance.
-
-Author: Agent-2 (Architecture & Design Specialist)
-License: MIT
-"""
+from __future__ import annotations
 
 import asyncio
-import time
 import logging
+from typing import Iterable, List
 
-from src.utils.stability_improvements import stability_manager, safe_import
-from abc import ABC, abstractmethod
-from typing import Dict, Any, List, Optional, Union
-from unittest.mock import Mock, AsyncMock
-
-# Import our types
-try:
-    from .testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario
-except ImportError:
-    from testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario
+from .base_test import BaseIntegrationTest
+from .integration_tests import (
+    CrossSystemCommunicationTest,
+    ServiceIntegrationTest,
+    DatabaseIntegrationTest,
+)
 
 
-class BaseIntegrationTest(ABC):
-    """Abstract base class for all integration tests."""
-    
-    def __init__(self, test_name: str, test_type: TestType, priority: TestPriority = TestPriority.NORMAL):
-        self.test_name = test_name
-        self.test_type = test_type
-        self.priority = priority
-        self.status = TestStatus.PENDING
-        self.start_time: Optional[float] = None
-        self.end_time: Optional[float] = None
-        self.error_message: Optional[str] = None
-        self.error_traceback: Optional[str] = None
-        self.metrics: Dict[str, Any] = {}
-        self.logs: List[str] = []
-        self.assertions_passed = 0
-        self.assertions_failed = 0
-        self.test_data: Dict[str, Any] = {}
-        
-        # Setup logging
-        self.logger = logging.getLogger(f"test.{self.__class__.__name__}")
-        self.logger.setLevel(logging.INFO)
-    
-    @abstractmethod
-    async def setup(self) -> bool:
-        """Setup test environment and dependencies."""
-        pass
-    
-    @abstractmethod
-    async def execute(self) -> bool:
-        """Execute the actual test logic."""
-        pass
-    
-    @abstractmethod
-    async def cleanup(self) -> bool:
-        """Cleanup test environment and resources."""
-        pass
-    
-    @abstractmethod
-    async def validate(self) -> bool:
-        """Validate test results and assertions."""
-        pass
-    
-    async def run(self) -> TestResult:
-        """Run the complete test lifecycle."""
-        self.status = TestStatus.RUNNING
-        self.start_time = time.time()
-        
-        try:
-            self.logger.info(f"Starting test: {self.test_name}")
-            self.logs.append(f"Test started at {time.strftime('%H:%M:%S')}")
-            
-            # Setup phase
-            if not await self.setup():
-                raise RuntimeError("Test setup failed")
-            
-            # Execute phase
-            if not await self.execute():
-                raise RuntimeError("Test execution failed")
-            
-            # Validate phase
-            if not await self.validate():
-                raise RuntimeError("Test validation failed")
-            
-            # Success
-            self.status = TestStatus.PASSED
-            self.logs.append("Test completed successfully")
-            
-        except Exception as e:
-            self.status = TestStatus.FAILED
-            self.error_message = str(e)
-            self.error_traceback = str(e.__traceback__)
-            self.logs.append(f"Test failed: {e}")
-            self.logger.error(f"Test failed: {e}")
-            
-        finally:
-            # Cleanup phase
-            try:
-                await self.cleanup()
-            except Exception as cleanup_error:
-                self.logs.append(f"Cleanup failed: {cleanup_error}")
-                self.logger.warning(f"Cleanup failed: {cleanup_error}")
-            
-            self.end_time = time.time()
-            duration = self.end_time - self.start_time
-            
-            self.logs.append(f"Test finished at {time.strftime('%H:%M:%S')}")
-            self.logger.info(f"Test {self.test_name} finished with status: {self.status.value}")
-        
-        return TestResult(
-            test_id=f"{self.__class__.__name__}_{int(time.time())}",
-            test_name=self.test_name,
-            test_type=self.test_type,
-            status=self.status,
-            start_time=self.start_time or 0,
-            end_time=self.end_time or 0,
-            duration=duration if self.start_time and self.end_time else 0,
-            error_message=self.error_message,
-            error_traceback=self.error_traceback,
-            metrics=self.metrics,
-            logs=self.logs,
-            assertions_passed=self.assertions_passed,
-            assertions_failed=self.assertions_failed,
-            test_data=self.test_data
-        )
+class TestManager:
+    """Lightweight orchestrator that runs integration tests sequentially."""
+
+    def __init__(self, tests: Iterable[BaseIntegrationTest] | None = None):
+        self.tests: List[BaseIntegrationTest] = list(tests or [])
+        self.logger = logging.getLogger(__name__)
+
+    def add_test(self, test: BaseIntegrationTest) -> None:
+        self.tests.append(test)
+        self.logger.info("Added test %s", test.test_name)
+
+    async def run_all(self):
+        results = []
+        for test in self.tests:
+            self.logger.info("Running %s", test.test_name)
+            results.append(await test.run())
+        return results
 
 
-class CrossSystemCommunicationTest(BaseIntegrationTest):
-    """Test for cross-system communication functionality."""
-    
-    def __init__(self, test_name: str, priority: TestPriority = TestPriority.HIGH):
-        super().__init__(test_name, TestType.INTEGRATION, priority)
-        self.communication_systems = []
-        self.message_queue = []
-        self.connection_status = {}
-    
-    async def setup(self) -> bool:
-        """Setup communication test environment."""
-        try:
-            self.logs.append("Setting up communication test environment")
-            
-            # Mock communication systems
-            self.communication_systems = [
-                {"name": "system_a", "status": "active"},
-                {"name": "system_b", "status": "active"},
-                {"name": "system_c", "status": "active"}
-            ]
-            
-            # Initialize message queue
-            self.message_queue = []
-            self.connection_status = {sys["name"]: "connected" for sys in self.communication_systems}
-            
-            self.logs.append(f"Setup {len(self.communication_systems)} communication systems")
-            return True
-            
-        except Exception as e:
-            self.logs.append(f"Setup failed: {e}")
-            return False
-    
-    async def execute(self) -> bool:
-        """Execute communication test."""
-        try:
-            self.logs.append("Executing communication test")
-            
-            # Test message sending
-            test_message = {"type": "test", "content": "Hello from system A", "timestamp": time.time()}
-            self.message_queue.append(test_message)
-            
-            # Simulate message processing
-            await asyncio.sleep(0.1)
-            
-            # Test message reception
-            if self.message_queue:
-                received_message = self.message_queue.pop(0)
-                if received_message["content"] == "Hello from system A":
-                    self.assertions_passed += 1
-                    self.logs.append("Message sending/receiving test passed")
-                else:
-                    self.assertions_failed += 1
-                    self.logs.append("Message sending/receiving test failed")
-            
-            # Test connection status
-            for system in self.communication_systems:
-                if self.connection_status.get(system["name"]) == "connected":
-                    self.assertions_passed += 1
-                else:
-                    self.assertions_failed += 1
-            
-            self.logs.append(f"Communication test completed: {self.assertions_passed} passed, {self.assertions_failed} failed")
-            return True
-            
-        except Exception as e:
-            self.logs.append(f"Execution failed: {e}")
-            return False
-    
-    async def cleanup(self) -> bool:
-        """Cleanup communication test environment."""
-        try:
-            self.logs.append("Cleaning up communication test environment")
-            
-            # Clear message queue
-            self.message_queue.clear()
-            
-            # Reset connection status
-            self.connection_status.clear()
-            
-            # Clear communication systems
-            self.communication_systems.clear()
-            
-            self.logs.append("Cleanup completed successfully")
-            return True
-            
-        except Exception as e:
-            self.logs.append(f"Cleanup failed: {e}")
-            return False
-    
-    async def validate(self) -> bool:
-        """Validate communication test results."""
-        try:
-            self.logs.append("Validating communication test results")
-            
-            # Check if all assertions passed
-            total_assertions = self.assertions_passed + self.assertions_failed
-            if total_assertions == 0:
-                self.logs.append("No assertions were made during test")
-                return False
-            
-            success_rate = self.assertions_passed / total_assertions
-            self.metrics["success_rate"] = success_rate
-            self.metrics["total_assertions"] = total_assertions
-            
-            self.logs.append(f"Validation completed: {success_rate:.2%} success rate")
-            return success_rate >= 0.8  # 80% success rate threshold
-            
-        except Exception as e:
-            self.logs.append(f"Validation failed: {e}")
-            return False
-
-
-class ServiceIntegrationTest(BaseIntegrationTest):
-    """Test for service integration functionality."""
-    
-    def __init__(self, test_name: str, priority: TestPriority = TestPriority.NORMAL):
-        super().__init__(test_name, TestType.INTEGRATION, priority)
-        self.services = []
-        self.service_status = {}
-        self.api_calls = []
-    
-    async def setup(self) -> bool:
-        """Setup service integration test environment."""
-        try:
-            self.logs.append("Setting up service integration test environment")
-            
-            # Mock services
-            self.services = [
-                {"name": "auth_service", "endpoint": "/auth", "status": "active"},
-                {"name": "user_service", "endpoint": "/users", "status": "active"},
-                {"name": "data_service", "endpoint": "/data", "status": "active"}
-            ]
-            
-            # Initialize service status
-            self.service_status = {svc["name"]: "healthy" for svc in self.services}
-            self.api_calls = []
-            
-            self.logs.append(f"Setup {len(self.services)} services")
-            return True
-            
-        except Exception as e:
-            self.logs.append(f"Setup failed: {e}")
-            return False
-    
-    async def execute(self) -> bool:
-        """Execute service integration test."""
-        try:
-            self.logs.append("Executing service integration test")
-            
-            # Test service health checks
-            for service in self.services:
-                if self.service_status.get(service["name"]) == "healthy":
-                    self.assertions_passed += 1
-                    self.logs.append(f"Service {service['name']} health check passed")
-                else:
-                    self.assertions_failed += 1
-                    self.logs.append(f"Service {service['name']} health check failed")
-            
-            # Test API calls
-            test_api_call = {
-                "service": "auth_service",
-                "endpoint": "/auth/login",
-                "method": "POST",
-                "status": 200
-            }
-            self.api_calls.append(test_api_call)
-            
-            if test_api_call["status"] == 200:
-                self.assertions_passed += 1
-                self.logs.append("API call test passed")
-            else:
-                self.assertions_failed += 1
-                self.logs.append("API call test failed")
-            
-            self.logs.append(f"Service integration test completed: {self.assertions_passed} passed, {self.assertions_failed} failed")
-            return True
-            
-        except Exception as e:
-            self.logs.append(f"Execution failed: {e}")
-            return False
-    
-    async def cleanup(self) -> bool:
-        """Cleanup service integration test environment."""
-        try:
-            self.logs.append("Cleaning up service integration test environment")
-            
-            # Clear services
-            self.services.clear()
-            self.service_status.clear()
-            self.api_calls.clear()
-            
-            self.logs.append("Cleanup completed successfully")
-            return True
-            
-        except Exception as e:
-            self.logs.append(f"Cleanup failed: {e}")
-            return False
-    
-    async def validate(self) -> bool:
-        """Validate service integration test results."""
-        try:
-            self.logs.append("Validating service integration test results")
-            
-            # Check if all assertions passed
-            total_assertions = self.assertions_passed + self.assertions_failed
-            if total_assertions == 0:
-                self.logs.append("No assertions were made during test")
-                return False
-            
-            success_rate = self.assertions_passed / total_assertions
-            self.metrics["success_rate"] = success_rate
-            self.metrics["total_assertions"] = total_assertions
-            self.metrics["services_tested"] = len(self.services)
-            
-            self.logs.append(f"Validation completed: {success_rate:.2%} success rate")
-            return success_rate >= 0.8  # 80% success rate threshold
-            
-        except Exception as e:
-            self.logs.append(f"Validation failed: {e}")
-            return False
-
-
-class DatabaseIntegrationTest(BaseIntegrationTest):
-    """Test for database integration functionality."""
-    
-    def __init__(self, test_name: str, priority: TestPriority = TestPriority.NORMAL):
-        super().__init__(test_name, TestType.INTEGRATION, priority)
-        self.database_connections = []
-        self.test_queries = []
-        self.query_results = {}
-    
-    async def setup(self) -> bool:
-        """Setup database integration test environment."""
-        try:
-            self.logs.append("Setting up database integration test environment")
-            
-            # Mock database connections
-            self.database_connections = [
-                {"name": "main_db", "type": "postgresql", "status": "connected"},
-                {"name": "cache_db", "type": "redis", "status": "connected"},
-                {"name": "analytics_db", "type": "mongodb", "status": "connected"}
-            ]
-            
-            # Initialize test queries
-            self.test_queries = [
-                "SELECT COUNT(*) FROM users",
-                "SELECT * FROM users LIMIT 1",
-                "INSERT INTO test_table (name) VALUES ('test')"
-            ]
-            
-            self.query_results = {}
-            
-            self.logs.append(f"Setup {len(self.database_connections)} database connections")
-            return True
-            
-        except Exception as e:
-            self.logs.append(f"Setup failed: {e}")
-            return False
-    
-    async def execute(self) -> bool:
-        """Execute database integration test."""
-        try:
-            self.logs.append("Executing database integration test")
-            
-            # Test database connections
-            for db in self.database_connections:
-                if db["status"] == "connected":
-                    self.assertions_passed += 1
-                    self.logs.append(f"Database {db['name']} connection test passed")
-                else:
-                    self.assertions_failed += 1
-                    self.logs.append(f"Database {db['name']} connection test failed")
-            
-            # Test query execution
-            for query in self.test_queries:
-                # Simulate query execution
-                if "SELECT" in query:
-                    self.query_results[query] = {"status": "success", "rows": 1}
-                    self.assertions_passed += 1
-                    self.logs.append(f"Query '{query[:30]}...' executed successfully")
-                elif "INSERT" in query:
-                    self.query_results[query] = {"status": "success", "affected_rows": 1}
-                    self.assertions_passed += 1
-                    self.logs.append(f"Query '{query[:30]}...' executed successfully")
-                else:
-                    self.assertions_failed += 1
-                    self.logs.append(f"Query '{query[:30]}...' failed")
-            
-            self.logs.append(f"Database integration test completed: {self.assertions_passed} passed, {self.assertions_failed} failed")
-            return True
-            
-        except Exception as e:
-            self.logs.append(f"Execution failed: {e}")
-            return False
-    
-    async def cleanup(self) -> bool:
-        """Cleanup database integration test environment."""
-        try:
-            self.logs.append("Cleaning up database integration test environment")
-            
-            # Clear database connections
-            self.database_connections.clear()
-            self.test_queries.clear()
-            self.query_results.clear()
-            
-            self.logs.append("Cleanup completed successfully")
-            return True
-            
-        except Exception as e:
-            self.logs.append(f"Cleanup failed: {e}")
-            return False
-    
-    async def validate(self) -> bool:
-        """Validate database integration test results."""
-        try:
-            self.logs.append("Validating database integration test results")
-            
-            # Check if all assertions passed
-            total_assertions = self.assertions_passed + self.assertions_failed
-            if total_assertions == 0:
-                self.logs.append("No assertions were made during test")
-                return False
-            
-            success_rate = self.assertions_passed / total_assertions
-            self.metrics["success_rate"] = success_rate
-            self.metrics["total_assertions"] = total_assertions
-            self.metrics["databases_tested"] = len(self.database_connections)
-            self.metrics["queries_executed"] = len(self.test_queries)
-            
-            self.logs.append(f"Validation completed: {success_rate:.2%} success rate")
-            return success_rate >= 0.8  # 80% success rate threshold
-            
-        except Exception as e:
-            self.logs.append(f"Validation failed: {e}")
-            return False
+async def run_demo_suite():
+    """Run a small demonstration suite of built-in tests."""
+    manager = TestManager(
+        [
+            CrossSystemCommunicationTest("Communication Test"),
+            ServiceIntegrationTest("Service Test"),
+            DatabaseIntegrationTest("Database Test"),
+        ]
+    )
+    return await manager.run_all()
 
 
 def run_smoke_test() -> bool:
-    """Run smoke test for testing core module."""
+    """Execute the demo suite to verify orchestration works."""
     try:
-        print("🧪 Testing Testing Core Module...")
-        
-        # Test base class instantiation (should fail for abstract class)
-        try:
-            test = BaseIntegrationTest("test", TestType.INTEGRATION)
-            print("❌ BaseIntegrationTest should not be instantiable")
-            return False
-        except TypeError:
-            print("✅ BaseIntegrationTest correctly prevents instantiation")
-        
-        # Test CrossSystemCommunicationTest
-        comm_test = CrossSystemCommunicationTest("Communication Test")
-        assert comm_test.test_name == "Communication Test"
-        assert comm_test.test_type == TestType.INTEGRATION
-        assert comm_test.priority == TestPriority.HIGH
-        print("✅ CrossSystemCommunicationTest creation successful")
-        
-        # Test ServiceIntegrationTest
-        service_test = ServiceIntegrationTest("Service Test")
-        assert service_test.test_name == "Service Test"
-        assert service_test.test_type == TestType.INTEGRATION
-        print("✅ ServiceIntegrationTest creation successful")
-        
-        # Test DatabaseIntegrationTest
-        db_test = DatabaseIntegrationTest("Database Test")
-        assert db_test.test_name == "Database Test"
-        assert db_test.test_type == TestType.INTEGRATION
-        print("✅ DatabaseIntegrationTest creation successful")
-        
-        print("🎉 All testing core smoke tests passed!")
+        asyncio.run(run_demo_suite())
+        print("🎉 Testing core smoke test passed!")
         return True
-        
-    except Exception as e:
-        print(f"❌ Testing core smoke test failed: {e}")
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"❌ Testing core smoke test failed: {exc}")
         return False
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     run_smoke_test()

--- a/src/core/testing_framework/testing_orchestration.py
+++ b/src/core/testing_framework/testing_orchestration.py
@@ -18,15 +18,29 @@ from src.utils.stability_improvements import stability_manager, safe_import
 
 # Import our modular components
 try:
-    from .testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from .testing_core import BaseIntegrationTest
+    from .testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from .base_test import BaseIntegrationTest
     from .testing_orchestration_core import IntegrationTestSuite, TestSuiteResult
     from .testing_orchestration_runner import IntegrationTestRunner
     from .testing_orchestration_executor import TestExecutor, ExecutionConfig
     from .testing_orchestration_orchestrator import TestOrchestrator
 except ImportError:
-    from testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from testing_core import BaseIntegrationTest
+    from testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from base_test import BaseIntegrationTest
     from testing_orchestration_core import IntegrationTestSuite, TestSuiteResult
     from testing_orchestration_runner import IntegrationTestRunner
     from testing_orchestration_executor import TestExecutor, ExecutionConfig

--- a/src/core/testing_framework/testing_orchestration_core.py
+++ b/src/core/testing_framework/testing_orchestration_core.py
@@ -20,11 +20,25 @@ from src.utils.stability_improvements import stability_manager, safe_import
 
 # Import our types and core classes
 try:
-    from .testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from .testing_core import BaseIntegrationTest
+    from .testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from .base_test import BaseIntegrationTest
 except ImportError:
-    from testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from testing_core import BaseIntegrationTest
+    from testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from base_test import BaseIntegrationTest
 
 
 @dataclass

--- a/src/core/testing_framework/testing_orchestration_executor.py
+++ b/src/core/testing_framework/testing_orchestration_executor.py
@@ -19,12 +19,26 @@ from src.utils.stability_improvements import stability_manager, safe_import
 
 # Import our types and core classes
 try:
-    from .testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from .testing_core import BaseIntegrationTest
+    from .testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from .base_test import BaseIntegrationTest
     from .testing_orchestration_core import IntegrationTestSuite
 except ImportError:
-    from testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from testing_core import BaseIntegrationTest
+    from testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from base_test import BaseIntegrationTest
     from testing_orchestration_core import IntegrationTestSuite
 
 

--- a/src/core/testing_framework/testing_orchestration_runner.py
+++ b/src/core/testing_framework/testing_orchestration_runner.py
@@ -19,12 +19,26 @@ from src.utils.stability_improvements import stability_manager, safe_import
 
 # Import our types and core classes
 try:
-    from .testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from .testing_core import BaseIntegrationTest
+    from .testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from .base_test import BaseIntegrationTest
     from .testing_orchestration_core import IntegrationTestSuite, TestSuiteResult
 except ImportError:
-    from testing_types import TestStatus, TestType, TestPriority, TestResult, TestScenario, TestEnvironment
-    from testing_core import BaseIntegrationTest
+    from testing_types import (
+        TestStatus,
+        TestType,
+        TestPriority,
+        TestResult,
+        TestScenario,
+        TestEnvironment,
+    )
+    from base_test import BaseIntegrationTest
     from testing_orchestration_core import IntegrationTestSuite, TestSuiteResult
 
 

--- a/tests/test_testing_framework_fixtures.py
+++ b/tests/test_testing_framework_fixtures.py
@@ -8,18 +8,20 @@ Tests for fixture-based integration test classes and suites.
 
 import pytest
 
-from src.core.testing_framework import (
+from src.core.testing_framework.testing_types import (
     TestStatus,
     TestType,
     TestPriority,
     TestResult,
-    BaseIntegrationTest,
+    TestEnvironment,
+)
+from src.core.testing_framework.base_test import BaseIntegrationTest
+from src.core.testing_framework.integration_tests import (
     CrossSystemCommunicationTest,
     ServiceIntegrationTest,
     DatabaseIntegrationTest,
-    IntegrationTestSuite,
-    TestEnvironment,
 )
+from src.core.testing_framework.testing_orchestration_core import IntegrationTestSuite
 
 
 @pytest.fixture

--- a/tests/test_testing_framework_runner.py
+++ b/tests/test_testing_framework_runner.py
@@ -11,17 +11,16 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from src.core.testing_framework import (
-    TestStatus,
-    TestPriority,
+from src.core.testing_framework.testing_types import TestStatus, TestPriority
+from src.core.testing_framework.integration_tests import (
     CrossSystemCommunicationTest,
     ServiceIntegrationTest,
-    IntegrationTestSuite,
-    IntegrationTestRunner,
-    TestExecutor,
-    TestOrchestrator,
-    TestingFrameworkCLI,
 )
+from src.core.testing_framework.testing_orchestration_core import IntegrationTestSuite
+from src.core.testing_framework.testing_orchestration_runner import IntegrationTestRunner
+from src.core.testing_framework.testing_orchestration_executor import TestExecutor
+from src.core.testing_framework.testing_orchestration_orchestrator import TestOrchestrator
+from src.core.testing_framework.testing_cli import TestingFrameworkCLI
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- factor out base test class into `base_test.py` and move concrete integration tests to `integration_tests.py`
- add `result_handler` and `async_utils` helpers and slim down `testing_core.py` to high-level orchestration
- update imports and tests for the new module layout

## Testing
- `pytest tests/test_testing_framework_core.py tests/test_testing_framework_fixtures.py tests/test_testing_framework_runner.py` *(fails: KeyError, AttributeError in runner/orchestrator tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac59fd5284832993a58314923a3fd4