### PR TITLE
Add Phase 3 batch 1 contracts for moderate files

### DIFF
--- a/contracts/phase3_moderate_400plus_loc.json
+++ b/contracts/phase3_moderate_400plus_loc.json
@@ -1,14 +1,285 @@
 {
   "phase": "Phase 3 - Moderate Violations (400+ LOC)",
   "description": "Moderate priority refactoring contracts for files exceeding 400 lines",
-  "total_files": 0,
+  "total_files": 10,
   "estimated_effort": "1-2 days per file",
   "priority": "MODERATE",
   "standards": {
     "target_loc": "400 LOC (standard), 600 LOC (GUI)",
     "focus": "SRP compliance, modular architecture, production-ready code"
   },
-  "contracts": [],
+  "contracts": [
+    {
+      "contract_id": "MODERATE-001",
+      "file_path": "src/services/automated_quality_gates.py",
+      "current_lines": 597,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "rule_engine.py",
+          "gate_executor.py",
+          "report_generator.py",
+          "config_loader.py"
+        ],
+        "main_class": "AutomatedQualityGates",
+        "responsibilities": "Coordinate quality gate workflow"
+      },
+      "dependencies": [
+        "src/utils/stability_improvements",
+        "src/services/quality_validation_orchestrator.py"
+      ],
+      "testing_strategy": "Unit tests for each module and integration tests for gate workflows",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Each module has a single responsibility",
+        "All tests pass",
+        "No regression in quality gate functionality"
+      ]
+    },
+    {
+      "contract_id": "MODERATE-002",
+      "file_path": "src/services/financial/risk_management_service.py",
+      "current_lines": 591,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "risk_assessor.py",
+          "portfolio_monitor.py",
+          "alert_manager.py",
+          "data_feed_handler.py"
+        ],
+        "main_class": "RiskManagementService",
+        "responsibilities": "Provide risk assessment and mitigation"
+      },
+      "dependencies": [
+        "src/services/financial/portfolio/risk_models.py",
+        "src/utils/stability_improvements"
+      ],
+      "testing_strategy": "Unit tests for risk calculations and integration tests with portfolio models",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Risk modules separated",
+        "All tests pass",
+        "No regression in risk calculations"
+      ]
+    },
+    {
+      "contract_id": "MODERATE-003",
+      "file_path": "src/services/captain_specific_stall_prevention.py",
+      "current_lines": 589,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "cursor_monitor.py",
+          "prompt_scheduler.py",
+          "activity_tracker.py",
+          "alert_dispatcher.py"
+        ],
+        "main_class": "StallPreventionService",
+        "responsibilities": "Monitor captain activity and dispatch prompts"
+      },
+      "dependencies": [
+        "src/utils/stability_improvements",
+        "src/core/agent_manager.py"
+      ],
+      "testing_strategy": "Unit tests for cursor monitoring and scheduling, integration tests for alert dispatch",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Modules isolated by concern",
+        "All tests pass",
+        "Prompts trigger correctly"
+      ]
+    },
+    {
+      "contract_id": "MODERATE-004",
+      "file_path": "src/services/contract_template_system.py",
+      "current_lines": 587,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "template_repository.py",
+          "template_renderer.py",
+          "template_validator.py",
+          "cli_interface.py"
+        ],
+        "main_class": "ContractTemplateSystem",
+        "responsibilities": "Manage contract templates"
+      },
+      "dependencies": [
+        "src/services/unified_contract_manager.py",
+        "src/utils/stability_improvements"
+      ],
+      "testing_strategy": "Unit tests for template operations and CLI integration tests",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Template management isolated",
+        "All tests pass",
+        "Backward compatibility maintained"
+      ]
+    },
+    {
+      "contract_id": "MODERATE-005",
+      "file_path": "src/setup_test_infrastructure.py",
+      "current_lines": 583,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "dependency_installer.py",
+          "structure_builder.py",
+          "environment_configurator.py",
+          "validation_runner.py"
+        ],
+        "main_class": "TestInfrastructureSetup",
+        "responsibilities": "Set up and validate testing environment"
+      },
+      "dependencies": [
+        "src/utils/stability_improvements",
+        "src/core/testing_framework"
+      ],
+      "testing_strategy": "Unit tests for setup helpers and integration tests validating environment",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Setup steps modularized",
+        "All tests pass",
+        "Environment configured correctly"
+      ]
+    },
+    {
+      "contract_id": "MODERATE-006",
+      "file_path": "src/core/agent_manager.py",
+      "current_lines": 581,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "agent_registry.py",
+          "status_tracker.py",
+          "capability_manager.py",
+          "agent_cli.py"
+        ],
+        "main_class": "AgentManager",
+        "responsibilities": "Manage agent lifecycle and capabilities"
+      },
+      "dependencies": [
+        "src/utils/stability_improvements",
+        "src/core/knowledge_database.py"
+      ],
+      "testing_strategy": "Unit tests for agent operations and integration tests with knowledge database",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Agent responsibilities separated",
+        "All tests pass",
+        "Lifecycle management maintained"
+      ]
+    },
+    {
+      "contract_id": "MODERATE-007",
+      "file_path": "src/core/knowledge_database.py",
+      "current_lines": 580,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "db_interface.py",
+          "knowledge_search.py",
+          "relationship_manager.py",
+          "recommendation_engine.py"
+        ],
+        "main_class": "KnowledgeDatabase",
+        "responsibilities": "Store and retrieve knowledge entries"
+      },
+      "dependencies": [
+        "src/utils/stability_improvements",
+        "src/core/agent_manager.py"
+      ],
+      "testing_strategy": "Unit tests for database operations and integration tests for search features",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Database functions modularized",
+        "All tests pass",
+        "Data integrity preserved"
+      ]
+    },
+    {
+      "contract_id": "MODERATE-008",
+      "file_path": "src/services/quality_validation_orchestrator.py",
+      "current_lines": 579,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "validation_scheduler.py",
+          "pipeline_runner.py",
+          "result_aggregator.py",
+          "reporting_interface.py"
+        ],
+        "main_class": "QualityValidationOrchestrator",
+        "responsibilities": "Coordinate quality validation workflows"
+      },
+      "dependencies": [
+        "src/utils/stability_improvements",
+        "src/services/automated_quality_gates.py"
+      ],
+      "testing_strategy": "Unit tests for orchestration logic and integration tests with quality gates",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Workflow modules isolated",
+        "All tests pass",
+        "Quality metrics remain accurate"
+      ]
+    },
+    {
+      "contract_id": "MODERATE-009",
+      "file_path": "src/services/financial/portfolio/risk_models.py",
+      "current_lines": 576,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "volatility_model.py",
+          "correlation_analyzer.py",
+          "scenario_generator.py",
+          "risk_reporter.py"
+        ],
+        "main_class": "RiskModels",
+        "responsibilities": "Provide portfolio risk modeling"
+      },
+      "dependencies": [
+        "src/utils/stability_improvements",
+        "src/services/financial/risk_management_service.py"
+      ],
+      "testing_strategy": "Unit tests for risk calculations and integration tests with risk management service",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Risk models separated",
+        "All tests pass",
+        "Model accuracy preserved"
+      ]
+    },
+    {
+      "contract_id": "MODERATE-010",
+      "file_path": "src/services/unified_contract_manager.py",
+      "current_lines": 575,
+      "target_lines": 300,
+      "refactoring_plan": {
+        "extract_modules": [
+          "lifecycle_manager.py",
+          "validation_engine.py",
+          "analytics_module.py",
+          "integration_adapter.py"
+        ],
+        "main_class": "UnifiedContractManager",
+        "responsibilities": "Manage contract lifecycle and analytics"
+      },
+      "dependencies": [
+        "src/utils/stability_improvements",
+        "src/services/contract_template_system.py"
+      ],
+      "testing_strategy": "Unit tests for each module and integration tests across contract lifecycle",
+      "success_criteria": [
+        "File reduced to \u2264300 lines",
+        "Contract operations modularized",
+        "All tests pass",
+        "Backward compatibility maintained"
+      ]
+    }
+  ],
   "completion_criteria": [
     "All files reduced to \u2264400 LOC (standard) or \u2264600 LOC (GUI)",
     "SRP compliance achieved",


### PR DESCRIPTION
## Summary
- Populate Phase 3 contract list with 10 moderate refactoring targets
- Include line counts, refactoring plans, dependencies, tests, and success criteria for each file

## Testing
- `pre-commit run --files contracts/phase3_moderate_400plus_loc.json`


------
https://chatgpt.com/codex/tasks/task_e_68ac5a9fa3d483298a5ed1bd32acbc8c