### PR TITLE
Refactor message routing into modular components

### DIFF
--- a/src/core/message_router.py
+++ b/src/core/message_router.py
@@ -1,609 +1,74 @@
-#!/usr/bin/env python3
-"""
-Message Router - V2 Core Message Routing System
+"""Orchestration layer for message routing.
 
-This module manages inter-agent message routing, queuing, and delivery.
-Follows Single Responsibility Principle - only message routing.
-Architecture: Single Responsibility Principle - message routing only
-LOC: Target 200 lines (under 200 limit)
-"""
-
-import os
-import json
-import logging
-from typing import Dict, List, Optional, Any, Callable
-from pathlib import Path
-from dataclasses import dataclass, asdict
-from enum import Enum
-from datetime import datetime, timedelta
-import threading
-import time
-import queue
-from collections import defaultdict
-
-logger = logging.getLogger(__name__)
-
-
-"""Simple message routing primitives used across the codebase.
-
-This project contains several overlapping messaging implementations.  Many of
-the service modules only need a very small subset of the full feature set, but
-the original ``message_router`` module attempted to depend on the much larger
-``v2_comprehensive_messaging_system`` package.  The heavy import pulled in a
-large collection of enums and complex logic which in turn triggered import
-errors during test collection.
-
-To keep the router lightweight and avoid those errors we rely on the shared
-enumerations defined in :mod:`src.core.shared_enums`.  They provide the basic
-``MessageType``, ``MessagePriority`` and ``MessageStatus`` enums which are more
-than sufficient for the router used in the tests.  Importing them here keeps the
-module self-contained and eliminates the previous ``NameError``.
+This module exposes :class:`MessageRouter` which coordinates the underlying
+routing components. Detailed implementations live in neighbouring modules:
+``routing_core``, ``routing_table``, ``strategy_factory``,
+``message_transformer`` and ``message_validator``.
 """
 
 from .shared_enums import MessagePriority, MessageStatus, MessageType
-
-
-@dataclass
-class Message:
-    """Message structure for inter-agent communication"""
-
-    message_id: str
-    sender_id: str
-    recipient_id: str
-    message_type: MessageType
-    priority: MessagePriority
-    content: Dict[str, Any]
-    timestamp: str
-    expires_at: Optional[str]
-    status: MessageStatus = MessageStatus.PENDING
-    delivery_attempts: int = 0
-    max_attempts: int = 3
-
-
-@dataclass
-class RoutingRule:
-    """Routing rule for message delivery"""
-
-    message_type: MessageType
-    priority: MessagePriority
-    target_agents: List[str]
-    delivery_strategy: str  # "broadcast", "round_robin", "specific"
-    retry_policy: Dict[str, Any]
+from .routing_models import Message, RoutingRule  # re-export for compatibility
+from .routing_core import RoutingCore
 
 
 class MessageRouter:
-    """
-    Manages inter-agent message routing, queuing, and delivery
+    """Thin wrapper delegating routing operations to :class:`RoutingCore`."""
 
-    Responsibilities:
-    - Message queuing and prioritization
-    - Intelligent routing based on message type
-    - Delivery confirmation and retry logic
-    - Message expiration and cleanup
-    """
+    def __init__(self, messages_dir: str = "messages") -> None:
+        self._core = RoutingCore(messages_dir)
 
-    def __init__(self, messages_dir: str = "messages"):
-        self.messages_dir = Path(messages_dir)
-        self.message_queue: queue.PriorityQueue = queue.PriorityQueue()
-        self.routing_rules: Dict[MessageType, RoutingRule] = {}
-        self.delivery_callbacks: Dict[str, Callable] = {}
-        self.message_history: Dict[str, Message] = {}
-        self.logger = logging.getLogger(f"{__name__}.MessageRouter")
-        self.routing_thread = None
-        self.running = False
-
-        # Ensure messages directory exists
-        self.messages_dir.mkdir(exist_ok=True)
-
-        # Initialize default routing rules
-        self._initialize_default_routing_rules()
-
-        # Start routing thread
-        self._start_routing_thread()
-
-    def _initialize_default_routing_rules(self):
-        """Initialize default routing rules for different message types"""
-        self.routing_rules = {
-            MessageType.CONTRACT_ASSIGNMENT: RoutingRule(
-                message_type=MessageType.CONTRACT_ASSIGNMENT,
-                priority=MessagePriority.HIGH,
-                target_agents=[],
-                delivery_strategy="specific",
-                retry_policy={"max_attempts": 3, "retry_delay": 5},
-            ),
-            MessageType.STATUS_UPDATE: RoutingRule(
-                message_type=MessageType.STATUS_UPDATE,
-                priority=MessagePriority.NORMAL,
-                target_agents=[],
-                delivery_strategy="broadcast",
-                retry_policy={"max_attempts": 1, "retry_delay": 0},
-            ),
-            MessageType.COORDINATION: RoutingRule(
-                message_type=MessageType.COORDINATION,
-                priority=MessagePriority.NORMAL,
-                target_agents=[],
-                delivery_strategy="broadcast",
-                retry_policy={"max_attempts": 2, "retry_delay": 10},
-            ),
-            MessageType.EMERGENCY: RoutingRule(
-                message_type=MessageType.EMERGENCY,
-                priority=MessagePriority.URGENT,
-                target_agents=[],
-                delivery_strategy="broadcast",
-                retry_policy={"max_attempts": 5, "retry_delay": 1},
-            ),
-            MessageType.HEARTBEAT: RoutingRule(
-                message_type=MessageType.HEARTBEAT,
-                priority=MessagePriority.LOW,
-                target_agents=[],
-                delivery_strategy="broadcast",
-                retry_policy={"max_attempts": 1, "retry_delay": 0},
-            ),
-            MessageType.SYSTEM_COMMAND: RoutingRule(
-                message_type=MessageType.SYSTEM_COMMAND,
-                priority=MessagePriority.HIGH,
-                target_agents=[],
-                delivery_strategy="specific",
-                retry_policy={"max_attempts": 3, "retry_delay": 5},
-            ),
-        }
-
+    # ------------------------------------------------------------------
+    # Delegated public API
+    # ------------------------------------------------------------------
     def send_message(
         self,
         sender_id: str,
         recipient_id: str,
         message_type: MessageType,
-        content: Dict[str, Any],
+        content,
         priority: MessagePriority = MessagePriority.NORMAL,
-        expires_in: Optional[int] = None,
+        expires_in=None,
     ) -> str:
-        """Send a message to a recipient"""
-        try:
-            # Generate unique message ID
-            message_id = f"{sender_id}_{recipient_id}_{int(time.time())}"
-
-            # Calculate expiration time
-            expires_at = None
-            if expires_in:
-                expires_at = (
-                    datetime.now() + timedelta(seconds=expires_in)
-                ).isoformat()
-
-            # Create message
-            message = Message(
-                message_id=message_id,
-                sender_id=sender_id,
-                recipient_id=recipient_id,
-                message_type=message_type,
-                priority=priority,
-                content=content,
-                timestamp=datetime.now().isoformat(),
-                expires_at=expires_at,
-                status=MessageStatus.PENDING,
-            )
-
-            # Add to queue with priority
-            priority_value = self._get_priority_value(priority)
-            self.message_queue.put((priority_value, message))
-
-            # Store in history
-            self.message_history[message_id] = message
-
-            # Save message to file
-            self._save_message(message)
-
-            self.logger.info(f"Message {message_id} queued for delivery")
-            return message_id
-
-        except Exception as e:
-            self.logger.error(f"Failed to send message: {e}")
-            return ""
+        return self._core.send_message(
+            sender_id, recipient_id, message_type, content, priority, expires_in
+        )
 
     def broadcast_message(
         self,
         sender_id: str,
         message_type: MessageType,
-        content: Dict[str, Any],
+        content,
         priority: MessagePriority = MessagePriority.NORMAL,
-        target_agents: Optional[List[str]] = None,
-    ) -> List[str]:
-        """Broadcast a message to multiple agents"""
-        try:
-            message_ids = []
-
-            # Use provided target agents or get all available
-            if target_agents is None:
-                target_agents = self._get_all_agent_ids()
-
-            # Send message to each target
-            for recipient_id in target_agents:
-                if recipient_id != sender_id:  # Don't send to self
-                    message_id = self.send_message(
-                        sender_id, recipient_id, message_type, content, priority
-                    )
-                    if message_id:
-                        message_ids.append(message_id)
-
-            self.logger.info(f"Broadcast message sent to {len(message_ids)} agents")
-            return message_ids
-
-        except Exception as e:
-            self.logger.error(f"Failed to broadcast message: {e}")
-            return []
-
-    def register_delivery_callback(self, message_type: MessageType, callback: Callable):
-        """Register a callback for message delivery"""
-        self.delivery_callbacks[message_type.value] = callback
-        self.logger.info(f"Registered delivery callback for {message_type.value}")
-
-    def get_message_status(self, message_id: str) -> Optional[MessageStatus]:
-        """Get the delivery status of a message"""
-        if message_id in self.message_history:
-            return self.message_history[message_id].status
-        return None
-
-    def get_pending_messages(self, recipient_id: str) -> List[Message]:
-        """Get all pending messages for a recipient"""
-        pending_messages = []
-        for message in self.message_history.values():
-            if (
-                message.recipient_id == recipient_id
-                and message.status == MessageStatus.PENDING
-                and not self._is_message_expired(message)
-            ):
-                pending_messages.append(message)
-
-        # Sort by priority and timestamp
-        pending_messages.sort(
-            key=lambda m: (self._get_priority_value(m.priority), m.timestamp)
+        target_agents=None,
+    ):
+        return self._core.broadcast_message(
+            sender_id, message_type, content, priority, target_agents
         )
-        return pending_messages
 
-    def _start_routing_thread(self):
-        """Start the message routing thread"""
-        self.running = True
-        self.routing_thread = threading.Thread(target=self._routing_loop, daemon=True)
-        self.routing_thread.start()
+    def register_delivery_callback(self, message_type: MessageType, callback):
+        self._core.register_delivery_callback(message_type, callback)
 
-    def _routing_loop(self):
-        """Main routing loop for processing messages"""
-        while self.running:
-            try:
-                if not self.message_queue.empty():
-                    priority, message = self.message_queue.get()
+    def get_message_status(self, message_id: str):
+        return self._core.get_message_status(message_id)
 
-                    # Check if message is expired
-                    if self._is_message_expired(message):
-                        message.status = MessageStatus.EXPIRED
-                        self._update_message_status(message)
-                        continue
+    def get_pending_messages(self, recipient_id: str):
+        return self._core.get_pending_messages(recipient_id)
 
-                    # Attempt delivery
-                    success = self._attempt_delivery(message)
-
-                    if success:
-                        message.status = MessageStatus.DELIVERED
-                        self._update_message_status(message)
-                    else:
-                        # Handle retry logic
-                        if message.delivery_attempts < message.max_attempts:
-                            message.delivery_attempts += 1
-                            # Re-queue with lower priority for retry
-                            retry_priority = (
-                                priority + 1000
-                            )  # Lower priority for retries
-                            self.message_queue.put((retry_priority, message))
-                            self.logger.warning(
-                                f"Message {message.message_id} queued for retry"
-                            )
-                        else:
-                            message.status = MessageStatus.FAILED
-                            self._update_message_status(message)
-                            self.logger.error(
-                                f"Message {message.message_id} delivery failed after {message.max_attempts} attempts"
-                            )
-
-                time.sleep(0.1)  # Small delay to prevent busy waiting
-
-            except Exception as e:
-                self.logger.error(f"Routing loop error: {e}")
-                time.sleep(1)
-
-    def _attempt_delivery(self, message: Message) -> bool:
-        """Attempt to deliver a message"""
-        try:
-            # Check if we have a callback for this message type
-            callback_key = message.message_type.value
-            if callback_key in self.delivery_callbacks:
-                callback = self.delivery_callbacks[callback_key]
-                return callback(message)
-
-            # Default delivery logic
-            return self._default_delivery(message)
-
-        except Exception as e:
-            self.logger.error(
-                f"Delivery attempt failed for message {message.message_id}: {e}"
-            )
-            return False
-
-    def _default_delivery(self, message: Message) -> bool:
-        """Default message delivery logic"""
-        try:
-            # For now, just mark as delivered
-            # In a real system, this would involve actual agent communication
-            self.logger.info(
-                f"Message {message.message_id} delivered to {message.recipient_id}"
-            )
-            return True
-
-        except Exception as e:
-            self.logger.error(f"Default delivery failed: {e}")
-            return False
-
-    def _is_message_expired(self, message: Message) -> bool:
-        """Check if a message has expired"""
-        if message.expires_at is None:
-            return False
-
-        try:
-            expires_time = datetime.fromisoformat(message.expires_at)
-            return datetime.now() > expires_time
-        except Exception:
-            return False
-
-    def _get_priority_value(self, priority: MessagePriority) -> int:
-        """Get numeric priority value for queue ordering"""
-        priority_map = {
-            MessagePriority.LOW: 1000,
-            MessagePriority.NORMAL: 500,
-            MessagePriority.HIGH: 100,
-            MessagePriority.URGENT: 0,
-        }
-        return priority_map.get(priority, 500)
-
-    def _get_all_agent_ids(self) -> List[str]:
-        """Get all available agent IDs"""
-        # This would typically query the agent manager
-        # For now, return a default list
-        return ["Agent-1", "Agent-2", "Agent-3", "Agent-4", "Agent-5"]
-
-    def _save_message(self, message: Message):
-        """Save message to file"""
-        try:
-            message_file = self.messages_dir / f"{message.message_id}.json"
-            message_data = asdict(message)
-            message_data["message_type"] = message.message_type.value
-            message_data["priority"] = message.priority.value
-            message_data["status"] = message.status.value
-
-            with open(message_file, "w") as f:
-                json.dump(message_data, f, indent=2, default=str)
-
-        except Exception as e:
-            self.logger.error(f"Failed to save message {message.message_id}: {e}")
-
-    def _update_message_status(self, message: Message):
-        """Update message status in file"""
-        self._save_message(message)
-
-    def get_routing_stats(self) -> Dict[str, Any]:
-        """Get routing statistics"""
-        try:
-            total_messages = len(self.message_history)
-            pending_messages = len(
-                [
-                    m
-                    for m in self.message_history.values()
-                    if m.status == MessageStatus.PENDING
-                ]
-            )
-            delivered_messages = len(
-                [
-                    m
-                    for m in self.message_history.values()
-                    if m.status == MessageStatus.DELIVERED
-                ]
-            )
-            failed_messages = len(
-                [
-                    m
-                    for m in self.message_history.values()
-                    if m.status == MessageStatus.FAILED
-                ]
-            )
-
-            return {
-                "total_messages": total_messages,
-                "pending_messages": pending_messages,
-                "delivered_messages": delivered_messages,
-                "failed_messages": failed_messages,
-                "queue_size": self.message_queue.qsize(),
-                "delivery_callbacks": len(self.delivery_callbacks),
-            }
-        except Exception as e:
-            self.logger.error(f"Failed to get routing stats: {e}")
-            return {"error": str(e)}
+    def get_routing_stats(self):
+        return self._core.get_routing_stats()
 
     def run_smoke_test(self) -> bool:
-        """Run basic functionality test for this instance"""
-        try:
-            # Test message sending
-            message_id = self.send_message(
-                "Agent-1",
-                "Agent-2",
-                MessageType.STATUS_UPDATE,
-                {"status": "online"},
-                MessagePriority.NORMAL,
-            )
-            if not message_id:
-                return False
+        return self._core.run_smoke_test()
 
-            # Test broadcast
-            broadcast_ids = self.broadcast_message(
-                "Agent-1",
-                MessageType.COORDINATION,
-                {"action": "sync"},
-                MessagePriority.NORMAL,
-            )
-            if len(broadcast_ids) == 0:
-                return False
-
-            # Test message status
-            status = self.get_message_status(message_id)
-            if status != MessageStatus.PENDING:
-                return False
-
-            # Test pending messages
-            pending = self.get_pending_messages("Agent-2")
-            if len(pending) == 0:
-                return False
-
-            # Test routing stats
-            stats = self.get_routing_stats()
-            if "total_messages" not in stats:
-                return False
-
-            return True
-
-        except Exception as e:
-            self.logger.error(f"Smoke test failed: {e}")
-            return False
-
-    def shutdown(self):
-        """Shutdown the message router"""
-        self.running = False
-        if self.routing_thread:
-            self.routing_thread.join(timeout=5)
+    def shutdown(self) -> None:
+        self._core.shutdown()
 
 
-def run_smoke_test():
-    """Run basic functionality test for MessageRouter"""
-    print("🧪 Running MessageRouter Smoke Test...")
-
-    try:
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            router = MessageRouter(temp_dir)
-
-            # Test message sending
-            message_id = router.send_message(
-                "Agent-1",
-                "Agent-2",
-                MessageType.STATUS_UPDATE,
-                {"status": "online"},
-                MessagePriority.NORMAL,
-            )
-            assert message_id
-
-            # Test broadcast
-            broadcast_ids = router.broadcast_message(
-                "Agent-1",
-                MessageType.COORDINATION,
-                {"action": "sync"},
-                MessagePriority.NORMAL,
-            )
-            assert len(broadcast_ids) > 0
-
-            # Test message status
-            status = router.get_message_status(message_id)
-            assert status == MessageStatus.PENDING
-
-            # Test pending messages
-            pending = router.get_pending_messages("Agent-2")
-            assert len(pending) > 0
-
-            # Test routing stats
-            stats = router.get_routing_stats()
-            assert "total_messages" in stats
-
-            router.shutdown()
-
-        print("✅ MessageRouter Smoke Test PASSED")
-        return True
-
-    except Exception as e:
-        print(f"❌ MessageRouter Smoke Test FAILED: {e}")
-        return False
-
-
-def main():
-    """CLI interface for MessageRouter testing"""
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Message Router CLI")
-    parser.add_argument("--test", action="store_true", help="Run smoke test")
-    parser.add_argument(
-        "--send",
-        nargs=4,
-        metavar=("SENDER", "RECIPIENT", "TYPE", "CONTENT"),
-        help="Send message",
-    )
-    parser.add_argument(
-        "--broadcast",
-        nargs=3,
-        metavar=("SENDER", "TYPE", "CONTENT"),
-        help="Broadcast message",
-    )
-    parser.add_argument("--status", help="Get message status by ID")
-    parser.add_argument("--pending", help="Get pending messages for agent")
-    parser.add_argument("--stats", action="store_true", help="Show routing statistics")
-
-    args = parser.parse_args()
-
-    if args.test:
-        run_smoke_test()
-        return
-
-    router = MessageRouter()
-
-    if args.send:
-        sender, recipient, msg_type, content = args.send
-        try:
-            message_type = MessageType(msg_type)
-            message_id = router.send_message(
-                sender, recipient, message_type, {"data": content}
-            )
-            print(f"Message sent: {'✅ Success' if message_id else '❌ Failed'}")
-            if message_id:
-                print(f"Message ID: {message_id}")
-        except ValueError:
-            print(f"❌ Invalid message type: {msg_type}")
-            print(f"Valid types: {[t.value for t in MessageType]}")
-    elif args.broadcast:
-        sender, msg_type, content = args.broadcast
-        try:
-            message_type = MessageType(msg_type)
-            message_ids = router.broadcast_message(
-                sender, message_type, {"data": content}
-            )
-            print(f"Broadcast sent: {'✅ Success' if message_ids else '❌ Failed'}")
-            print(f"Messages sent: {len(message_ids)}")
-        except ValueError:
-            print(f"❌ Invalid message type: {msg_type}")
-            print(f"Valid types: {[t.value for t in MessageType]}")
-    elif args.status:
-        status = router.get_message_status(args.status)
-        if status:
-            print(f"Message status: {status.value}")
-        else:
-            print(f"Message '{args.status}' not found")
-    elif args.pending:
-        pending = router.get_pending_messages(args.pending)
-        print(f"Pending messages for {args.pending}:")
-        for msg in pending:
-            print(f"  {msg.message_id}: {msg.message_type.value} from {msg.sender_id}")
-    elif args.stats:
-        stats = router.get_routing_stats()
-        print("Routing Statistics:")
-        for key, value in stats.items():
-            print(f"  {key}: {value}")
-    else:
-        parser.print_help()
-
-    router.shutdown()
-
-
-if __name__ == "__main__":
-    main()
+__all__ = [
+    "MessageRouter",
+    "Message",
+    "RoutingRule",
+    "MessagePriority",
+    "MessageStatus",
+    "MessageType",
+]

--- a/src/core/message_transformer.py
+++ b/src/core/message_transformer.py
@@ -1,0 +1,25 @@
+"""Utilities for transforming messages to and from storage representations."""
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Dict, Any
+
+from .routing_models import Message
+
+
+class MessageTransformer:
+    """Handle persistence of :class:`~core.routing_models.Message` objects."""
+
+    def to_dict(self, message: Message) -> Dict[str, Any]:
+        data = asdict(message)
+        data["message_type"] = message.message_type.value
+        data["priority"] = message.priority.value
+        data["status"] = message.status.value
+        return data
+
+    def save(self, message: Message, directory: Path) -> None:
+        directory.mkdir(exist_ok=True)
+        message_file = directory / f"{message.message_id}.json"
+        with open(message_file, "w") as f:
+            json.dump(self.to_dict(message), f, indent=2, default=str)

--- a/src/core/message_validator.py
+++ b/src/core/message_validator.py
@@ -1,0 +1,27 @@
+"""Validation helpers for routed messages."""
+
+from datetime import datetime
+
+from .routing_models import Message
+from .shared_enums import MessagePriority
+
+
+class MessageValidator:
+    """Validate message metadata and priorities."""
+
+    def is_expired(self, message: Message) -> bool:
+        if message.expires_at is None:
+            return False
+        try:
+            return datetime.now() > datetime.fromisoformat(message.expires_at)
+        except Exception:
+            return False
+
+    def priority_value(self, priority: MessagePriority) -> int:
+        priority_map = {
+            MessagePriority.LOW: 1000,
+            MessagePriority.NORMAL: 500,
+            MessagePriority.HIGH: 100,
+            MessagePriority.URGENT: 0,
+        }
+        return priority_map.get(priority, 500)

--- a/src/core/routing_core.py
+++ b/src/core/routing_core.py
@@ -1,0 +1,242 @@
+"""Core message routing logic separated from orchestration layer."""
+
+import logging
+import queue
+import threading
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional, Any, Callable
+
+from .shared_enums import MessagePriority, MessageStatus, MessageType
+from .routing_models import Message
+from .routing_table import RoutingTable
+from .strategy_factory import StrategyFactory
+from .message_transformer import MessageTransformer
+from .message_validator import MessageValidator
+
+
+class RoutingCore:
+    """Implements message queueing and delivery."""
+
+    def __init__(self, messages_dir: str) -> None:
+        self.messages_dir = Path(messages_dir)
+        self.message_queue: queue.PriorityQueue = queue.PriorityQueue()
+        self.delivery_callbacks: Dict[str, Callable[[Message], bool]] = {}
+        self.message_history: Dict[str, Message] = {}
+        self.logger = logging.getLogger(f"{__name__}.RoutingCore")
+        self.routing_table = RoutingTable()
+        self.transformer = MessageTransformer()
+        self.validator = MessageValidator()
+        self.strategy_factory = StrategyFactory(self._default_delivery)
+        self.running = False
+        self.routing_thread: Optional[threading.Thread] = None
+        self._start_routing_thread()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def send_message(
+        self,
+        sender_id: str,
+        recipient_id: str,
+        message_type: MessageType,
+        content: Dict[str, Any],
+        priority: MessagePriority = MessagePriority.NORMAL,
+        expires_in: Optional[int] = None,
+    ) -> str:
+        """Queue a message for delivery."""
+        try:
+            message_id = f"{sender_id}_{recipient_id}_{int(time.time())}"
+            expires_at = None
+            if expires_in:
+                expires_at = (
+                    datetime.now() + timedelta(seconds=expires_in)
+                ).isoformat()
+
+            message = Message(
+                message_id=message_id,
+                sender_id=sender_id,
+                recipient_id=recipient_id,
+                message_type=message_type,
+                priority=priority,
+                content=content,
+                timestamp=datetime.now().isoformat(),
+                expires_at=expires_at,
+                status=MessageStatus.PENDING,
+            )
+
+            priority_value = self.validator.priority_value(priority)
+            # Include timestamp to avoid comparisons between Message objects
+            self.message_queue.put((priority_value, time.time(), message))
+            self.message_history[message_id] = message
+            self.transformer.save(message, self.messages_dir)
+            self.logger.info("Message %s queued for delivery", message_id)
+            return message_id
+        except Exception as e:  # pragma: no cover - unlikely in tests
+            self.logger.error("Failed to send message: %s", e)
+            return ""
+
+    def broadcast_message(
+        self,
+        sender_id: str,
+        message_type: MessageType,
+        content: Dict[str, Any],
+        priority: MessagePriority = MessagePriority.NORMAL,
+        target_agents: Optional[List[str]] = None,
+    ) -> List[str]:
+        """Broadcast a message to multiple agents."""
+        message_ids: List[str] = []
+        try:
+            if target_agents is None:
+                target_agents = self._get_all_agent_ids()
+            for recipient_id in target_agents:
+                if recipient_id != sender_id:
+                    mid = self.send_message(
+                        sender_id, recipient_id, message_type, content, priority
+                    )
+                    if mid:
+                        message_ids.append(mid)
+            self.logger.info("Broadcast message sent to %d agents", len(message_ids))
+        except Exception as e:  # pragma: no cover
+            self.logger.error("Failed to broadcast message: %s", e)
+        return message_ids
+
+    def register_delivery_callback(self, message_type: MessageType, callback: Callable):
+        self.delivery_callbacks[message_type.value] = callback
+
+    def get_message_status(self, message_id: str) -> Optional[MessageStatus]:
+        if message_id in self.message_history:
+            return self.message_history[message_id].status
+        return None
+
+    def get_pending_messages(self, recipient_id: str) -> List[Message]:
+        pending = [
+            m
+            for m in self.message_history.values()
+            if m.recipient_id == recipient_id
+            and m.status == MessageStatus.PENDING
+            and not self.validator.is_expired(m)
+        ]
+        pending.sort(
+            key=lambda m: (self.validator.priority_value(m.priority), m.timestamp)
+        )
+        return pending
+
+    def get_routing_stats(self) -> Dict[str, Any]:
+        total = len(self.message_history)
+        pending = len(
+            [
+                m
+                for m in self.message_history.values()
+                if m.status == MessageStatus.PENDING
+            ]
+        )
+        delivered = len(
+            [
+                m
+                for m in self.message_history.values()
+                if m.status == MessageStatus.DELIVERED
+            ]
+        )
+        failed = len(
+            [
+                m
+                for m in self.message_history.values()
+                if m.status == MessageStatus.FAILED
+            ]
+        )
+        return {
+            "total_messages": total,
+            "pending_messages": pending,
+            "delivered_messages": delivered,
+            "failed_messages": failed,
+            "queue_size": self.message_queue.qsize(),
+            "delivery_callbacks": len(self.delivery_callbacks),
+        }
+
+    def run_smoke_test(self) -> bool:  # pragma: no cover - convenience method
+        try:
+            mid = self.send_message(
+                "Agent-1",
+                "Agent-2",
+                MessageType.STATUS_UPDATE,
+                {"status": "online"},
+            )
+            if not mid:
+                return False
+            bids = self.broadcast_message(
+                "Agent-1",
+                MessageType.COORDINATION,
+                {"action": "sync"},
+            )
+            if not bids:
+                return False
+            if self.get_message_status(mid) != MessageStatus.PENDING:
+                return False
+            if not self.get_pending_messages("Agent-2"):
+                return False
+            if "total_messages" not in self.get_routing_stats():
+                return False
+            return True
+        except Exception:  # pragma: no cover
+            return False
+
+    def shutdown(self) -> None:
+        self.running = False
+        if self.routing_thread:
+            self.routing_thread.join(timeout=5)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _start_routing_thread(self) -> None:
+        self.running = True
+        self.routing_thread = threading.Thread(target=self._routing_loop, daemon=True)
+        self.routing_thread.start()
+
+    def _routing_loop(self) -> None:
+        while self.running:
+            try:
+                if not self.message_queue.empty():
+                    priority, _, message = self.message_queue.get()
+                    if self.validator.is_expired(message):
+                        message.status = MessageStatus.EXPIRED
+                        self.transformer.save(message, self.messages_dir)
+                        continue
+                    success = self._attempt_delivery(message)
+                    if success:
+                        message.status = MessageStatus.DELIVERED
+                        self.transformer.save(message, self.messages_dir)
+                    else:
+                        if message.delivery_attempts < message.max_attempts:
+                            message.delivery_attempts += 1
+                            self.message_queue.put((priority + 1000, message))
+                        else:
+                            message.status = MessageStatus.FAILED
+                            self.transformer.save(message, self.messages_dir)
+                time.sleep(0.1)
+            except Exception as e:  # pragma: no cover
+                self.logger.error("Routing loop error: %s", e)
+                time.sleep(1)
+
+    def _attempt_delivery(self, message: Message) -> bool:
+        callback_key = message.message_type.value
+        if callback_key in self.delivery_callbacks:
+            try:
+                return self.delivery_callbacks[callback_key](message)
+            except Exception:  # pragma: no cover
+                return False
+        rule = self.routing_table.get_rule(message.message_type)
+        strategy_name = rule.delivery_strategy if rule else "specific"
+        strategy = self.strategy_factory.get_strategy(strategy_name)
+        return strategy(message)
+
+    def _default_delivery(self, message: Message) -> bool:
+        self.logger.info(
+            "Message %s delivered to %s", message.message_id, message.recipient_id
+        )
+        return True
+
+    def _get_all_agent_ids(self) -> List[str]:
+        return ["Agent-1", "Agent-2", "Agent-3", "Agent-4", "Agent-5"]

--- a/src/core/routing_models.py
+++ b/src/core/routing_models.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Dict, List, Any, Optional
+
+from .shared_enums import MessagePriority, MessageStatus, MessageType
+
+
+@dataclass
+class Message:
+    """Data structure representing a routed message."""
+
+    message_id: str
+    sender_id: str
+    recipient_id: str
+    message_type: MessageType
+    priority: MessagePriority
+    content: Dict[str, Any]
+    timestamp: str
+    expires_at: Optional[str]
+    status: MessageStatus = MessageStatus.PENDING
+    delivery_attempts: int = 0
+    max_attempts: int = 3
+
+
+@dataclass
+class RoutingRule:
+    """Rule describing how a message type should be delivered."""
+
+    message_type: MessageType
+    priority: MessagePriority
+    target_agents: List[str]
+    delivery_strategy: str
+    retry_policy: Dict[str, Any]

--- a/src/core/routing_table.py
+++ b/src/core/routing_table.py
@@ -1,0 +1,69 @@
+"""Routing table management for message routing."""
+
+from typing import Dict, Optional
+
+from .routing_models import RoutingRule
+from .shared_enums import MessageType, MessagePriority
+
+
+class RoutingTable:
+    """Store and manage routing rules."""
+
+    def __init__(self) -> None:
+        self.rules: Dict[MessageType, RoutingRule] = {}
+        self.initialize_default_rules()
+
+    def initialize_default_rules(self) -> None:
+        """Populate the table with default routing rules."""
+        self.rules = {
+            MessageType.CONTRACT_ASSIGNMENT: RoutingRule(
+                message_type=MessageType.CONTRACT_ASSIGNMENT,
+                priority=MessagePriority.HIGH,
+                target_agents=[],
+                delivery_strategy="specific",
+                retry_policy={"max_attempts": 3, "retry_delay": 5},
+            ),
+            MessageType.STATUS_UPDATE: RoutingRule(
+                message_type=MessageType.STATUS_UPDATE,
+                priority=MessagePriority.NORMAL,
+                target_agents=[],
+                delivery_strategy="broadcast",
+                retry_policy={"max_attempts": 1, "retry_delay": 0},
+            ),
+            MessageType.COORDINATION: RoutingRule(
+                message_type=MessageType.COORDINATION,
+                priority=MessagePriority.NORMAL,
+                target_agents=[],
+                delivery_strategy="broadcast",
+                retry_policy={"max_attempts": 2, "retry_delay": 10},
+            ),
+            MessageType.EMERGENCY: RoutingRule(
+                message_type=MessageType.EMERGENCY,
+                priority=MessagePriority.URGENT,
+                target_agents=[],
+                delivery_strategy="broadcast",
+                retry_policy={"max_attempts": 5, "retry_delay": 1},
+            ),
+            MessageType.HEARTBEAT: RoutingRule(
+                message_type=MessageType.HEARTBEAT,
+                priority=MessagePriority.LOW,
+                target_agents=[],
+                delivery_strategy="broadcast",
+                retry_policy={"max_attempts": 1, "retry_delay": 0},
+            ),
+            MessageType.SYSTEM_COMMAND: RoutingRule(
+                message_type=MessageType.SYSTEM_COMMAND,
+                priority=MessagePriority.HIGH,
+                target_agents=[],
+                delivery_strategy="specific",
+                retry_policy={"max_attempts": 3, "retry_delay": 5},
+            ),
+        }
+
+    def get_rule(self, message_type: MessageType) -> Optional[RoutingRule]:
+        """Retrieve routing rule for a given message type."""
+        return self.rules.get(message_type)
+
+    def set_rule(self, message_type: MessageType, rule: RoutingRule) -> None:
+        """Update or add a routing rule."""
+        self.rules[message_type] = rule

--- a/src/core/shared_enums.py
+++ b/src/core/shared_enums.py
@@ -1,0 +1,26 @@
+"""Shared enums used by the lightweight message router."""
+
+from enum import Enum
+
+
+class MessageType(Enum):
+    CONTRACT_ASSIGNMENT = "contract_assignment"
+    STATUS_UPDATE = "status_update"
+    COORDINATION = "coordination"
+    EMERGENCY = "emergency"
+    HEARTBEAT = "heartbeat"
+    SYSTEM_COMMAND = "system_command"
+
+
+class MessagePriority(Enum):
+    LOW = "low"
+    NORMAL = "normal"
+    HIGH = "high"
+    URGENT = "urgent"
+
+
+class MessageStatus(Enum):
+    PENDING = "pending"
+    DELIVERED = "delivered"
+    FAILED = "failed"
+    EXPIRED = "expired"

--- a/src/core/strategy_factory.py
+++ b/src/core/strategy_factory.py
@@ -1,0 +1,21 @@
+"""Factory for creating message delivery strategies."""
+
+from typing import Callable
+
+from .routing_models import Message
+
+
+class StrategyFactory:
+    """Return delivery strategy callables based on name."""
+
+    def __init__(self, default_strategy: Callable[[Message], bool]) -> None:
+        self.default_strategy = default_strategy
+
+    def get_strategy(self, name: str) -> Callable[[Message], bool]:
+        """Return a strategy implementation."""
+        strategies = {
+            "broadcast": self.default_strategy,
+            "round_robin": self.default_strategy,
+            "specific": self.default_strategy,
+        }
+        return strategies.get(name, self.default_strategy)

--- a/tests/test_message_routing_components.py
+++ b/tests/test_message_routing_components.py
@@ -1,0 +1,34 @@
+"""Tests for the refactored message routing components."""
+
+import tempfile
+import sys
+from pathlib import Path
+
+# Ensure src directory is on path
+src_path = Path(__file__).resolve().parents[1] / "src"
+if str(src_path) not in sys.path:
+    sys.path.insert(0, str(src_path))
+
+from core.message_router import (
+    MessageRouter,
+    MessageType,
+    MessagePriority,
+    MessageStatus,
+)
+
+
+def test_send_and_broadcast_messages():
+    with tempfile.TemporaryDirectory() as tmp:
+        router = MessageRouter(tmp)
+
+        msg_id = router.send_message(
+            "Agent-1", "Agent-2", MessageType.STATUS_UPDATE, {"status": "ok"}
+        )
+        assert msg_id
+        assert router.get_message_status(msg_id) == MessageStatus.PENDING
+
+        broadcast_ids = router.broadcast_message(
+            "Agent-1", MessageType.COORDINATION, {"action": "sync"}
+        )
+        assert broadcast_ids
+        router.shutdown()

--- a/tests/test_performance_integration_setup.py
+++ b/tests/test_performance_integration_setup.py
@@ -19,7 +19,7 @@ def create_env():
     """Create core components for tests."""
     tracker = PerformanceMonitor(CONFIG)
     profiler = PerformanceMonitor(CONFIG)
-    messaging = V2ComprehensiveMessagingSystem(CONFIG)
+    messaging = V2ComprehensiveMessagingSystem()
     gateway = APIGateway(CONFIG)
     dashboard = PerformanceDashboard(
         agent_manager=None,


### PR DESCRIPTION
## Summary
- extract routing models, core loop, strategy factory, validator, transformer, and routing table into dedicated modules
- simplify message_router to orchestration-only wrapper around new RoutingCore
- add regression tests for message routing components and adjust performance setup test

## Testing
- `pre-commit run --files src/core/routing_models.py src/core/routing_table.py src/core/strategy_factory.py src/core/message_validator.py src/core/message_transformer.py src/core/routing_core.py src/core/message_router.py tests/test_message_routing_components.py` *(failed: ModuleNotFoundError: No module named 'src'; duplication-detector missing script)*
- `pytest tests/test_message_routing_components.py tests/unit/test_core_system.py tests/test_cross_agent_modules.py tests/test_performance_integration_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac59f9df808329b0b8ff3035273645