### PR TITLE
Add automated refactoring extraction with import updates

### DIFF
--- a/scripts/refactoring_executor.py
+++ b/scripts/refactoring_executor.py
@@ -5,54 +5,63 @@ Refactoring Executor - Automated assistance for compliance violations refactorin
 
 import json
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 
+
 class RefactoringExecutor:
-    def __init__(self, compliance_file: str = "data/compliance_validation_results.json"):
+    def __init__(
+        self, compliance_file: str = "data/compliance_validation_results.json"
+    ):
         self.compliance_file = compliance_file
         self.violations = self._load_compliance_data()
         self.workspace_root = Path.cwd()
-        
+        self.last_extraction: Optional[Dict[str, List[str]]] = None
+
     def _load_compliance_data(self) -> Dict:
         """Load compliance validation results"""
-        with open(self.compliance_file, 'r') as f:
+        with open(self.compliance_file, "r") as f:
             return json.load(f)
-    
+
     def get_violation_summary(self) -> Dict[str, int]:
         """Get summary of current violations"""
         summary = {}
-        for category in ['critical', 'major', 'moderate', 'compliant']:
-            summary[category] = len(self.violations['violations'].get(category, []))
+        for category in ["critical", "major", "moderate", "compliant"]:
+            summary[category] = len(self.violations["violations"].get(category, []))
         return summary
-    
+
     def analyze_file_for_refactoring(self, file_path: str) -> Dict:
         """Analyze a specific file for refactoring opportunities"""
         if not os.path.exists(file_path):
             return {"error": f"File {file_path} not found"}
-        
+
         try:
-            with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+            with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                 lines = f.readlines()
-            
+
             line_count = len(lines)
-            
+
             # Basic analysis
             analysis = {
                 "file_path": file_path,
                 "line_count": line_count,
                 "violation_level": self._get_violation_level(line_count),
-                "refactoring_priority": self._get_refactoring_priority(file_path, line_count),
-                "suggested_modules": self._suggest_module_extractions(file_path, line_count),
-                "estimated_effort": self._estimate_refactoring_effort(line_count)
+                "refactoring_priority": self._get_refactoring_priority(
+                    file_path, line_count
+                ),
+                "suggested_modules": self._suggest_module_extractions(
+                    file_path, line_count
+                ),
+                "estimated_effort": self._estimate_refactoring_effort(line_count),
             }
-            
+
             return analysis
-            
+
         except Exception as e:
             return {"error": f"Error analyzing file: {e}"}
-    
+
     def _get_violation_level(self, line_count: int) -> str:
         """Determine violation level based on line count"""
         if line_count >= 800:
@@ -63,7 +72,7 @@ class RefactoringExecutor:
             return "moderate"
         else:
             return "compliant"
-    
+
     def _get_refactoring_priority(self, file_path: str, line_count: int) -> str:
         """Determine refactoring priority"""
         if line_count >= 800:
@@ -74,60 +83,70 @@ class RefactoringExecutor:
             return "medium"
         else:
             return "low"
-    
+
     def _suggest_module_extractions(self, file_path: str, line_count: int) -> List[str]:
         """Suggest modules to extract based on file path and size"""
         suggestions = []
-        
+
         if line_count < 300:
             return suggestions
-        
+
         # Core messaging system
         if "v2_comprehensive_messaging_system" in file_path:
-            suggestions.extend([
-                "src/core/messaging/router.py",
-                "src/core/messaging/validator.py", 
-                "src/core/messaging/formatter.py",
-                "src/core/messaging/storage.py"
-            ])
-        
+            suggestions.extend(
+                [
+                    "src/core/messaging/router.py",
+                    "src/core/messaging/validator.py",
+                    "src/core/messaging/formatter.py",
+                    "src/core/messaging/storage.py",
+                ]
+            )
+
         # Autonomous development
         elif "autonomous_development" in file_path:
-            suggestions.extend([
-                "src/autonomous_development/workflow/engine.py",
-                "src/autonomous_development/tasks/manager.py",
-                "src/autonomous_development/code/generator.py",
-                "src/autonomous_development/testing/orchestrator.py"
-            ])
-        
+            suggestions.extend(
+                [
+                    "src/autonomous_development/workflow/engine.py",
+                    "src/autonomous_development/tasks/manager.py",
+                    "src/autonomous_development/code/generator.py",
+                    "src/autonomous_development/testing/orchestrator.py",
+                ]
+            )
+
         # Performance validation
         elif "performance_validation_system" in file_path:
-            suggestions.extend([
-                "src/core/performance/metrics/collector.py",
-                "src/core/performance/validation/rules.py",
-                "src/core/performance/reporting/generator.py",
-                "src/core/performance/alerts/manager.py"
-            ])
-        
+            suggestions.extend(
+                [
+                    "src/core/performance/metrics/collector.py",
+                    "src/core/performance/validation/rules.py",
+                    "src/core/performance/reporting/generator.py",
+                    "src/core/performance/alerts/manager.py",
+                ]
+            )
+
         # Financial services
         elif "financial" in file_path and "options_trading" in file_path:
-            suggestions.extend([
-                "src/services/financial/options/pricing.py",
-                "src/services/financial/options/risk.py",
-                "src/services/financial/options/strategy.py",
-                "src/services/financial/options/market_data.py"
-            ])
-        
+            suggestions.extend(
+                [
+                    "src/services/financial/options/pricing.py",
+                    "src/services/financial/options/risk.py",
+                    "src/services/financial/options/strategy.py",
+                    "src/services/financial/options/market_data.py",
+                ]
+            )
+
         # Generic suggestions for large files
         elif line_count >= 500:
-            suggestions.extend([
-                f"src/extracted/{Path(file_path).stem}/core.py",
-                f"src/extracted/{Path(file_path).stem}/utils.py",
-                f"src/extracted/{Path(file_path).stem}/models.py"
-            ])
-        
+            suggestions.extend(
+                [
+                    f"src/extracted/{Path(file_path).stem}/core.py",
+                    f"src/extracted/{Path(file_path).stem}/utils.py",
+                    f"src/extracted/{Path(file_path).stem}/models.py",
+                ]
+            )
+
         return suggestions
-    
+
     def _estimate_refactoring_effort(self, line_count: int) -> str:
         """Estimate refactoring effort"""
         if line_count >= 800:
@@ -138,14 +157,14 @@ class RefactoringExecutor:
             return "4-8 hours"
         else:
             return "1-2 hours"
-    
+
     def create_refactoring_plan(self, target_file: str) -> Dict:
         """Create a detailed refactoring plan for a specific file"""
         analysis = self.analyze_file_for_refactoring(target_file)
-        
+
         if "error" in analysis:
             return analysis
-        
+
         plan = {
             "file_analysis": analysis,
             "refactoring_steps": [
@@ -153,57 +172,57 @@ class RefactoringExecutor:
                     "step": 1,
                     "action": "Create extraction directory structure",
                     "details": f"Create directories for: {', '.join(analysis['suggested_modules'])}",
-                    "estimated_time": "30 minutes"
+                    "estimated_time": "30 minutes",
                 },
                 {
                     "step": 2,
                     "action": "Extract core functionality",
                     "details": "Move main classes and functions to new modules",
-                    "estimated_time": analysis['estimated_effort']
+                    "estimated_time": analysis["estimated_effort"],
                 },
                 {
                     "step": 3,
                     "action": "Update imports and references",
                     "details": "Fix all import statements and references",
-                    "estimated_time": "2-4 hours"
+                    "estimated_time": "2-4 hours",
                 },
                 {
                     "step": 4,
                     "action": "Update tests",
                     "details": "Move and update test files for new modules",
-                    "estimated_time": "2-3 hours"
+                    "estimated_time": "2-3 hours",
                 },
                 {
                     "step": 5,
                     "action": "Validate refactoring",
                     "details": "Run tests and compliance check",
-                    "estimated_time": "1 hour"
-                }
+                    "estimated_time": "1 hour",
+                },
             ],
             "success_criteria": [
                 f"File size reduced from {analysis['line_count']} to <300 lines",
                 "All functionality preserved",
                 "Tests pass",
-                "No new compliance violations introduced"
-            ]
+                "No new compliance violations introduced",
+            ],
         }
-        
+
         return plan
-    
+
     def generate_directory_structure(self, target_file: str) -> List[str]:
         """Generate the directory structure needed for refactoring"""
         analysis = self.analyze_file_for_refactoring(target_file)
-        
+
         if "error" in analysis:
             return []
-        
+
         directories = set()
-        for module_path in analysis['suggested_modules']:
+        for module_path in analysis["suggested_modules"]:
             dir_path = str(Path(module_path).parent)
             directories.add(dir_path)
-        
+
         return sorted(list(directories))
-    
+
     def create_extraction_template(self, target_file: str, module_name: str) -> str:
         """Create a template for an extracted module"""
         template = f'''"""
@@ -217,24 +236,23 @@ Extraction date: {__import__('datetime').datetime.now().strftime('%Y-%m-%d')}
 """
 
 from typing import Any, Dict, List, Optional
+import logging
 
-# TODO: Import necessary dependencies
-# TODO: Move relevant classes and functions here
-# TODO: Update imports in original file
+logger = logging.getLogger(__name__)
 
 class {Path(module_name).stem.title().replace('_', '')}:
     """Extracted functionality from {target_file}"""
-    
+
     def __init__(self):
         """Initialize the extracted component"""
         pass
-    
-    # TODO: Add extracted methods and properties
 
-# TODO: Add any standalone functions that were extracted
+    # Implement extracted methods and properties here
+
+# Additional standalone functions can be added below
 '''
         return template
-    
+
     def execute_refactoring_step(self, target_file: str, step: int) -> Dict:
         """Execute a specific refactoring step"""
         if step == 1:
@@ -249,76 +267,164 @@ class {Path(module_name).stem.title().replace('_', '')}:
             return self._validate_refactoring(target_file)
         else:
             return {"error": f"Unknown step: {step}"}
-    
+
     def _create_extraction_directories(self, target_file: str) -> Dict:
         """Create the directory structure for extracted modules"""
         directories = self.generate_directory_structure(target_file)
         created = []
-        
+
         for directory in directories:
             try:
                 Path(directory).mkdir(parents=True, exist_ok=True)
                 created.append(directory)
             except Exception as e:
                 return {"error": f"Failed to create directory {directory}: {e}"}
-        
+
         return {
             "success": True,
             "message": f"Created {len(created)} directories",
-            "directories": created
+            "directories": created,
         }
-    
+
     def _extract_core_functionality(self, target_file: str) -> Dict:
-        """Extract core functionality to new modules"""
-        # This is a placeholder - actual extraction would require
-        # detailed analysis of the file content
-        return {
-            "success": True,
-            "message": "Core functionality extraction completed",
-            "note": "This step requires manual code analysis and movement"
-        }
-    
+        """Extract top-level classes and functions to a new module"""
+        analysis = self.analyze_file_for_refactoring(target_file)
+        if "error" in analysis:
+            return analysis
+        module_path = (
+            analysis["suggested_modules"][0]
+            if analysis["suggested_modules"]
+            else str(
+                Path(target_file).with_name(f"{Path(target_file).stem}_extracted.py")
+            )
+        )
+        return self._perform_extraction(target_file, module_path)
+
+    def _perform_extraction(self, target_file: str, module_path: str) -> Dict:
+        """Move top-level classes and functions into a separate module"""
+        try:
+            with open(target_file, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+
+            pattern = re.compile(r"^(class|def)\s+(\w+)")
+            extracted: List[str] = []
+            remaining: List[str] = []
+            names: List[str] = []
+            capturing = False
+            indent = 0
+            buffer: List[str] = []
+
+            for line in lines:
+                match = pattern.match(line)
+                if match and not capturing:
+                    capturing = True
+                    indent = len(line) - len(line.lstrip())
+                    names.append(match.group(2))
+                    buffer.append(line)
+                    continue
+                if capturing:
+                    curr = len(line) - len(line.lstrip())
+                    if line.strip() and curr > indent:
+                        buffer.append(line)
+                    else:
+                        extracted.append("".join(buffer))
+                        buffer = []
+                        capturing = False
+                        remaining.append(line)
+                else:
+                    remaining.append(line)
+
+            if buffer:
+                extracted.append("".join(buffer))
+
+            mod_path = Path(module_path)
+            mod_path.parent.mkdir(parents=True, exist_ok=True)
+            if not mod_path.exists():
+                mod_path.write_text(
+                    self.create_extraction_template(target_file, module_path)
+                )
+
+            with mod_path.open("a", encoding="utf-8") as mf:
+                mf.write("\n".join(extracted))
+
+            Path(target_file).write_text("".join(remaining), encoding="utf-8")
+
+            self.last_extraction = {"module": module_path, "names": names}
+            update_info = self._update_imports_and_references(target_file)
+            return {
+                "success": True,
+                "module": module_path,
+                "names": names,
+                "imports_updated": update_info.get("success", False),
+            }
+        except Exception as e:
+            return {"error": f"Extraction failed: {e}"}
+
     def _update_imports_and_references(self, target_file: str) -> Dict:
-        """Update imports and references after extraction"""
-        return {
-            "success": True,
-            "message": "Import updates completed",
-            "note": "This step requires manual import statement updates"
-        }
-    
+        """Update import statements after extraction"""
+        if not self.last_extraction:
+            return {"error": "No extraction metadata available"}
+        module_path = self.last_extraction.get("module")
+        names = self.last_extraction.get("names", [])
+        try:
+            rel_module = os.path.splitext(
+                os.path.relpath(module_path, Path(target_file).parent)
+            )[0].replace(os.sep, ".")
+            with open(target_file, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+            import_line = f"from {rel_module} import {', '.join(names)}\n"
+            insert_at = 0
+            for idx, line in enumerate(lines):
+                if line.startswith("from ") or line.startswith("import "):
+                    insert_at = idx + 1
+            lines.insert(insert_at, import_line)
+            with open(target_file, "w", encoding="utf-8") as f:
+                f.writelines(lines)
+            return {
+                "success": True,
+                "message": f"Updated imports in {target_file}",
+                "module": rel_module,
+                "members": names,
+            }
+        except Exception as e:
+            return {"error": f"Failed to update imports: {e}"}
+
     def _update_tests(self, target_file: str) -> Dict:
         """Update test files for extracted modules"""
         return {
             "success": True,
             "message": "Test updates completed",
-            "note": "This step requires manual test file updates"
+            "note": "This step requires manual test file updates",
         }
-    
+
     def _validate_refactoring(self, target_file: str) -> Dict:
         """Validate the refactoring was successful"""
         return {
             "success": True,
             "message": "Refactoring validation completed",
-            "note": "Run compliance check and tests to verify"
+            "note": "Run compliance check and tests to verify",
         }
+
 
 def main():
     """Main execution function"""
     executor = RefactoringExecutor()
-    
+
     print("=== Compliance Violations Refactoring Executor ===\n")
-    
+
     # Show current violation summary
     summary = executor.get_violation_summary()
     print("Current Violation Summary:")
     for category, count in summary.items():
         print(f"  {category.title()}: {count}")
-    
-    print(f"\nTotal files to refactor: {summary['critical'] + summary['major'] + summary['moderate']}")
-    
+
+    print(
+        f"\nTotal files to refactor: {summary['critical'] + summary['major'] + summary['moderate']}"
+    )
+
     # Interactive mode
     while True:
-        print("\n" + "="*50)
+        print("\n" + "=" * 50)
         print("Options:")
         print("1. Analyze specific file")
         print("2. Create refactoring plan")
@@ -326,16 +432,16 @@ def main():
         print("4. Create extraction template")
         print("5. Execute refactoring step")
         print("6. Exit")
-        
+
         choice = input("\nEnter your choice (1-6): ").strip()
-        
+
         if choice == "1":
             file_path = input("Enter file path to analyze: ").strip()
             analysis = executor.analyze_file_for_refactoring(file_path)
             print("\nFile Analysis:")
             for key, value in analysis.items():
                 print(f"  {key}: {value}")
-        
+
         elif choice == "2":
             file_path = input("Enter file path for refactoring plan: ").strip()
             plan = executor.create_refactoring_plan(file_path)
@@ -344,24 +450,28 @@ def main():
                 if key == "refactoring_steps":
                     print(f"  {key}:")
                     for step in value:
-                        print(f"    Step {step['step']}: {step['action']} ({step['estimated_time']})")
+                        print(
+                            f"    Step {step['step']}: {step['action']} ({step['estimated_time']})"
+                        )
                 else:
                     print(f"  {key}: {value}")
-        
+
         elif choice == "3":
             file_path = input("Enter file path for directory structure: ").strip()
             directories = executor.generate_directory_structure(file_path)
             print("\nRequired Directory Structure:")
             for directory in directories:
                 print(f"  {directory}")
-        
+
         elif choice == "4":
             file_path = input("Enter target file path: ").strip()
-            module_name = input("Enter module name (e.g., src/core/messaging/router.py): ").strip()
+            module_name = input(
+                "Enter module name (e.g., src/core/messaging/router.py): "
+            ).strip()
             template = executor.create_extraction_template(file_path, module_name)
             print("\nExtraction Template:")
             print(template)
-        
+
         elif choice == "5":
             file_path = input("Enter target file path: ").strip()
             step = int(input("Enter step number (1-5): ").strip())
@@ -369,13 +479,14 @@ def main():
             print("\nStep Execution Result:")
             for key, value in result.items():
                 print(f"  {key}: {value}")
-        
+
         elif choice == "6":
             print("Exiting...")
             break
-        
+
         else:
             print("Invalid choice. Please try again.")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_refactoring_executor_workflow.py
+++ b/tests/test_refactoring_executor_workflow.py
@@ -1,0 +1,28 @@
+import json
+import os
+from pathlib import Path
+
+from scripts.refactoring_executor import RefactoringExecutor
+
+
+def test_extraction_and_import(tmp_path):
+    compliance_file = tmp_path / "compliance.json"
+    compliance_file.write_text(json.dumps({"violations": {}}))
+
+    target_file = tmp_path / "sample.py"
+    target_file.write_text("class Demo:\n    pass\n\n" "def helper():\n    return 1\n")
+
+    os.chdir(tmp_path)
+    executor = RefactoringExecutor(str(compliance_file))
+
+    result = executor._extract_core_functionality(str(target_file))
+    assert result["success"]
+
+    module_path = tmp_path / "sample_extracted.py"
+    assert module_path.exists()
+    module_content = module_path.read_text()
+    assert "class Demo" in module_content
+
+    updated_content = target_file.read_text()
+    assert "class Demo" not in updated_content
+    assert "from sample_extracted import Demo" in updated_content


### PR DESCRIPTION
## Summary
- add logging and scaffold to generated extraction modules
- move top-level definitions into generated modules and update imports automatically
- add test demonstrating extraction workflow

## Testing
- `pre-commit run --files scripts/refactoring_executor.py tests/test_refactoring_executor_workflow.py` *(fails: ModuleNotFoundError: No module named 'src'; duplication-detector missing)*
- `pytest tests/test_refactoring_executor_workflow.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac5a1edec48329ba0f29b6d046c34b