### PR TITLE
refactor: split validation modules for srp

### DIFF
--- a/src/core/validation/README.md
+++ b/src/core/validation/README.md
@@ -101,7 +101,8 @@ from src.core.validation import ValidationSeverity
 
 ## 📊 Validation Results
 
-Each validation returns a `ValidationResult` object with:
+All validator `validate` methods return a list of `ValidationResult` objects.
+Each `ValidationResult` includes:
 
 - **Status**: PASSED, FAILED, or WARNING
 - **Rule Name**: Name of the validation rule
@@ -185,7 +186,7 @@ class CustomValidator(BaseValidator):
     def __init__(self):
         super().__init__("custom")
         self.add_rule("custom_rule", self.validate_custom_rule)
-    
+
     def validate_custom_rule(self, data):
         # Custom validation logic
         if some_condition:

--- a/src/core/validation/__init__.py
+++ b/src/core/validation/__init__.py
@@ -11,7 +11,13 @@ Components:
 - Specialized validators for different domains
 """
 
-from .base_validator import BaseValidator, ValidationResult, ValidationRule, ValidationSeverity, ValidationStatus
+from .base_validator import BaseValidator
+from .models import (
+    ValidationResult,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+)
 from .contract_validator import ContractValidator
 from .config_validator import ConfigValidator
 # WorkflowValidator removed during workflow unification cleanup

--- a/src/core/validation/code_validator.py
+++ b/src/core/validation/code_validator.py
@@ -8,12 +8,18 @@ and following the unified validation framework patterns.
 import ast
 import re
 from typing import Dict, List, Any, Optional
-from .base_validator import BaseValidator, ValidationRule, ValidationSeverity, ValidationStatus, ValidationResult
+from .base_validator import (
+    BaseValidator,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+    ValidationResult,
+)
 
 
 class CodeValidator(BaseValidator):
     """Validates code structure, syntax, and quality using unified validation framework"""
-    
+
     def __init__(self):
         """Initialize code validator"""
         super().__init__("CodeValidator")
@@ -23,16 +29,45 @@ class CodeValidator(BaseValidator):
             "max_class_length": 500,
             "max_file_length": 400,
             "max_parameters": 7,
-            "max_nesting_depth": 4
+            "max_nesting_depth": 4,
         }
-        
+
         self.python_keywords = [
-            'False', 'None', 'True', 'and', 'as', 'assert', 'break', 'class', 'continue',
-            'def', 'del', 'elif', 'else', 'except', 'finally', 'for', 'from', 'global',
-            'if', 'import', 'in', 'is', 'lambda', 'nonlocal', 'not', 'or', 'pass',
-            'raise', 'return', 'try', 'while', 'with', 'yield'
+            "False",
+            "None",
+            "True",
+            "and",
+            "as",
+            "assert",
+            "break",
+            "class",
+            "continue",
+            "def",
+            "del",
+            "elif",
+            "else",
+            "except",
+            "finally",
+            "for",
+            "from",
+            "global",
+            "if",
+            "import",
+            "in",
+            "is",
+            "lambda",
+            "nonlocal",
+            "not",
+            "or",
+            "pass",
+            "raise",
+            "return",
+            "try",
+            "while",
+            "with",
+            "yield",
         ]
-    
+
     def _setup_default_rules(self) -> None:
         """Setup default code validation rules"""
         default_rules = [
@@ -41,68 +76,77 @@ class CodeValidator(BaseValidator):
                 rule_name="Code Structure",
                 rule_type="code",
                 description="Validate code structure and syntax",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="code_quality_validation",
                 rule_name="Code Quality Validation",
                 rule_type="code",
                 description="Validate code quality and standards",
-                severity=ValidationSeverity.WARNING
+                severity=ValidationSeverity.WARNING,
             ),
             ValidationRule(
                 rule_id="naming_convention_validation",
                 rule_name="Naming Convention Validation",
                 rule_type="code",
                 description="Validate naming conventions and standards",
-                severity=ValidationSeverity.WARNING
+                severity=ValidationSeverity.WARNING,
             ),
             ValidationRule(
                 rule_id="complexity_validation",
                 rule_name="Complexity Validation",
                 rule_type="code",
                 description="Validate code complexity and maintainability",
-                severity=ValidationSeverity.WARNING
-            )
+                severity=ValidationSeverity.WARNING,
+            ),
         ]
-        
+
         for rule in default_rules:
             self.add_validation_rule(rule)
-    
+
     def validate(self, code_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
-        """Validate code data and return validation results"""
+        """Validate code data and return validation results.
+
+        Returns:
+            List[ValidationResult]: Validation results produced during code
+            validation.
+        """
         results = []
-        
+
         try:
             # Validate code data structure
             structure_results = self._validate_code_structure(code_data)
             results.extend(structure_results)
-            
+
             # Validate required fields
             required_fields = ["file_path", "content", "language"]
             field_results = self._validate_required_fields(code_data, required_fields)
             results.extend(field_results)
-            
+
             # Validate code content if present
             if "content" in code_data:
-                content_results = self._validate_code_content(code_data["content"], code_data.get("language"))
+                content_results = self._validate_code_content(
+                    code_data["content"], code_data.get("language")
+                )
                 results.extend(content_results)
-            
+
             # Validate code metrics if present
             if "metrics" in code_data:
                 metrics_results = self._validate_code_metrics(code_data["metrics"])
                 results.extend(metrics_results)
-            
+
             # Validate naming conventions if present
             if "naming" in code_data:
                 naming_results = self._validate_naming_conventions(code_data["naming"])
                 results.extend(naming_results)
-            
+
             # Validate complexity if present
             if "complexity" in code_data:
-                complexity_results = self._validate_code_complexity(code_data["complexity"])
+                complexity_results = self._validate_code_complexity(
+                    code_data["complexity"]
+                )
                 results.extend(complexity_results)
-            
+
             # Add overall success result if no critical errors
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
                 success_result = self._create_result(
@@ -111,10 +155,10 @@ class CodeValidator(BaseValidator):
                     status=ValidationStatus.PASSED,
                     severity=ValidationSeverity.INFO,
                     message="Code validation passed successfully",
-                    details={"total_checks": len(results)}
+                    details={"total_checks": len(results)},
                 )
                 results.append(success_result)
-            
+
         except Exception as e:
             error_result = self._create_result(
                 rule_id="code_validation_error",
@@ -122,16 +166,18 @@ class CodeValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.CRITICAL,
                 message=f"Code validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
+                details={"error_type": type(e).__name__},
             )
             results.append(error_result)
-        
+
         return results
-    
-    def _validate_code_structure(self, code_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_code_structure(
+        self, code_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate code data structure and format"""
         results = []
-        
+
         if not isinstance(code_data, dict):
             result = self._create_result(
                 rule_id="code_type",
@@ -140,11 +186,11 @@ class CodeValidator(BaseValidator):
                 severity=ValidationSeverity.ERROR,
                 message="Code data must be a dictionary",
                 actual_value=type(code_data).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         if len(code_data) == 0:
             result = self._create_result(
                 rule_id="code_empty",
@@ -153,16 +199,18 @@ class CodeValidator(BaseValidator):
                 severity=ValidationSeverity.WARNING,
                 message="Code data is empty",
                 actual_value=code_data,
-                expected_value="non-empty code data"
+                expected_value="non-empty code data",
             )
             results.append(result)
-        
+
         return results
-    
-    def _validate_code_content(self, content: Any, language: str = None) -> List[ValidationResult]:
+
+    def _validate_code_content(
+        self, content: Any, language: str = None
+    ) -> List[ValidationResult]:
         """Validate code content"""
         results = []
-        
+
         if not isinstance(content, str):
             result = self._create_result(
                 rule_id="content_type",
@@ -172,11 +220,11 @@ class CodeValidator(BaseValidator):
                 message="Code content must be a string",
                 field_path="content",
                 actual_value=type(content).__name__,
-                expected_value="str"
+                expected_value="str",
             )
             results.append(result)
             return results
-        
+
         if len(content) == 0:
             result = self._create_result(
                 rule_id="content_empty",
@@ -186,46 +234,46 @@ class CodeValidator(BaseValidator):
                 message="Code content is empty",
                 field_path="content",
                 actual_value=content,
-                expected_value="non-empty code content"
+                expected_value="non-empty code content",
             )
             results.append(result)
             return results
-        
+
         # Validate Python code if language is Python
         if language and language.lower() in ["python", "py"]:
             python_results = self._validate_python_code(content)
             results.extend(python_results)
-        
+
         # Validate line length
         line_length_results = self._validate_line_lengths(content)
         results.extend(line_length_results)
-        
+
         return results
-    
+
     def _validate_python_code(self, content: str) -> List[ValidationResult]:
         """Validate Python code syntax and structure"""
         results = []
-        
+
         try:
             # Parse Python code
             tree = ast.parse(content)
-            
+
             # Validate imports
             import_results = self._validate_python_imports(tree)
             results.extend(import_results)
-            
+
             # Validate functions
             function_results = self._validate_python_functions(tree)
             results.extend(function_results)
-            
+
             # Validate classes
             class_results = self._validate_python_classes(tree)
             results.extend(class_results)
-            
+
             # Validate naming conventions
             naming_results = self._validate_python_naming(tree)
             results.extend(naming_results)
-            
+
         except SyntaxError as e:
             result = self._create_result(
                 rule_id="python_syntax_error",
@@ -235,7 +283,7 @@ class CodeValidator(BaseValidator):
                 message=f"Python syntax error: {str(e)}",
                 field_path="content",
                 actual_value=f"line {e.lineno}: {e.text}",
-                expected_value="valid Python syntax"
+                expected_value="valid Python syntax",
             )
             results.append(result)
         except Exception as e:
@@ -247,16 +295,16 @@ class CodeValidator(BaseValidator):
                 message=f"Python parsing error: {str(e)}",
                 field_path="content",
                 actual_value=str(e),
-                expected_value="parseable Python code"
+                expected_value="parseable Python code",
             )
             results.append(result)
-        
+
         return results
-    
+
     def _validate_python_imports(self, tree: ast.AST) -> List[ValidationResult]:
         """Validate Python imports"""
         results = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 # Check import names
@@ -270,10 +318,10 @@ class CodeValidator(BaseValidator):
                             message=f"Import name '{alias.name}' conflicts with Python keyword",
                             field_path="imports",
                             actual_value=alias.name,
-                            expected_value="non-keyword import name"
+                            expected_value="non-keyword import name",
                         )
                         results.append(result)
-            
+
             elif isinstance(node, ast.ImportFrom):
                 # Check from imports
                 if node.module in self.python_keywords:
@@ -285,20 +333,20 @@ class CodeValidator(BaseValidator):
                         message=f"From import module '{node.module}' conflicts with Python keyword",
                         field_path="imports",
                         actual_value=node.module,
-                        expected_value="non-keyword module name"
+                        expected_value="non-keyword module name",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def _validate_python_functions(self, tree: ast.AST) -> List[ValidationResult]:
         """Validate Python functions"""
         results = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.FunctionDef):
                 # Check function name
-                if not re.match(r'^[a-z_][a-z0-9_]*$', node.name):
+                if not re.match(r"^[a-z_][a-z0-9_]*$", node.name):
                     result = self._create_result(
                         rule_id="function_naming_convention",
                         rule_name="Function Naming Convention",
@@ -307,12 +355,12 @@ class CodeValidator(BaseValidator):
                         message=f"Function name '{node.name}' should follow snake_case convention",
                         field_path="functions",
                         actual_value=node.name,
-                        expected_value="snake_case naming"
+                        expected_value="snake_case naming",
                     )
                     results.append(result)
-                
+
                 # Check function length
-                if hasattr(node, 'end_lineno') and hasattr(node, 'lineno'):
+                if hasattr(node, "end_lineno") and hasattr(node, "lineno"):
                     function_length = node.end_lineno - node.lineno + 1
                     if function_length > self.code_standards["max_function_length"]:
                         result = self._create_result(
@@ -323,10 +371,10 @@ class CodeValidator(BaseValidator):
                             message=f"Function '{node.name}' is {function_length} lines long",
                             field_path="functions",
                             actual_value=function_length,
-                            expected_value=f"<= {self.code_standards['max_function_length']} lines"
+                            expected_value=f"<= {self.code_standards['max_function_length']} lines",
                         )
                         results.append(result)
-                
+
                 # Check number of parameters
                 if len(node.args.args) > self.code_standards["max_parameters"]:
                     result = self._create_result(
@@ -337,20 +385,20 @@ class CodeValidator(BaseValidator):
                         message=f"Function '{node.name}' has {len(node.args.args)} parameters",
                         field_path="functions",
                         actual_value=len(node.args.args),
-                        expected_value=f"<= {self.code_standards['max_parameters']} parameters"
+                        expected_value=f"<= {self.code_standards['max_parameters']} parameters",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def _validate_python_classes(self, tree: ast.AST) -> List[ValidationResult]:
         """Validate Python classes"""
         results = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
                 # Check class name
-                if not re.match(r'^[A-Z][a-zA-Z0-9]*$', node.name):
+                if not re.match(r"^[A-Z][a-zA-Z0-9]*$", node.name):
                     result = self._create_result(
                         rule_id="class_naming_convention",
                         rule_name="Class Naming Convention",
@@ -359,12 +407,12 @@ class CodeValidator(BaseValidator):
                         message=f"Class name '{node.name}' should follow PascalCase convention",
                         field_path="classes",
                         actual_value=node.name,
-                        expected_value="PascalCase naming"
+                        expected_value="PascalCase naming",
                     )
                     results.append(result)
-                
+
                 # Check class length
-                if hasattr(node, 'end_lineno') and hasattr(node, 'lineno'):
+                if hasattr(node, "end_lineno") and hasattr(node, "lineno"):
                     class_length = node.end_lineno - node.lineno + 1
                     if class_length > self.code_standards["max_class_length"]:
                         result = self._create_result(
@@ -375,22 +423,24 @@ class CodeValidator(BaseValidator):
                             message=f"Class '{node.name}' is {class_length} lines long",
                             field_path="classes",
                             actual_value=class_length,
-                            expected_value=f"<= {self.code_standards['max_class_length']} lines"
+                            expected_value=f"<= {self.code_standards['max_class_length']} lines",
                         )
                         results.append(result)
-        
+
         return results
-    
+
     def _validate_python_naming(self, tree: ast.AST) -> List[ValidationResult]:
         """Validate Python naming conventions"""
         results = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Name):
                 # Check variable naming
-                if not re.match(r'^[a-z_][a-z0-9_]*$', node.id):
+                if not re.match(r"^[a-z_][a-z0-9_]*$", node.id):
                     # Skip if it's a built-in or imported name
-                    if node.id not in self.python_keywords and not node.id.startswith('__'):
+                    if node.id not in self.python_keywords and not node.id.startswith(
+                        "__"
+                    ):
                         result = self._create_result(
                             rule_id="variable_naming_convention",
                             rule_name="Variable Naming Convention",
@@ -399,17 +449,17 @@ class CodeValidator(BaseValidator):
                             message=f"Variable name '{node.id}' should follow snake_case convention",
                             field_path="naming",
                             actual_value=node.id,
-                            expected_value="snake_case naming"
+                            expected_value="snake_case naming",
                         )
                         results.append(result)
-        
+
         return results
-    
+
     def _validate_line_lengths(self, content: str) -> List[ValidationResult]:
         """Validate line lengths"""
         results = []
-        
-        lines = content.split('\n')
+
+        lines = content.split("\n")
         for i, line in enumerate(lines, 1):
             if len(line) > self.code_standards["max_line_length"]:
                 result = self._create_result(
@@ -420,16 +470,16 @@ class CodeValidator(BaseValidator):
                     message=f"Line {i} is {len(line)} characters long",
                     field_path="content",
                     actual_value=f"line {i}: {len(line)} chars",
-                    expected_value=f"<= {self.code_standards['max_line_length']} characters"
+                    expected_value=f"<= {self.code_standards['max_line_length']} characters",
                 )
                 results.append(result)
-        
+
         return results
-    
+
     def _validate_code_metrics(self, metrics: Any) -> List[ValidationResult]:
         """Validate code metrics"""
         results = []
-        
+
         if not isinstance(metrics, dict):
             result = self._create_result(
                 rule_id="metrics_type",
@@ -439,11 +489,11 @@ class CodeValidator(BaseValidator):
                 message="Code metrics must be a dictionary",
                 field_path="metrics",
                 actual_value=type(metrics).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate each metric against standards
         for metric_name, metric_value in metrics.items():
             if metric_name in self.code_standards:
@@ -458,16 +508,16 @@ class CodeValidator(BaseValidator):
                             message=f"Code metric '{metric_name}' exceeds threshold: {metric_value} > {threshold}",
                             field_path=f"metrics.{metric_name}",
                             actual_value=metric_value,
-                            expected_value=f"<= {threshold}"
+                            expected_value=f"<= {threshold}",
                         )
                         results.append(result)
-        
+
         return results
-    
+
     def _validate_naming_conventions(self, naming: Any) -> List[ValidationResult]:
         """Validate naming conventions"""
         results = []
-        
+
         if not isinstance(naming, dict):
             result = self._create_result(
                 rule_id="naming_type",
@@ -477,11 +527,11 @@ class CodeValidator(BaseValidator):
                 message="Naming conventions must be a dictionary",
                 field_path="naming",
                 actual_value=type(naming).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate naming patterns if present
         if "patterns" in naming:
             patterns = naming["patterns"]
@@ -499,16 +549,16 @@ class CodeValidator(BaseValidator):
                                 message=f"Invalid naming pattern '{pattern_name}': {pattern}",
                                 field_path=f"naming.patterns.{pattern_name}",
                                 actual_value=pattern,
-                                expected_value="valid regex pattern"
+                                expected_value="valid regex pattern",
                             )
                             results.append(result)
-        
+
         return results
-    
+
     def _validate_code_complexity(self, complexity: Any) -> List[ValidationResult]:
         """Validate code complexity"""
         results = []
-        
+
         if not isinstance(complexity, dict):
             result = self._create_result(
                 rule_id="complexity_type",
@@ -518,11 +568,11 @@ class CodeValidator(BaseValidator):
                 message="Code complexity must be a dictionary",
                 field_path="complexity",
                 actual_value=type(complexity).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate cyclomatic complexity if present
         if "cyclomatic_complexity" in complexity:
             cc = complexity["cyclomatic_complexity"]
@@ -536,10 +586,10 @@ class CodeValidator(BaseValidator):
                         message=f"Cyclomatic complexity is high: {cc}",
                         field_path="complexity.cyclomatic_complexity",
                         actual_value=cc,
-                        expected_value="<= 10"
+                        expected_value="<= 10",
                     )
                     results.append(result)
-        
+
         # Validate nesting depth if present
         if "nesting_depth" in complexity:
             depth = complexity["nesting_depth"]
@@ -553,12 +603,12 @@ class CodeValidator(BaseValidator):
                         message=f"Nesting depth exceeds threshold: {depth} > {self.code_standards['max_nesting_depth']}",
                         field_path="complexity.nesting_depth",
                         actual_value=depth,
-                        expected_value=f"<= {self.code_standards['max_nesting_depth']}"
+                        expected_value=f"<= {self.code_standards['max_nesting_depth']}",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def set_code_standard(self, standard_name: str, value: float) -> bool:
         """Set a custom code standard threshold"""
         try:
@@ -572,11 +622,11 @@ class CodeValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to set code standard: {e}")
             return False
-    
+
     def get_code_standards(self) -> Dict[str, float]:
         """Get current code standards"""
         return self.code_standards.copy()
-    
+
     # Code validation functionality integration (from duplicate ai_ml/validation.py)
     def validate_code_legacy(self, code: str) -> None:
         """Legacy code validation method (from duplicate ai_ml/validation.py)"""
@@ -586,25 +636,29 @@ class CodeValidator(BaseValidator):
             # that the code contains at least one function definition
             if "def " not in code:
                 raise ValueError("Generated code must contain a function definition")
-            
+
             # Additional lightweight checks can be added here without touching the orchestrating engine
             if len(code.strip()) == 0:
                 raise ValueError("Generated code cannot be empty")
-            
+
             # Check for basic Python syntax indicators
-            if not any(keyword in code for keyword in ['def ', 'class ', 'import ', 'from ']):
-                raise ValueError("Generated code should contain basic Python syntax elements")
-                
+            if not any(
+                keyword in code for keyword in ["def ", "class ", "import ", "from "]
+            ):
+                raise ValueError(
+                    "Generated code should contain basic Python syntax elements"
+                )
+
         except Exception as e:
             self.logger.error(f"Legacy code validation failed: {e}")
             raise
-    
+
     def validate_code_with_legacy_fallback(self, code: str) -> Dict[str, Any]:
         """Validate code using both unified and legacy methods"""
         try:
             # Use unified validation first
             unified_results = self.validate({"code": code})
-            
+
             # Use legacy validation as fallback
             legacy_valid = True
             legacy_message = "Code validation passed"
@@ -613,56 +667,66 @@ class CodeValidator(BaseValidator):
             except Exception as e:
                 legacy_valid = False
                 legacy_message = str(e)
-            
+
             return {
                 "unified_validation": {
                     "total": len(unified_results),
-                    "passed": len([r for r in unified_results if r.status.value == "passed"]),
-                    "failed": len([r for r in unified_results if r.status.value == "failed"]),
-                    "warnings": len([r for r in unified_results if r.severity.value == "warning"]),
-                    "results": unified_results
+                    "passed": len(
+                        [r for r in unified_results if r.status.value == "passed"]
+                    ),
+                    "failed": len(
+                        [r for r in unified_results if r.status.value == "failed"]
+                    ),
+                    "warnings": len(
+                        [r for r in unified_results if r.severity.value == "warning"]
+                    ),
+                    "results": unified_results,
                 },
-                "legacy_validation": {
-                    "valid": legacy_valid,
-                    "message": legacy_message
-                },
-                "overall_valid": legacy_valid and len([r for r in unified_results if r.status.value == "failed"]) == 0,
-                "timestamp": self._get_current_timestamp()
+                "legacy_validation": {"valid": legacy_valid, "message": legacy_message},
+                "overall_valid": legacy_valid
+                and len([r for r in unified_results if r.status.value == "failed"])
+                == 0,
+                "timestamp": self._get_current_timestamp(),
             }
-            
+
         except Exception as e:
             self.logger.error(f"Code validation failed: {e}")
             return {
                 "error": str(e),
                 "overall_valid": False,
-                "timestamp": self._get_current_timestamp()
+                "timestamp": self._get_current_timestamp(),
             }
-    
+
     def get_code_validation_summary(self, code: str) -> Dict[str, Any]:
         """Get comprehensive code validation summary"""
         try:
             validation_result = self.validate_code_with_legacy_fallback(code)
-            
+
             # Add code statistics
             code_stats = {
-                "total_lines": len(code.split('\n')),
+                "total_lines": len(code.split("\n")),
                 "total_characters": len(code),
-                "function_count": code.count('def '),
-                "class_count": code.count('class '),
-                "import_count": code.count('import ') + code.count('from '),
-                "comment_lines": len([line for line in code.split('\n') if line.strip().startswith('#')]),
-                "empty_lines": len([line for line in code.split('\n') if line.strip() == ''])
+                "function_count": code.count("def "),
+                "class_count": code.count("class "),
+                "import_count": code.count("import ") + code.count("from "),
+                "comment_lines": len(
+                    [line for line in code.split("\n") if line.strip().startswith("#")]
+                ),
+                "empty_lines": len(
+                    [line for line in code.split("\n") if line.strip() == ""]
+                ),
             }
-            
+
             validation_result["code_statistics"] = code_stats
-            
+
             return validation_result
-            
+
         except Exception as e:
             self.logger.error(f"Failed to get code validation summary: {e}")
             return {"error": str(e)}
-    
+
     def _get_current_timestamp(self) -> str:
         """Get current timestamp in ISO format"""
         from datetime import datetime
+
         return datetime.now().isoformat()

--- a/src/core/validation/config_validator.py
+++ b/src/core/validation/config_validator.py
@@ -6,18 +6,24 @@ and following the unified validation framework patterns.
 """
 
 from typing import Dict, List, Any, Callable
-from .base_validator import BaseValidator, ValidationRule, ValidationSeverity, ValidationStatus, ValidationResult
+from .base_validator import (
+    BaseValidator,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+    ValidationResult,
+)
 
 
 class ConfigValidator(BaseValidator):
     """Validates configuration data using unified validation framework"""
-    
+
     def __init__(self, validators: Dict[str, Callable[[Dict[str, Any]], bool]] = None):
         """Initialize config validator with optional custom validators"""
         super().__init__("ConfigValidator")
         self.custom_validators = validators or {}
         self._setup_default_rules()
-    
+
     def _setup_default_rules(self) -> None:
         """Setup default configuration validation rules"""
         default_rules = [
@@ -26,57 +32,66 @@ class ConfigValidator(BaseValidator):
                 rule_name="Configuration Structure",
                 rule_type="config",
                 description="Validate configuration structure and format",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="required_sections",
                 rule_name="Required Sections",
                 rule_type="config",
                 description="Ensure all required configuration sections are present",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="section_validators",
                 rule_name="Section Validators",
                 rule_type="config",
                 description="Run section-specific validation functions",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="config_consistency",
                 rule_name="Configuration Consistency",
                 rule_type="config",
                 description="Check for configuration consistency across sections",
-                severity=ValidationSeverity.WARNING
-            )
+                severity=ValidationSeverity.WARNING,
+            ),
         ]
-        
+
         for rule in default_rules:
             self.add_validation_rule(rule)
-    
-    def validate(self, configs: Dict[str, Dict[str, Any]], **kwargs) -> List[ValidationResult]:
-        """Validate configuration data and return validation results"""
+
+    def validate(
+        self, configs: Dict[str, Dict[str, Any]], **kwargs
+    ) -> List[ValidationResult]:
+        """Validate configuration data and return validation results.
+
+        Returns:
+            List[ValidationResult]: Validation results produced during
+            configuration validation.
+        """
         results = []
-        
+
         try:
             # Validate configuration structure
             structure_results = self._validate_config_structure(configs)
             results.extend(structure_results)
-            
+
             # Validate required sections if specified
-            required_sections = kwargs.get('required_sections', [])
+            required_sections = kwargs.get("required_sections", [])
             if required_sections:
-                section_results = self._validate_required_sections(configs, required_sections)
+                section_results = self._validate_required_sections(
+                    configs, required_sections
+                )
                 results.extend(section_results)
-            
+
             # Run section-specific validators
             validator_results = self._run_section_validators(configs)
             results.extend(validator_results)
-            
+
             # Check configuration consistency
             consistency_results = self._validate_config_consistency(configs)
             results.extend(consistency_results)
-            
+
             # Add overall success result if no critical errors
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
                 success_result = self._create_result(
@@ -85,10 +100,13 @@ class ConfigValidator(BaseValidator):
                     status=ValidationStatus.PASSED,
                     severity=ValidationSeverity.INFO,
                     message="Configuration validation passed successfully",
-                    details={"total_sections": len(configs), "total_checks": len(results)}
+                    details={
+                        "total_sections": len(configs),
+                        "total_checks": len(results),
+                    },
                 )
                 results.append(success_result)
-            
+
         except Exception as e:
             error_result = self._create_result(
                 rule_id="config_validation_error",
@@ -96,16 +114,18 @@ class ConfigValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.CRITICAL,
                 message=f"Configuration validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
+                details={"error_type": type(e).__name__},
             )
             results.append(error_result)
-        
+
         return results
-    
-    def _validate_config_structure(self, configs: Dict[str, Dict[str, Any]]) -> List[ValidationResult]:
+
+    def _validate_config_structure(
+        self, configs: Dict[str, Dict[str, Any]]
+    ) -> List[ValidationResult]:
         """Validate configuration structure and format"""
         results = []
-        
+
         if not isinstance(configs, dict):
             result = self._create_result(
                 rule_id="config_type",
@@ -114,11 +134,11 @@ class ConfigValidator(BaseValidator):
                 severity=ValidationSeverity.ERROR,
                 message="Configuration must be a dictionary",
                 actual_value=type(configs).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         if len(configs) == 0:
             result = self._create_result(
                 rule_id="config_empty",
@@ -127,11 +147,11 @@ class ConfigValidator(BaseValidator):
                 severity=ValidationSeverity.WARNING,
                 message="Configuration is empty",
                 actual_value=configs,
-                expected_value="non-empty configuration"
+                expected_value="non-empty configuration",
             )
             results.append(result)
             return results
-        
+
         # Validate each section is a dictionary
         for section_name, section_data in configs.items():
             if not isinstance(section_data, dict):
@@ -143,20 +163,18 @@ class ConfigValidator(BaseValidator):
                     message=f"Section '{section_name}' must be a dictionary",
                     field_path=section_name,
                     actual_value=type(section_data).__name__,
-                    expected_value="dict"
+                    expected_value="dict",
                 )
                 results.append(result)
-        
+
         return results
-    
+
     def _validate_required_sections(
-        self, 
-        configs: Dict[str, Dict[str, Any]], 
-        required_sections: List[str]
+        self, configs: Dict[str, Dict[str, Any]], required_sections: List[str]
     ) -> List[ValidationResult]:
         """Validate that all required sections are present"""
         results = []
-        
+
         for section_name in required_sections:
             if section_name not in configs:
                 result = self._create_result(
@@ -167,16 +185,18 @@ class ConfigValidator(BaseValidator):
                     message=f"Required configuration section '{section_name}' is missing",
                     field_path=section_name,
                     actual_value="missing",
-                    expected_value="present"
+                    expected_value="present",
                 )
                 results.append(result)
-        
+
         return results
-    
-    def _run_section_validators(self, configs: Dict[str, Dict[str, Any]]) -> List[ValidationResult]:
+
+    def _run_section_validators(
+        self, configs: Dict[str, Dict[str, Any]]
+    ) -> List[ValidationResult]:
         """Run section-specific validation functions"""
         results = []
-        
+
         for section_name, section_data in configs.items():
             validator = self.custom_validators.get(section_name)
             if validator and callable(validator):
@@ -191,7 +211,7 @@ class ConfigValidator(BaseValidator):
                             message=f"Section '{section_name}' failed custom validation",
                             field_path=section_name,
                             actual_value=section_data,
-                            expected_value="valid configuration"
+                            expected_value="valid configuration",
                         )
                         results.append(result)
                 except Exception as e:
@@ -202,27 +222,29 @@ class ConfigValidator(BaseValidator):
                         severity=ValidationSeverity.ERROR,
                         message=f"Section '{section_name}' validator error: {str(e)}",
                         field_path=section_name,
-                        details={"error_type": type(e).__name__}
+                        details={"error_type": type(e).__name__},
                     )
                     results.append(result)
-        
+
         return results
-    
-    def _validate_config_consistency(self, configs: Dict[str, Dict[str, Any]]) -> List[ValidationResult]:
+
+    def _validate_config_consistency(
+        self, configs: Dict[str, Dict[str, Any]]
+    ) -> List[ValidationResult]:
         """Check for configuration consistency across sections"""
         results = []
-        
+
         # Check for duplicate keys across sections
         all_keys = set()
         duplicate_keys = set()
-        
+
         for section_name, section_data in configs.items():
             if isinstance(section_data, dict):
                 for key in section_data.keys():
                     if key in all_keys:
                         duplicate_keys.add(key)
                     all_keys.add(key)
-        
+
         if duplicate_keys:
             result = self._create_result(
                 rule_id="duplicate_keys",
@@ -230,10 +252,10 @@ class ConfigValidator(BaseValidator):
                 status=ValidationStatus.WARNING,
                 severity=ValidationSeverity.WARNING,
                 message=f"Duplicate keys found across sections: {list(duplicate_keys)}",
-                details={"duplicate_keys": list(duplicate_keys)}
+                details={"duplicate_keys": list(duplicate_keys)},
             )
             results.append(result)
-        
+
         # Check for conflicting values (basic check)
         # This could be extended with more sophisticated conflict detection
         for key in all_keys:
@@ -241,7 +263,7 @@ class ConfigValidator(BaseValidator):
             for section_data in configs.values():
                 if isinstance(section_data, dict) and key in section_data:
                     values.append(section_data[key])
-            
+
             if len(set(values)) > 1:
                 result = self._create_result(
                     rule_id=f"conflicting_values_{key}",
@@ -249,13 +271,15 @@ class ConfigValidator(BaseValidator):
                     status=ValidationStatus.WARNING,
                     severity=ValidationSeverity.WARNING,
                     message=f"Conflicting values for key '{key}' across sections",
-                    details={"key": key, "values": values}
+                    details={"key": key, "values": values},
                 )
                 results.append(result)
-        
+
         return results
-    
-    def add_section_validator(self, section_name: str, validator: Callable[[Dict[str, Any]], bool]) -> bool:
+
+    def add_section_validator(
+        self, section_name: str, validator: Callable[[Dict[str, Any]], bool]
+    ) -> bool:
         """Add a custom validator for a specific configuration section"""
         try:
             self.custom_validators[section_name] = validator
@@ -264,7 +288,7 @@ class ConfigValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to add section validator: {e}")
             return False
-    
+
     def remove_section_validator(self, section_name: str) -> bool:
         """Remove a custom validator for a specific configuration section"""
         try:
@@ -276,12 +300,14 @@ class ConfigValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to remove section validator: {e}")
             return False
-    
+
     # ConfigManagerValidator functionality integration
-    def validate_config_sections(self, configs: Dict[str, Dict[str, Any]]) -> Dict[str, bool]:
+    def validate_config_sections(
+        self, configs: Dict[str, Dict[str, Any]]
+    ) -> Dict[str, bool]:
         """Validate configuration sections using custom validators (from ConfigManagerValidator)"""
         results: Dict[str, bool] = {}
-        
+
         try:
             for name, data in configs.items():
                 validator = self.custom_validators.get(name)
@@ -289,43 +315,48 @@ class ConfigValidator(BaseValidator):
                     # No validator specified, assume valid
                     results[name] = True
                     continue
-                
+
                 try:
                     results[name] = bool(validator(data))
                 except Exception:
                     # Any exception during validation means invalid
                     results[name] = False
-                    
+
         except Exception as e:
             self.logger.error(f"Config section validation failed: {e}")
             # Return empty results on error
             results = {}
-            
+
         return results
-    
-    def get_validation_summary(self, configs: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+
+    def get_validation_summary(
+        self, configs: Dict[str, Dict[str, Any]]
+    ) -> Dict[str, Any]:
         """Get validation summary for configuration sections"""
         try:
             section_results = self.validate_config_sections(configs)
-            
+
             total_sections = len(section_results)
             valid_sections = sum(1 for valid in section_results.values() if valid)
             invalid_sections = total_sections - valid_sections
-            
+
             return {
                 "total_sections": total_sections,
                 "valid_sections": valid_sections,
                 "invalid_sections": invalid_sections,
-                "pass_rate": (valid_sections / total_sections * 100) if total_sections > 0 else 0,
+                "pass_rate": (valid_sections / total_sections * 100)
+                if total_sections > 0
+                else 0,
                 "section_results": section_results,
-                "timestamp": self._get_current_timestamp()
+                "timestamp": self._get_current_timestamp(),
             }
-            
+
         except Exception as e:
             self.logger.error(f"Failed to get validation summary: {e}")
             return {"error": str(e)}
-    
+
     def _get_current_timestamp(self) -> str:
         """Get current timestamp in ISO format"""
         from datetime import datetime
+
         return datetime.now().isoformat()

--- a/src/core/validation/contract_validator.py
+++ b/src/core/validation/contract_validator.py
@@ -6,16 +6,22 @@ and following the unified validation framework patterns.
 """
 
 from typing import Dict, List, Any
-from .base_validator import BaseValidator, ValidationRule, ValidationSeverity, ValidationStatus, ValidationResult
+from .base_validator import (
+    BaseValidator,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+    ValidationResult,
+)
 
 
 class ContractValidator(BaseValidator):
     """Validates contract data and structure using unified validation framework"""
-    
+
     def __init__(self):
         """Initialize contract validator"""
         super().__init__("ContractValidator")
-    
+
     def _setup_default_rules(self) -> None:
         """Setup default contract validation rules"""
         default_rules = [
@@ -24,62 +30,78 @@ class ContractValidator(BaseValidator):
                 rule_name="Required Fields Check",
                 rule_type="contract",
                 description="Ensure all required contract fields are present",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="priority_validation",
                 rule_name="Priority Validation",
                 rule_type="contract",
                 description="Validate contract priority values",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="capabilities_validation",
                 rule_name="Capabilities Validation",
                 rule_type="contract",
                 description="Validate required capabilities format",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="deadline_validation",
                 rule_name="Deadline Validation",
                 rule_type="contract",
                 description="Validate contract deadline format and logic",
-                severity=ValidationSeverity.WARNING
-            )
+                severity=ValidationSeverity.WARNING,
+            ),
         ]
-        
+
         for rule in default_rules:
             self.add_validation_rule(rule)
-    
-    def validate(self, contract_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
-        """Validate contract data and return validation results"""
+
+    def validate(
+        self, contract_data: Dict[str, Any], **kwargs
+    ) -> List[ValidationResult]:
+        """Validate contract data and return validation results.
+
+        Returns:
+            List[ValidationResult]: Validation results produced during contract
+            validation.
+        """
         results = []
-        
+
         try:
             # Validate required fields
-            required_fields = ["title", "description", "priority", "required_capabilities"]
-            field_results = self._validate_required_fields(contract_data, required_fields)
+            required_fields = [
+                "title",
+                "description",
+                "priority",
+                "required_capabilities",
+            ]
+            field_results = self._validate_required_fields(
+                contract_data, required_fields
+            )
             results.extend(field_results)
-            
+
             # Validate priority field
             if "priority" in contract_data:
                 priority_result = self._validate_priority(contract_data["priority"])
                 if priority_result:
                     results.append(priority_result)
-            
+
             # Validate capabilities field
             if "required_capabilities" in contract_data:
-                capabilities_result = self._validate_capabilities(contract_data["required_capabilities"])
+                capabilities_result = self._validate_capabilities(
+                    contract_data["required_capabilities"]
+                )
                 if capabilities_result:
                     results.append(capabilities_result)
-            
+
             # Validate deadline if present
             if "deadline" in contract_data:
                 deadline_result = self._validate_deadline(contract_data["deadline"])
                 if deadline_result:
                     results.append(deadline_result)
-            
+
             # Add overall success result if no critical errors
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
                 success_result = self._create_result(
@@ -88,10 +110,10 @@ class ContractValidator(BaseValidator):
                     status=ValidationStatus.PASSED,
                     severity=ValidationSeverity.INFO,
                     message="Contract validation passed successfully",
-                    details={"total_checks": len(results)}
+                    details={"total_checks": len(results)},
                 )
                 results.append(success_result)
-            
+
         except Exception as e:
             error_result = self._create_result(
                 rule_id="validation_error",
@@ -99,16 +121,16 @@ class ContractValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.CRITICAL,
                 message=f"Validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
+                details={"error_type": type(e).__name__},
             )
             results.append(error_result)
-        
+
         return results
-    
+
     def _validate_priority(self, priority: Any) -> ValidationResult:
         """Validate contract priority value"""
         valid_priorities = ["LOW", "MEDIUM", "HIGH", "CRITICAL"]
-        
+
         if not isinstance(priority, str):
             return self._create_result(
                 rule_id="priority_type",
@@ -118,9 +140,9 @@ class ContractValidator(BaseValidator):
                 message="Priority must be a string",
                 field_path="priority",
                 actual_value=type(priority).__name__,
-                expected_value="str"
+                expected_value="str",
             )
-        
+
         if priority not in valid_priorities:
             return self._create_result(
                 rule_id="priority_value",
@@ -130,11 +152,11 @@ class ContractValidator(BaseValidator):
                 message=f"Invalid priority value: {priority}",
                 field_path="priority",
                 actual_value=priority,
-                expected_value=f"one of {valid_priorities}"
+                expected_value=f"one of {valid_priorities}",
             )
-        
+
         return None
-    
+
     def _validate_capabilities(self, capabilities: Any) -> ValidationResult:
         """Validate required capabilities format"""
         if not isinstance(capabilities, list):
@@ -146,9 +168,9 @@ class ContractValidator(BaseValidator):
                 message="Required capabilities must be a list",
                 field_path="required_capabilities",
                 actual_value=type(capabilities).__name__,
-                expected_value="list"
+                expected_value="list",
             )
-        
+
         if len(capabilities) == 0:
             return self._create_result(
                 rule_id="capabilities_empty",
@@ -158,9 +180,9 @@ class ContractValidator(BaseValidator):
                 message="Required capabilities must be a non-empty list",
                 field_path="required_capabilities",
                 actual_value=capabilities,
-                expected_value="non-empty list"
+                expected_value="non-empty list",
             )
-        
+
         # Validate each capability is a string
         for i, capability in enumerate(capabilities):
             if not isinstance(capability, str):
@@ -172,15 +194,15 @@ class ContractValidator(BaseValidator):
                     message=f"Capability {i} must be a string",
                     field_path=f"required_capabilities[{i}]",
                     actual_value=type(capability).__name__,
-                    expected_value="str"
+                    expected_value="str",
                 )
-        
+
         return None
-    
+
     def _validate_deadline(self, deadline: Any) -> ValidationResult:
         """Validate contract deadline format and logic"""
         from datetime import datetime
-        
+
         if not isinstance(deadline, str):
             return self._create_result(
                 rule_id="deadline_type",
@@ -190,9 +212,9 @@ class ContractValidator(BaseValidator):
                 message="Deadline must be a string",
                 field_path="deadline",
                 actual_value=type(deadline).__name__,
-                expected_value="str"
+                expected_value="str",
             )
-        
+
         try:
             deadline_date = datetime.fromisoformat(deadline)
             if deadline_date < datetime.now():
@@ -204,7 +226,7 @@ class ContractValidator(BaseValidator):
                     message="Deadline is in the past",
                     field_path="deadline",
                     actual_value=deadline,
-                    expected_value="future date"
+                    expected_value="future date",
                 )
         except ValueError:
             return self._create_result(
@@ -215,26 +237,30 @@ class ContractValidator(BaseValidator):
                 message="Invalid deadline format. Use ISO format (YYYY-MM-DD)",
                 field_path="deadline",
                 actual_value=deadline,
-                expected_value="ISO format date string"
+                expected_value="ISO format date string",
             )
-        
+
         return None
-    
+
     # Contract validation functionality integration (from duplicate validation.py)
-    def validate_contract_legacy(self, contract_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def validate_contract_legacy(
+        self, contract_data: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         """Legacy contract validation method (from duplicate validation.py)"""
         results: List[Dict[str, Any]] = []
-        
+
         try:
             required = ["title", "description", "priority", "required_capabilities"]
             for field in required:
                 if field not in contract_data or not contract_data[field]:
-                    results.append({
-                        "field": field,
-                        "issue": f"Required field '{field}' is missing or empty",
-                        "severity": "critical",
-                        "passed": False,
-                    })
+                    results.append(
+                        {
+                            "field": field,
+                            "issue": f"Required field '{field}' is missing or empty",
+                            "severity": "critical",
+                            "passed": False,
+                        }
+                    )
 
             if "priority" in contract_data:
                 try:
@@ -242,83 +268,102 @@ class ContractValidator(BaseValidator):
                     priority = contract_data["priority"]
                     valid_priorities = ["low", "medium", "high", "critical"]
                     if priority not in valid_priorities:
-                        results.append({
+                        results.append(
+                            {
+                                "field": "priority",
+                                "issue": f"Invalid priority value: {priority}",
+                                "severity": "critical",
+                                "passed": False,
+                            }
+                        )
+                except Exception:
+                    results.append(
+                        {
                             "field": "priority",
-                            "issue": f"Invalid priority value: {priority}",
+                            "issue": f"Invalid priority value: {contract_data['priority']}",
                             "severity": "critical",
                             "passed": False,
-                        })
-                except Exception:
-                    results.append({
-                        "field": "priority",
-                        "issue": f"Invalid priority value: {contract_data['priority']}",
-                        "severity": "critical",
-                        "passed": False,
-                    })
+                        }
+                    )
 
             if "required_capabilities" in contract_data:
                 capabilities = contract_data["required_capabilities"]
                 if not isinstance(capabilities, list) or len(capabilities) == 0:
-                    results.append({
-                        "field": "required_capabilities",
-                        "issue": "Required capabilities must be a non-empty list",
-                        "severity": "critical",
-                        "passed": False,
-                    })
+                    results.append(
+                        {
+                            "field": "required_capabilities",
+                            "issue": "Required capabilities must be a non-empty list",
+                            "severity": "critical",
+                            "passed": False,
+                        }
+                    )
 
-            if not any(r["severity"] == "critical" and not r["passed"] for r in results):
-                results.append({
-                    "field": "overall",
-                    "issue": "Contract validation passed",
-                    "severity": "info",
-                    "passed": True,
-                })
-                
+            if not any(
+                r["severity"] == "critical" and not r["passed"] for r in results
+            ):
+                results.append(
+                    {
+                        "field": "overall",
+                        "issue": "Contract validation passed",
+                        "severity": "info",
+                        "passed": True,
+                    }
+                )
+
         except Exception as e:
-            results.append({
-                "field": "validation_error",
-                "issue": f"Validation error: {str(e)}",
-                "severity": "critical",
-                "passed": False,
-            })
-            
+            results.append(
+                {
+                    "field": "validation_error",
+                    "issue": f"Validation error: {str(e)}",
+                    "severity": "critical",
+                    "passed": False,
+                }
+            )
+
         return results
-    
+
     def get_validation_summary(self, contract_data: Dict[str, Any]) -> Dict[str, Any]:
         """Get validation summary for contract data"""
         try:
             # Use both validation methods
             unified_results = self.validate(contract_data)
             legacy_results = self.validate_contract_legacy(contract_data)
-            
+
             # Count results
             total_unified = len(unified_results)
-            passed_unified = len([r for r in unified_results if r.status.value == "passed"])
-            
+            passed_unified = len(
+                [r for r in unified_results if r.status.value == "passed"]
+            )
+
             total_legacy = len(legacy_results)
             passed_legacy = len([r for r in legacy_results if r["passed"]])
-            
+
             return {
                 "unified_validation": {
                     "total": total_unified,
                     "passed": passed_unified,
                     "failed": total_unified - passed_unified,
-                    "pass_rate": (passed_unified / total_unified * 100) if total_unified > 0 else 0
+                    "pass_rate": (passed_unified / total_unified * 100)
+                    if total_unified > 0
+                    else 0,
                 },
                 "legacy_validation": {
                     "total": total_legacy,
                     "passed": passed_legacy,
                     "failed": total_legacy - passed_legacy,
-                    "pass_rate": (passed_legacy / total_legacy * 100) if total_legacy > 0 else 0
+                    "pass_rate": (passed_legacy / total_legacy * 100)
+                    if total_legacy > 0
+                    else 0,
                 },
-                "timestamp": self._get_current_timestamp()
+                "timestamp": self._get_current_timestamp(),
             }
-            
+
         except Exception as e:
             self.logger.error(f"Failed to get validation summary: {e}")
             return {"error": str(e)}
-    
+
     def _get_current_timestamp(self) -> str:
         """Get current timestamp in ISO format"""
         from datetime import datetime
+
         return datetime.now().isoformat()

--- a/src/core/validation/message_validator.py
+++ b/src/core/validation/message_validator.py
@@ -10,7 +10,13 @@ import re
 from typing import Dict, List, Any, Optional
 from datetime import datetime
 
-from .base_validator import BaseValidator, ValidationRule, ValidationSeverity, ValidationStatus, ValidationResult
+from .base_validator import (
+    BaseValidator,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+    ValidationResult,
+)
 from src.services.messaging.models.unified_message import (
     UnifiedMessage,
     UnifiedMessageType,
@@ -22,12 +28,12 @@ from src.services.messaging.models.unified_message import (
 
 class MessageValidator(BaseValidator):
     """Validates UnifiedMessage data and structure using unified validation framework"""
-    
+
     def __init__(self):
         """Initialize message validator"""
         super().__init__("MessageValidator")
         self._setup_default_rules()
-    
+
     def _setup_default_rules(self) -> None:
         """Setup default message validation rules"""
         default_rules = [
@@ -36,70 +42,87 @@ class MessageValidator(BaseValidator):
                 rule_name="Unified Message Structure",
                 rule_type="message",
                 description="Validate UnifiedMessage structure and format",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="required_fields",
                 rule_name="Required Fields",
                 rule_type="message",
                 description="Ensure all required UnifiedMessage fields are present",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="message_format",
                 rule_name="Message Format",
                 rule_type="message",
                 description="Validate UnifiedMessage format and encoding",
-                severity=ValidationSeverity.WARNING
+                severity=ValidationSeverity.WARNING,
             ),
             ValidationRule(
                 rule_id="content_validation",
                 rule_name="Content Validation",
                 rule_type="message",
                 description="Validate UnifiedMessage content and structure",
-                severity=ValidationSeverity.WARNING
+                severity=ValidationSeverity.WARNING,
             ),
             ValidationRule(
                 rule_id="enum_validation",
                 rule_name="Enum Validation",
                 rule_type="message",
                 description="Validate UnifiedMessage enum values",
-                severity=ValidationSeverity.ERROR
-            )
+                severity=ValidationSeverity.ERROR,
+            ),
         ]
-        
+
         for rule in default_rules:
             self.add_validation_rule(rule)
-    
-    def validate(self, message_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
-        """Validate UnifiedMessage data and return validation results"""
+
+    def validate(
+        self, message_data: Dict[str, Any], **kwargs
+    ) -> List[ValidationResult]:
+        """Validate UnifiedMessage data and return validation results.
+
+        Returns:
+            List[ValidationResult]: Validation results produced during message
+            validation.
+        """
         results = []
-        
+
         try:
             # Validate message structure
             structure_results = self._validate_unified_message_structure(message_data)
             results.extend(structure_results)
-            
+
             # Validate required fields
-            required_fields = ["message_id", "message_type", "priority", "status", "sender_id", "recipient_id", "content"]
-            field_results = self._validate_required_fields(message_data, required_fields)
+            required_fields = [
+                "message_id",
+                "message_type",
+                "priority",
+                "status",
+                "sender_id",
+                "recipient_id",
+                "content",
+            ]
+            field_results = self._validate_required_fields(
+                message_data, required_fields
+            )
             results.extend(field_results)
-            
+
             # Validate enum values
             enum_results = self._validate_enum_values(message_data)
             results.extend(enum_results)
-            
+
             # Validate timestamp if present
             if "timestamp" in message_data:
                 timestamp_result = self._validate_timestamp(message_data["timestamp"])
                 if timestamp_result:
                     results.append(timestamp_result)
-            
+
             # Validate content if present
             if "content" in message_data:
                 content_results = self._validate_content(message_data["content"])
                 results.extend(content_results)
-            
+
             # Add overall success result if no critical errors
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
                 success_result = self._create_result(
@@ -108,10 +131,10 @@ class MessageValidator(BaseValidator):
                     status=ValidationStatus.PASSED,
                     severity=ValidationSeverity.INFO,
                     message="UnifiedMessage validation passed successfully",
-                    details={"validated_fields": list(message_data.keys())}
+                    details={"validated_fields": list(message_data.keys())},
                 )
                 results.append(success_result)
-            
+
         except Exception as e:
             error_result = self._create_result(
                 rule_id="validation_exception",
@@ -119,20 +142,24 @@ class MessageValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.ERROR,
                 message=f"Validation failed with exception: {str(e)}",
-                details={"exception": str(e)}
+                details={"exception": str(e)},
             )
             results.append(error_result)
-        
+
         return results
-    
-    def validate_unified_message(self, message: UnifiedMessage) -> List[ValidationResult]:
+
+    def validate_unified_message(
+        self, message: UnifiedMessage
+    ) -> List[ValidationResult]:
         """Validate a UnifiedMessage instance directly"""
         return self.validate(message.to_dict())
-    
-    def _validate_unified_message_structure(self, message_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_unified_message_structure(
+        self, message_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate UnifiedMessage structure specifically"""
         results = []
-        
+
         # Check for required UnifiedMessage fields
         expected_fields = {
             "message_id": str,
@@ -143,144 +170,180 @@ class MessageValidator(BaseValidator):
             "recipient_id": str,
             "content": str,
         }
-        
+
         for field, expected_type in expected_fields.items():
             if field not in message_data:
-                results.append(self._create_result(
-                    rule_id="missing_field",
-                    rule_name=f"Missing Field: {field}",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Required field '{field}' is missing",
-                    details={"field": field, "expected_type": str(expected_type)}
-                ))
+                results.append(
+                    self._create_result(
+                        rule_id="missing_field",
+                        rule_name=f"Missing Field: {field}",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Required field '{field}' is missing",
+                        details={"field": field, "expected_type": str(expected_type)},
+                    )
+                )
             elif not isinstance(message_data[field], expected_type):
-                results.append(self._create_result(
-                    rule_id="invalid_field_type",
-                    rule_name=f"Invalid Field Type: {field}",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Field '{field}' has invalid type",
-                    details={"field": field, "expected_type": str(expected_type), "actual_type": str(type(message_data[field]))}
-                ))
-        
+                results.append(
+                    self._create_result(
+                        rule_id="invalid_field_type",
+                        rule_name=f"Invalid Field Type: {field}",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Field '{field}' has invalid type",
+                        details={
+                            "field": field,
+                            "expected_type": str(expected_type),
+                            "actual_type": str(type(message_data[field])),
+                        },
+                    )
+                )
+
         return results
-    
-    def _validate_enum_values(self, message_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_enum_values(
+        self, message_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate that enum values are valid"""
         results = []
-        
+
         # Validate message_type
         if "message_type" in message_data:
             try:
                 UnifiedMessageType(message_data["message_type"])
             except ValueError:
-                results.append(self._create_result(
-                    rule_id="invalid_message_type",
-                    rule_name="Invalid Message Type",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Invalid message_type: {message_data['message_type']}",
-                    details={"valid_types": [t.value for t in UnifiedMessageType]}
-                ))
-        
+                results.append(
+                    self._create_result(
+                        rule_id="invalid_message_type",
+                        rule_name="Invalid Message Type",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Invalid message_type: {message_data['message_type']}",
+                        details={"valid_types": [t.value for t in UnifiedMessageType]},
+                    )
+                )
+
         # Validate priority
         if "priority" in message_data:
             try:
                 UnifiedMessagePriority(message_data["priority"])
             except ValueError:
-                results.append(self._create_result(
-                    rule_id="invalid_priority",
-                    rule_name="Invalid Priority",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Invalid priority: {message_data['priority']}",
-                    details={"valid_priorities": [p.value for p in UnifiedMessagePriority]}
-                ))
-        
+                results.append(
+                    self._create_result(
+                        rule_id="invalid_priority",
+                        rule_name="Invalid Priority",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Invalid priority: {message_data['priority']}",
+                        details={
+                            "valid_priorities": [
+                                p.value for p in UnifiedMessagePriority
+                            ]
+                        },
+                    )
+                )
+
         # Validate status
         if "status" in message_data:
             try:
                 UnifiedMessageStatus(message_data["status"])
             except ValueError:
-                results.append(self._create_result(
-                    rule_id="invalid_status",
-                    rule_name="Invalid Status",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Invalid status: {message_data['status']}",
-                    details={"valid_statuses": [s.value for s in UnifiedMessageStatus]}
-                ))
-        
+                results.append(
+                    self._create_result(
+                        rule_id="invalid_status",
+                        rule_name="Invalid Status",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Invalid status: {message_data['status']}",
+                        details={
+                            "valid_statuses": [s.value for s in UnifiedMessageStatus]
+                        },
+                    )
+                )
+
         return results
-    
-    def _validate_required_fields(self, message_data: Dict[str, Any], required_fields: List[str]) -> List[ValidationResult]:
+
+    def _validate_required_fields(
+        self, message_data: Dict[str, Any], required_fields: List[str]
+    ) -> List[ValidationResult]:
         """Validate that all required fields are present"""
         results = []
-        
+
         for field in required_fields:
             if field not in message_data or message_data[field] is None:
-                results.append(self._create_result(
-                    rule_id="missing_required_field",
-                    rule_name=f"Missing Required Field: {field}",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Required field '{field}' is missing or null",
-                    details={"field": field}
-                ))
-            elif isinstance(message_data[field], str) and not message_data[field].strip():
-                results.append(self._create_result(
-                    rule_id="empty_required_field",
-                    rule_name=f"Empty Required Field: {field}",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Required field '{field}' is empty",
-                    details={"field": field}
-                ))
-        
+                results.append(
+                    self._create_result(
+                        rule_id="missing_required_field",
+                        rule_name=f"Missing Required Field: {field}",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Required field '{field}' is missing or null",
+                        details={"field": field},
+                    )
+                )
+            elif (
+                isinstance(message_data[field], str) and not message_data[field].strip()
+            ):
+                results.append(
+                    self._create_result(
+                        rule_id="empty_required_field",
+                        rule_name=f"Empty Required Field: {field}",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Required field '{field}' is empty",
+                        details={"field": field},
+                    )
+                )
+
         return results
-    
+
     def _validate_message_format(self, format_data: Any) -> List[ValidationResult]:
         """Validate message format"""
         results = []
-        
+
         if not isinstance(format_data, str):
-            results.append(self._create_result(
-                rule_id="invalid_format_type",
-                rule_name="Invalid Format Type",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.WARNING,
-                message="Message format should be a string",
-                details={"actual_type": str(type(format_data))}
-            ))
-        
+            results.append(
+                self._create_result(
+                    rule_id="invalid_format_type",
+                    rule_name="Invalid Format Type",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.WARNING,
+                    message="Message format should be a string",
+                    details={"actual_type": str(type(format_data))},
+                )
+            )
+
         return results
-    
+
     def _validate_content(self, content: Any) -> List[ValidationResult]:
         """Validate message content"""
         results = []
-        
+
         if not isinstance(content, str):
-            results.append(self._create_result(
-                rule_id="invalid_content_type",
-                rule_name="Invalid Content Type",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.WARNING,
-                message="Message content should be a string",
-                details={"actual_type": str(type(content))}
-            ))
+            results.append(
+                self._create_result(
+                    rule_id="invalid_content_type",
+                    rule_name="Invalid Content Type",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.WARNING,
+                    message="Message content should be a string",
+                    details={"actual_type": str(type(content))},
+                )
+            )
         elif len(content.strip()) == 0:
-            results.append(self._create_result(
-                rule_id="empty_content",
-                rule_name="Empty Content",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.WARNING,
-                message="Message content cannot be empty",
-                details={"content_length": len(content)}
-            ))
-        
+            results.append(
+                self._create_result(
+                    rule_id="empty_content",
+                    rule_name="Empty Content",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.WARNING,
+                    message="Message content cannot be empty",
+                    details={"content_length": len(content)},
+                )
+            )
+
         return results
-    
+
     def _validate_timestamp(self, timestamp: Any) -> Optional[ValidationResult]:
         """Validate timestamp format"""
         if isinstance(timestamp, str):
@@ -294,7 +357,7 @@ class MessageValidator(BaseValidator):
                     status=ValidationStatus.FAILED,
                     severity=ValidationSeverity.WARNING,
                     message="Timestamp should be in ISO format",
-                    details={"timestamp": timestamp}
+                    details={"timestamp": timestamp},
                 )
         elif isinstance(timestamp, datetime):
             return None  # Valid timestamp
@@ -305,9 +368,9 @@ class MessageValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.WARNING,
                 message="Timestamp should be a string or datetime object",
-                details={"actual_type": str(type(timestamp))}
+                details={"actual_type": str(type(timestamp))},
             )
-    
+
     def _validate_message_type(self, message_type: Any) -> Optional[ValidationResult]:
         """Validate message type"""
         if not isinstance(message_type, str):
@@ -317,7 +380,7 @@ class MessageValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.WARNING,
                 message="Message type should be a string",
-                details={"actual_type": str(type(message_type))}
+                details={"actual_type": str(type(message_type))},
             )
         return None
 

--- a/src/core/validation/models.py
+++ b/src/core/validation/models.py
@@ -1,0 +1,54 @@
+"""Validation data models and enums."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class ValidationSeverity(Enum):
+    """Validation severity levels."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+    CRITICAL = "critical"
+
+
+class ValidationStatus(Enum):
+    """Validation result status."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+    WARNING = "warning"
+    PENDING = "pending"
+
+
+@dataclass
+class ValidationRule:
+    """Configurable validation rule."""
+
+    rule_id: str
+    rule_name: str
+    rule_type: str
+    description: str
+    severity: ValidationSeverity = ValidationSeverity.ERROR
+    threshold: Optional[float] = None
+    enabled: bool = True
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ValidationResult:
+    """Standardized validation result."""
+
+    rule_id: str
+    rule_name: str
+    status: ValidationStatus
+    severity: ValidationSeverity
+    message: str
+    details: Dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=datetime.now)
+    field_path: Optional[str] = None
+    actual_value: Optional[Any] = None
+    expected_value: Optional[Any] = None

--- a/src/core/validation/onboarding_validator.py
+++ b/src/core/validation/onboarding_validator.py
@@ -6,22 +6,39 @@ and following the unified validation framework patterns.
 """
 
 from typing import Dict, List, Any, Optional
-from .base_validator import BaseValidator, ValidationRule, ValidationSeverity, ValidationStatus, ValidationResult
+from .base_validator import (
+    BaseValidator,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+    ValidationResult,
+)
 
 
 class OnboardingValidator(BaseValidator):
     """Validates onboarding data and processes using unified validation framework"""
-    
+
     def __init__(self):
         """Initialize onboarding validator"""
         super().__init__("OnboardingValidator")
         self.onboarding_stages = [
-            "registration", "verification", "profile_setup", "training", "activation", "completion"
+            "registration",
+            "verification",
+            "profile_setup",
+            "training",
+            "activation",
+            "completion",
         ]
         self.verification_methods = [
-            "email", "sms", "phone", "document", "biometric", "social", "manual"
+            "email",
+            "sms",
+            "phone",
+            "document",
+            "biometric",
+            "social",
+            "manual",
         ]
-    
+
     def _setup_default_rules(self) -> None:
         """Setup default onboarding validation rules"""
         default_rules = [
@@ -30,73 +47,86 @@ class OnboardingValidator(BaseValidator):
                 rule_name="Onboarding Structure",
                 rule_type="onboarding",
                 description="Validate onboarding data structure and format",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="onboarding_flow_validation",
                 rule_name="Onboarding Flow Validation",
                 rule_type="onboarding",
                 description="Validate onboarding flow and progression",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="verification_validation",
                 rule_name="Verification Validation",
                 rule_type="onboarding",
                 description="Validate verification methods and status",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="compliance_check",
                 rule_name="Compliance Check",
                 rule_type="onboarding",
                 description="Check onboarding compliance requirements",
-                severity=ValidationSeverity.WARNING
-            )
+                severity=ValidationSeverity.WARNING,
+            ),
         ]
-        
+
         for rule in default_rules:
             self.add_validation_rule(rule)
-    
-    def validate(self, onboarding_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
-        """Validate onboarding data and return validation results"""
+
+    def validate(
+        self, onboarding_data: Dict[str, Any], **kwargs
+    ) -> List[ValidationResult]:
+        """Validate onboarding data and return validation results.
+
+        Returns:
+            List[ValidationResult]: Validation results produced during
+            onboarding validation.
+        """
         results = []
-        
+
         try:
             # Validate onboarding data structure
             structure_results = self._validate_onboarding_structure(onboarding_data)
             results.extend(structure_results)
-            
+
             # Validate required fields
             required_fields = ["user_id", "stage", "start_date", "status"]
-            field_results = self._validate_required_fields(onboarding_data, required_fields)
+            field_results = self._validate_required_fields(
+                onboarding_data, required_fields
+            )
             results.extend(field_results)
-            
+
             # Validate onboarding stage if present
             if "stage" in onboarding_data:
                 stage_result = self._validate_onboarding_stage(onboarding_data["stage"])
                 if stage_result:
                     results.append(stage_result)
-            
+
             # Validate onboarding flow if present
             if "flow" in onboarding_data:
                 flow_results = self._validate_onboarding_flow(onboarding_data["flow"])
                 results.extend(flow_results)
-            
+
             # Validate verification if present
             if "verification" in onboarding_data:
-                verification_results = self._validate_verification(onboarding_data["verification"])
+                verification_results = self._validate_verification(
+                    onboarding_data["verification"]
+                )
                 results.extend(verification_results)
-            
+
             # Validate compliance if present
             if "compliance" in onboarding_data:
-                compliance_results = self._validate_compliance(onboarding_data["compliance"])
+                compliance_results = self._validate_compliance(
+                    onboarding_data["compliance"]
+                )
                 results.extend(compliance_results)
-            
+
             # Check onboarding progression
             progression_results = self._validate_onboarding_progression(onboarding_data)
             results.extend(progression_results)
-            
+
             # Add overall success result if no critical errors
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
                 success_result = self._create_result(
@@ -105,10 +135,10 @@ class OnboardingValidator(BaseValidator):
                     status=ValidationStatus.PASSED,
                     severity=ValidationSeverity.INFO,
                     message="Onboarding validation passed successfully",
-                    details={"total_checks": len(results)}
+                    details={"total_checks": len(results)},
                 )
                 results.append(success_result)
-            
+
         except Exception as e:
             error_result = self._create_result(
                 rule_id="onboarding_validation_error",
@@ -116,16 +146,18 @@ class OnboardingValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.CRITICAL,
                 message=f"Onboarding validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
+                details={"error_type": type(e).__name__},
             )
             results.append(error_result)
-        
+
         return results
-    
-    def _validate_onboarding_structure(self, onboarding_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_onboarding_structure(
+        self, onboarding_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate onboarding data structure and format"""
         results = []
-        
+
         if not isinstance(onboarding_data, dict):
             result = self._create_result(
                 rule_id="onboarding_type",
@@ -134,11 +166,11 @@ class OnboardingValidator(BaseValidator):
                 severity=ValidationSeverity.ERROR,
                 message="Onboarding data must be a dictionary",
                 actual_value=type(onboarding_data).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         if len(onboarding_data) == 0:
             result = self._create_result(
                 rule_id="onboarding_empty",
@@ -147,12 +179,12 @@ class OnboardingValidator(BaseValidator):
                 severity=ValidationSeverity.WARNING,
                 message="Onboarding data is empty",
                 actual_value=onboarding_data,
-                expected_value="non-empty onboarding data"
+                expected_value="non-empty onboarding data",
             )
             results.append(result)
-        
+
         return results
-    
+
     def _validate_onboarding_stage(self, stage: Any) -> Optional[ValidationResult]:
         """Validate onboarding stage value"""
         if not isinstance(stage, str):
@@ -164,9 +196,9 @@ class OnboardingValidator(BaseValidator):
                 message="Onboarding stage must be a string",
                 field_path="stage",
                 actual_value=type(stage).__name__,
-                expected_value="str"
+                expected_value="str",
             )
-        
+
         if stage.lower() not in self.onboarding_stages:
             return self._create_result(
                 rule_id="stage_invalid",
@@ -176,15 +208,15 @@ class OnboardingValidator(BaseValidator):
                 message=f"Invalid onboarding stage: {stage}",
                 field_path="stage",
                 actual_value=stage,
-                expected_value=f"one of {self.onboarding_stages}"
+                expected_value=f"one of {self.onboarding_stages}",
             )
-        
+
         return None
-    
+
     def _validate_onboarding_flow(self, flow: Any) -> List[ValidationResult]:
         """Validate onboarding flow data"""
         results = []
-        
+
         if not isinstance(flow, dict):
             result = self._create_result(
                 rule_id="flow_type",
@@ -194,11 +226,11 @@ class OnboardingValidator(BaseValidator):
                 message="Onboarding flow must be a dictionary",
                 field_path="flow",
                 actual_value=type(flow).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate stages if present
         if "stages" in flow:
             stages = flow["stages"]
@@ -212,7 +244,7 @@ class OnboardingValidator(BaseValidator):
                         message="Onboarding flow must have at least one stage",
                         field_path="flow.stages",
                         actual_value=stages,
-                        expected_value="non-empty list of stages"
+                        expected_value="non-empty list of stages",
                     )
                     results.append(result)
                 else:
@@ -227,18 +259,22 @@ class OnboardingValidator(BaseValidator):
                                 message=f"Flow stage {i} must be a dictionary",
                                 field_path=f"flow.stages[{i}]",
                                 actual_value=type(stage).__name__,
-                                expected_value="dict"
+                                expected_value="dict",
                             )
                             results.append(result)
                             continue
-                        
+
                         # Validate required stage fields
                         stage_required_fields = ["name", "order", "required"]
-                        stage_field_results = self._validate_required_fields(stage, stage_required_fields)
+                        stage_field_results = self._validate_required_fields(
+                            stage, stage_required_fields
+                        )
                         for stage_result in stage_field_results:
-                            stage_result.field_path = f"flow.stages[{i}].{stage_result.field_path}"
+                            stage_result.field_path = (
+                                f"flow.stages[{i}].{stage_result.field_path}"
+                            )
                         results.extend(stage_field_results)
-                        
+
                         # Validate stage order
                         if "order" in stage:
                             order = stage["order"]
@@ -252,16 +288,16 @@ class OnboardingValidator(BaseValidator):
                                         message=f"Flow stage {i} order must be greater than 0",
                                         field_path=f"flow.stages[{i}].order",
                                         actual_value=order,
-                                        expected_value="> 0"
+                                        expected_value="> 0",
                                     )
                                     results.append(result)
-        
+
         return results
-    
+
     def _validate_verification(self, verification: Any) -> List[ValidationResult]:
         """Validate verification data"""
         results = []
-        
+
         if not isinstance(verification, dict):
             result = self._create_result(
                 rule_id="verification_type",
@@ -271,11 +307,11 @@ class OnboardingValidator(BaseValidator):
                 message="Verification data must be a dictionary",
                 field_path="verification",
                 actual_value=type(verification).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate verification method if present
         if "method" in verification:
             method = verification["method"]
@@ -289,15 +325,21 @@ class OnboardingValidator(BaseValidator):
                         message=f"Invalid verification method: {method}",
                         field_path="verification.method",
                         actual_value=method,
-                        expected_value=f"one of {self.verification_methods}"
+                        expected_value=f"one of {self.verification_methods}",
                     )
                     results.append(result)
-        
+
         # Validate verification status if present
         if "status" in verification:
             status = verification["status"]
-            valid_statuses = ["pending", "in_progress", "completed", "failed", "expired"]
-            
+            valid_statuses = [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "expired",
+            ]
+
             if isinstance(status, str):
                 if status.lower() not in valid_statuses:
                     result = self._create_result(
@@ -308,10 +350,10 @@ class OnboardingValidator(BaseValidator):
                         message=f"Invalid verification status: {status}",
                         field_path="verification.status",
                         actual_value=status,
-                        expected_value=f"one of {valid_statuses}"
+                        expected_value=f"one of {valid_statuses}",
                     )
                     results.append(result)
-        
+
         # Validate verification attempts if present
         if "attempts" in verification:
             attempts = verification["attempts"]
@@ -325,16 +367,16 @@ class OnboardingValidator(BaseValidator):
                         message="Verification attempts cannot be negative",
                         field_path="verification.attempts",
                         actual_value=attempts,
-                        expected_value=">= 0"
+                        expected_value=">= 0",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def _validate_compliance(self, compliance: Any) -> List[ValidationResult]:
         """Validate compliance data"""
         results = []
-        
+
         if not isinstance(compliance, dict):
             result = self._create_result(
                 rule_id="compliance_type",
@@ -344,11 +386,11 @@ class OnboardingValidator(BaseValidator):
                 message="Compliance data must be a dictionary",
                 field_path="compliance",
                 actual_value=type(compliance).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate required compliance fields if present
         if "required_fields" in compliance:
             required_fields = compliance["required_fields"]
@@ -362,7 +404,7 @@ class OnboardingValidator(BaseValidator):
                         message="No required compliance fields specified",
                         field_path="compliance.required_fields",
                         actual_value=required_fields,
-                        expected_value="non-empty list of required fields"
+                        expected_value="non-empty list of required fields",
                     )
                     results.append(result)
                 else:
@@ -377,15 +419,21 @@ class OnboardingValidator(BaseValidator):
                                 message=f"Compliance field {i} must be a string",
                                 field_path=f"compliance.required_fields[{i}]",
                                 actual_value=type(field).__name__,
-                                expected_value="str"
+                                expected_value="str",
                             )
                             results.append(result)
-        
+
         # Validate compliance status if present
         if "status" in compliance:
             status = compliance["status"]
-            valid_statuses = ["pending", "in_review", "approved", "rejected", "requires_action"]
-            
+            valid_statuses = [
+                "pending",
+                "in_review",
+                "approved",
+                "rejected",
+                "requires_action",
+            ]
+
             if isinstance(status, str):
                 if status.lower() not in valid_statuses:
                     result = self._create_result(
@@ -396,25 +444,27 @@ class OnboardingValidator(BaseValidator):
                         message=f"Invalid compliance status: {status}",
                         field_path="compliance.status",
                         actual_value=status,
-                        expected_value=f"one of {valid_statuses}"
+                        expected_value=f"one of {valid_statuses}",
                     )
                     results.append(result)
-        
+
         return results
-    
-    def _validate_onboarding_progression(self, onboarding_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_onboarding_progression(
+        self, onboarding_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate onboarding progression logic"""
         results = []
-        
+
         # Check if current stage is valid for the current status
         if "stage" in onboarding_data and "status" in onboarding_data:
             stage = onboarding_data["stage"]
             status = onboarding_data["status"]
-            
+
             if isinstance(stage, str) and isinstance(status, str):
                 stage_lower = stage.lower()
                 status_lower = status.lower()
-                
+
                 # Validate stage progression logic
                 if stage_lower == "completion" and status_lower != "completed":
                     result = self._create_result(
@@ -425,10 +475,10 @@ class OnboardingValidator(BaseValidator):
                         message="Completion stage should have 'completed' status",
                         field_path="stage",
                         actual_value=f"stage: {stage}, status: {status}",
-                        expected_value="status: completed for completion stage"
+                        expected_value="status: completed for completion stage",
                     )
                     results.append(result)
-                
+
                 # Check if stage is in valid progression order
                 if stage_lower in self.onboarding_stages:
                     stage_index = self.onboarding_stages.index(stage_lower)
@@ -447,15 +497,15 @@ class OnboardingValidator(BaseValidator):
                                             message=f"Stage '{stage}' reached before completing '{prev_stage}'",
                                             field_path="stage",
                                             actual_value=f"current: {stage}, missing: {prev_stage}",
-                                            expected_value=f"complete {prev_stage} before {stage}"
+                                            expected_value=f"complete {prev_stage} before {stage}",
                                         )
                                         results.append(result)
-        
+
         # Check if required fields are completed for current stage
         if "stage" in onboarding_data and "required_fields" in onboarding_data:
             stage = onboarding_data["stage"]
             required_fields = onboarding_data["required_fields"]
-            
+
             if isinstance(required_fields, dict) and isinstance(stage, str):
                 stage_requirements = required_fields.get(stage.lower(), [])
                 if isinstance(stage_requirements, list) and len(stage_requirements) > 0:
@@ -463,7 +513,11 @@ class OnboardingValidator(BaseValidator):
                     if "completed_fields" in onboarding_data:
                         completed_fields = onboarding_data["completed_fields"]
                         if isinstance(completed_fields, list):
-                            missing_fields = [field for field in stage_requirements if field not in completed_fields]
+                            missing_fields = [
+                                field
+                                for field in stage_requirements
+                                if field not in completed_fields
+                            ]
                             if missing_fields:
                                 result = self._create_result(
                                     rule_id="required_fields_incomplete",
@@ -473,12 +527,12 @@ class OnboardingValidator(BaseValidator):
                                     message=f"Missing required fields for stage '{stage}': {missing_fields}",
                                     field_path="required_fields",
                                     actual_value=f"missing: {missing_fields}",
-                                    expected_value=f"complete all required fields for {stage}"
+                                    expected_value=f"complete all required fields for {stage}",
                                 )
                                 results.append(result)
-        
+
         return results
-    
+
     def add_onboarding_stage(self, stage: str) -> bool:
         """Add a custom onboarding stage"""
         try:
@@ -489,7 +543,7 @@ class OnboardingValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to add onboarding stage: {e}")
             return False
-    
+
     def add_verification_method(self, method: str) -> bool:
         """Add a custom verification method"""
         try:
@@ -500,52 +554,60 @@ class OnboardingValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to add verification method: {e}")
             return False
-    
+
     # V2OnboardingSequenceValidator functionality integration
-    def _wait_for_phase_response(self, session: Dict[str, Any], phase: str, message_id: str, 
-                                phase_timeout: float = 30.0) -> bool:
+    def _wait_for_phase_response(
+        self,
+        session: Dict[str, Any],
+        phase: str,
+        message_id: str,
+        phase_timeout: float = 30.0,
+    ) -> bool:
         """Wait for and validate phase response (from V2OnboardingSequenceValidator)"""
         import time
-        
+
         start = time.time()
         while time.time() - start < phase_timeout:
             time.sleep(0.1)
             # In a real implementation, this would check for actual response
             # For now, return True after timeout for testing/non-interactive environments
             return True
-        
+
         self.logger.warning(
             f"Timeout waiting for response for phase {phase} in session {session.get('session_id', 'unknown')}"
         )
         return False
-    
-    def _validate_onboarding_completion(self, session: Dict[str, Any], 
-                                      role_definitions: Dict[str, Any] = None,
-                                      fsm_core: Any = None) -> bool:
+
+    def _validate_onboarding_completion(
+        self,
+        session: Dict[str, Any],
+        role_definitions: Dict[str, Any] = None,
+        fsm_core: Any = None,
+    ) -> bool:
         """Validate that onboarding has been completed successfully (from V2OnboardingSequenceValidator)"""
         try:
             if not role_definitions:
                 role_definitions = {}
-            
-            agent_id = session.get('agent_id', 'unknown')
-            required_phases = role_definitions.get(agent_id, {}).get('onboarding_phases', [])
-            
+
+            agent_id = session.get("agent_id", "unknown")
+            required_phases = role_definitions.get(agent_id, {}).get(
+                "onboarding_phases", []
+            )
+
             if required_phases:
-                completed_phases = session.get('completed_phases', [])
+                completed_phases = session.get("completed_phases", [])
                 if not all(phase in completed_phases for phase in required_phases):
                     self.logger.warning(
                         f"Not all required phases completed for {agent_id}"
                     )
                     return False
-            
+
             if not self._validate_performance_metrics(session):
-                self.logger.warning(
-                    f"Performance validation failed for {agent_id}"
-                )
+                self.logger.warning(f"Performance validation failed for {agent_id}")
                 return False
-            
+
             # Create FSM task if FSM core is available
-            if fsm_core and hasattr(fsm_core, 'create_task'):
+            if fsm_core and hasattr(fsm_core, "create_task"):
                 try:
                     fsm_core.create_task(
                         title=f"Onboarding Completion - {agent_id}",
@@ -556,44 +618,44 @@ class OnboardingValidator(BaseValidator):
                     )
                 except Exception as e:
                     self.logger.warning(f"Failed to create FSM task: {e}")
-            
+
             return True
-            
+
         except Exception as e:
             self.logger.error(f"Onboarding completion validation failed: {e}")
             return False
-    
+
     def _validate_performance_metrics(self, session: Dict[str, Any]) -> bool:
         """Validate performance metrics for onboarding completion (from V2OnboardingSequenceValidator)"""
         try:
             # Basic performance validation - can be extended
-            performance_data = session.get('performance_metrics', {})
-            
+            performance_data = session.get("performance_metrics", {})
+
             # Check if required metrics are present
-            required_metrics = ['completion_time', 'success_rate', 'error_count']
+            required_metrics = ["completion_time", "success_rate", "error_count"]
             for metric in required_metrics:
                 if metric not in performance_data:
                     self.logger.warning(f"Missing performance metric: {metric}")
                     return False
-            
+
             # Validate metric values
-            completion_time = performance_data.get('completion_time', 0)
+            completion_time = performance_data.get("completion_time", 0)
             if completion_time < 0:
                 self.logger.warning("Completion time cannot be negative")
                 return False
-            
-            success_rate = performance_data.get('success_rate', 0)
+
+            success_rate = performance_data.get("success_rate", 0)
             if not (0 <= success_rate <= 100):
                 self.logger.warning("Success rate must be between 0 and 100")
                 return False
-            
-            error_count = performance_data.get('error_count', 0)
+
+            error_count = performance_data.get("error_count", 0)
             if error_count < 0:
                 self.logger.warning("Error count cannot be negative")
                 return False
-            
+
             return True
-            
+
         except Exception as e:
             self.logger.error(f"Performance metrics validation failed: {e}")
             return False

--- a/src/core/validation/quality_validator.py
+++ b/src/core/validation/quality_validator.py
@@ -6,13 +6,19 @@ and following the unified validation framework patterns.
 """
 
 from typing import Dict, List, Any, Optional
-from .base_validator import BaseValidator, ValidationRule, ValidationSeverity, ValidationStatus, ValidationResult
+from .base_validator import (
+    BaseValidator,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+    ValidationResult,
+)
 import time
 
 
 class QualityValidator(BaseValidator):
     """Validates code quality metrics and standards using unified validation framework"""
-    
+
     def __init__(self):
         """Initialize quality validator"""
         super().__init__("QualityValidator")
@@ -24,9 +30,9 @@ class QualityValidator(BaseValidator):
             "documentation_coverage": 70.0,
             "max_function_length": 50,
             "max_class_length": 500,
-            "max_file_length": 400
+            "max_file_length": 400,
         }
-    
+
     def _setup_default_rules(self) -> None:
         """Setup default quality validation rules"""
         default_rules = [
@@ -35,68 +41,85 @@ class QualityValidator(BaseValidator):
                 rule_name="Quality Metrics",
                 rule_type="quality",
                 description="Validate code quality metrics against thresholds",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="complexity_analysis",
                 rule_name="Complexity Analysis",
                 rule_type="quality",
                 description="Check cyclomatic complexity and maintainability",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="duplication_check",
                 rule_name="Duplication Check",
                 rule_type="quality",
                 description="Identify code duplication patterns",
-                severity=ValidationSeverity.WARNING
+                severity=ValidationSeverity.WARNING,
             ),
             ValidationRule(
                 rule_id="test_coverage_validation",
                 rule_name="Test Coverage Validation",
                 rule_type="quality",
                 description="Validate test coverage requirements",
-                severity=ValidationSeverity.WARNING
-            )
+                severity=ValidationSeverity.WARNING,
+            ),
         ]
-        
+
         for rule in default_rules:
             self.add_validation_rule(rule)
-    
-    def validate(self, quality_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
-        """Validate quality data and return validation results"""
+
+    def validate(
+        self, quality_data: Dict[str, Any], **kwargs
+    ) -> List[ValidationResult]:
+        """Validate quality data and return validation results.
+
+        Returns:
+            List[ValidationResult]: Validation results produced during quality
+            validation.
+        """
         results = []
-        
+
         try:
             # Validate quality data structure
             structure_results = self._validate_quality_structure(quality_data)
             results.extend(structure_results)
-            
+
             # Validate required fields
             required_fields = ["file_path", "metrics", "timestamp"]
-            field_results = self._validate_required_fields(quality_data, required_fields)
+            field_results = self._validate_required_fields(
+                quality_data, required_fields
+            )
             results.extend(field_results)
-            
+
             # Validate quality metrics if present
             if "metrics" in quality_data:
-                metrics_results = self._validate_quality_metrics(quality_data["metrics"])
+                metrics_results = self._validate_quality_metrics(
+                    quality_data["metrics"]
+                )
                 results.extend(metrics_results)
-            
+
             # Validate complexity analysis if present
             if "complexity" in quality_data:
-                complexity_results = self._validate_complexity_analysis(quality_data["complexity"])
+                complexity_results = self._validate_complexity_analysis(
+                    quality_data["complexity"]
+                )
                 results.extend(complexity_results)
-            
+
             # Validate duplication analysis if present
             if "duplication" in quality_data:
-                duplication_results = self._validate_duplication_analysis(quality_data["duplication"])
+                duplication_results = self._validate_duplication_analysis(
+                    quality_data["duplication"]
+                )
                 results.extend(duplication_results)
-            
+
             # Validate test coverage if present
             if "test_coverage" in quality_data:
-                coverage_results = self._validate_test_coverage(quality_data["test_coverage"])
+                coverage_results = self._validate_test_coverage(
+                    quality_data["test_coverage"]
+                )
                 results.extend(coverage_results)
-            
+
             # Add overall success result if no critical errors
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
                 success_result = self._create_result(
@@ -105,10 +128,10 @@ class QualityValidator(BaseValidator):
                     status=ValidationStatus.PASSED,
                     severity=ValidationSeverity.INFO,
                     message="Quality validation passed successfully",
-                    details={"total_checks": len(results)}
+                    details={"total_checks": len(results)},
                 )
                 results.append(success_result)
-            
+
         except Exception as e:
             error_result = self._create_result(
                 rule_id="quality_validation_error",
@@ -116,16 +139,18 @@ class QualityValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.CRITICAL,
                 message=f"Quality validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
+                details={"error_type": type(e).__name__},
             )
             results.append(error_result)
-        
+
         return results
-    
-    def _validate_quality_structure(self, quality_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_quality_structure(
+        self, quality_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate quality data structure and format"""
         results = []
-        
+
         if not isinstance(quality_data, dict):
             result = self._create_result(
                 rule_id="quality_type",
@@ -134,11 +159,11 @@ class QualityValidator(BaseValidator):
                 severity=ValidationSeverity.ERROR,
                 message="Quality data must be a dictionary",
                 actual_value=type(quality_data).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         if len(quality_data) == 0:
             result = self._create_result(
                 rule_id="quality_empty",
@@ -147,16 +172,16 @@ class QualityValidator(BaseValidator):
                 severity=ValidationSeverity.WARNING,
                 message="Quality data is empty",
                 actual_value=quality_data,
-                expected_value="non-empty quality data"
+                expected_value="non-empty quality data",
             )
             results.append(result)
-        
+
         return results
-    
+
     def _validate_quality_metrics(self, metrics: Any) -> List[ValidationResult]:
         """Validate quality metrics against thresholds"""
         results = []
-        
+
         if not isinstance(metrics, dict):
             result = self._create_result(
                 rule_id="metrics_type",
@@ -166,11 +191,11 @@ class QualityValidator(BaseValidator):
                 message="Metrics must be a dictionary",
                 field_path="metrics",
                 actual_value=type(metrics).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate each metric against thresholds
         for metric_name, metric_value in metrics.items():
             if metric_name in self.quality_thresholds:
@@ -180,14 +205,11 @@ class QualityValidator(BaseValidator):
                 )
                 if threshold_result:
                     results.append(threshold_result)
-        
+
         return results
-    
+
     def _validate_metric_threshold(
-        self, 
-        metric_name: str, 
-        metric_value: Any, 
-        threshold: float
+        self, metric_name: str, metric_value: Any, threshold: float
     ) -> Optional[ValidationResult]:
         """Validate a single metric against its threshold"""
         if not isinstance(metric_value, (int, float)):
@@ -199,11 +221,16 @@ class QualityValidator(BaseValidator):
                 message=f"Metric '{metric_name}' must be numeric",
                 field_path=f"metrics.{metric_name}",
                 actual_value=type(metric_value).__name__,
-                expected_value="numeric value"
+                expected_value="numeric value",
             )
-        
+
         # Different validation logic based on metric type
-        if metric_name in ["cyclomatic_complexity", "max_function_length", "max_class_length", "max_file_length"]:
+        if metric_name in [
+            "cyclomatic_complexity",
+            "max_function_length",
+            "max_class_length",
+            "max_file_length",
+        ]:
             # These should be <= threshold
             if metric_value > threshold:
                 return self._create_result(
@@ -214,10 +241,14 @@ class QualityValidator(BaseValidator):
                     message=f"Metric '{metric_name}' exceeds threshold: {metric_value} > {threshold}",
                     field_path=f"metrics.{metric_name}",
                     actual_value=metric_value,
-                    expected_value=f"<= {threshold}"
+                    expected_value=f"<= {threshold}",
                 )
-        
-        elif metric_name in ["maintainability_index", "test_coverage", "documentation_coverage"]:
+
+        elif metric_name in [
+            "maintainability_index",
+            "test_coverage",
+            "documentation_coverage",
+        ]:
             # These should be >= threshold
             if metric_value < threshold:
                 return self._create_result(
@@ -228,9 +259,9 @@ class QualityValidator(BaseValidator):
                     message=f"Metric '{metric_name}' below threshold: {metric_value} < {threshold}",
                     field_path=f"metrics.{metric_name}",
                     actual_value=metric_value,
-                    expected_value=f">= {threshold}"
+                    expected_value=f">= {threshold}",
                 )
-        
+
         elif metric_name == "code_duplication":
             # This should be <= threshold (percentage)
             if metric_value > threshold:
@@ -242,15 +273,15 @@ class QualityValidator(BaseValidator):
                     message=f"Code duplication exceeds threshold: {metric_value}% > {threshold}%",
                     field_path=f"metrics.{metric_name}",
                     actual_value=f"{metric_value}%",
-                    expected_value=f"<= {threshold}%"
+                    expected_value=f"<= {threshold}%",
                 )
-        
+
         return None
-    
+
     def _validate_complexity_analysis(self, complexity: Any) -> List[ValidationResult]:
         """Validate complexity analysis data"""
         results = []
-        
+
         if not isinstance(complexity, dict):
             result = self._create_result(
                 rule_id="complexity_type",
@@ -260,11 +291,11 @@ class QualityValidator(BaseValidator):
                 message="Complexity data must be a dictionary",
                 field_path="complexity",
                 actual_value=type(complexity).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate cyclomatic complexity if present
         if "cyclomatic_complexity" in complexity:
             cc_value = complexity["cyclomatic_complexity"]
@@ -278,10 +309,10 @@ class QualityValidator(BaseValidator):
                         message=f"Cyclomatic complexity too high: {cc_value}",
                         field_path="complexity.cyclomatic_complexity",
                         actual_value=cc_value,
-                        expected_value=f"<= {self.quality_thresholds['cyclomatic_complexity']}"
+                        expected_value=f"<= {self.quality_thresholds['cyclomatic_complexity']}",
                     )
                     results.append(result)
-        
+
         # Validate maintainability index if present
         if "maintainability_index" in complexity:
             mi_value = complexity["maintainability_index"]
@@ -295,16 +326,18 @@ class QualityValidator(BaseValidator):
                         message=f"Maintainability index too low: {mi_value}",
                         field_path="complexity.maintainability_index",
                         actual_value=mi_value,
-                        expected_value=f">= {self.quality_thresholds['maintainability_index']}"
+                        expected_value=f">= {self.quality_thresholds['maintainability_index']}",
                     )
                     results.append(result)
-        
+
         return results
-    
-    def _validate_duplication_analysis(self, duplication: Any) -> List[ValidationResult]:
+
+    def _validate_duplication_analysis(
+        self, duplication: Any
+    ) -> List[ValidationResult]:
         """Validate duplication analysis data"""
         results = []
-        
+
         if not isinstance(duplication, dict):
             result = self._create_result(
                 rule_id="duplication_type",
@@ -314,11 +347,11 @@ class QualityValidator(BaseValidator):
                 message="Duplication data must be a dictionary",
                 field_path="duplication",
                 actual_value=type(duplication).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate duplication percentage if present
         if "percentage" in duplication:
             dup_percentage = duplication["percentage"]
@@ -332,10 +365,10 @@ class QualityValidator(BaseValidator):
                         message=f"Code duplication too high: {dup_percentage}%",
                         field_path="duplication.percentage",
                         actual_value=f"{dup_percentage}%",
-                        expected_value=f"<= {self.quality_thresholds['code_duplication']}%"
+                        expected_value=f"<= {self.quality_thresholds['code_duplication']}%",
                     )
                     results.append(result)
-        
+
         # Validate duplicate blocks if present
         if "duplicate_blocks" in duplication:
             dup_blocks = duplication["duplicate_blocks"]
@@ -349,16 +382,16 @@ class QualityValidator(BaseValidator):
                         message=f"Found {len(dup_blocks)} duplicate code blocks",
                         field_path="duplication.duplicate_blocks",
                         actual_value=len(dup_blocks),
-                        expected_value="0 duplicate blocks"
+                        expected_value="0 duplicate blocks",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def _validate_test_coverage(self, test_coverage: Any) -> List[ValidationResult]:
         """Validate test coverage data"""
         results = []
-        
+
         if not isinstance(test_coverage, dict):
             result = self._create_result(
                 rule_id="test_coverage_type",
@@ -368,11 +401,11 @@ class QualityValidator(BaseValidator):
                 message="Test coverage data must be a dictionary",
                 field_path="test_coverage",
                 actual_value=type(test_coverage).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate overall coverage if present
         if "overall" in test_coverage:
             overall_coverage = test_coverage["overall"]
@@ -386,10 +419,10 @@ class QualityValidator(BaseValidator):
                         message=f"Test coverage too low: {overall_coverage}%",
                         field_path="test_coverage.overall",
                         actual_value=f"{overall_coverage}%",
-                        expected_value=f">= {self.quality_thresholds['test_coverage']}%"
+                        expected_value=f">= {self.quality_thresholds['test_coverage']}%",
                     )
                     results.append(result)
-        
+
         # Validate line coverage if present
         if "line_coverage" in test_coverage:
             line_coverage = test_coverage["line_coverage"]
@@ -403,18 +436,20 @@ class QualityValidator(BaseValidator):
                         message=f"Line coverage too low: {line_coverage}%",
                         field_path="test_coverage.line_coverage",
                         actual_value=f"{line_coverage}%",
-                        expected_value=f">= {self.quality_thresholds['test_coverage']}%"
+                        expected_value=f">= {self.quality_thresholds['test_coverage']}%",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def set_quality_threshold(self, metric_name: str, threshold: float) -> bool:
         """Set a custom quality threshold for a metric"""
         try:
             if metric_name in self.quality_thresholds:
                 self.quality_thresholds[metric_name] = threshold
-                self.logger.info(f"Quality threshold updated: {metric_name} = {threshold}")
+                self.logger.info(
+                    f"Quality threshold updated: {metric_name} = {threshold}"
+                )
                 return True
             else:
                 self.logger.warning(f"Unknown metric: {metric_name}")
@@ -422,98 +457,110 @@ class QualityValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to set quality threshold: {e}")
             return False
-    
+
     def get_quality_thresholds(self) -> Dict[str, float]:
         """Get current quality thresholds"""
         return self.quality_thresholds.copy()
-    
+
     # Quality validation functionality integration (from duplicate quality_validator.py)
-    def validate_service_quality_legacy(self, service_id: str, quality_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def validate_service_quality_legacy(
+        self, service_id: str, quality_data: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         """Legacy service quality validation method (from duplicate quality_validator.py)"""
         try:
             validation_results = []
             current_time = time.time()
-            
+
             # Check test coverage
             if "test_coverage" in quality_data:
                 test_coverage = quality_data["test_coverage"]
                 if isinstance(test_coverage, (int, float)):
                     if test_coverage < 80.0:
-                        validation_results.append({
-                            "validation_id": f"validation_{service_id}_test_coverage_{int(current_time)}",
-                            "rule_id": "test_coverage_min",
-                            "service_id": service_id,
-                            "status": "failed",
-                            "timestamp": current_time,
-                            "actual_value": test_coverage,
-                            "expected_value": 80.0,
-                            "message": f"Test coverage {test_coverage}% below threshold 80%",
-                            "details": {
-                                "rule_name": "Minimum Test Coverage",
-                                "rule_type": "coverage",
-                                "severity": "high"
+                        validation_results.append(
+                            {
+                                "validation_id": f"validation_{service_id}_test_coverage_{int(current_time)}",
+                                "rule_id": "test_coverage_min",
+                                "service_id": service_id,
+                                "status": "failed",
+                                "timestamp": current_time,
+                                "actual_value": test_coverage,
+                                "expected_value": 80.0,
+                                "message": f"Test coverage {test_coverage}% below threshold 80%",
+                                "details": {
+                                    "rule_name": "Minimum Test Coverage",
+                                    "rule_type": "coverage",
+                                    "severity": "high",
+                                },
                             }
-                        })
+                        )
                     else:
-                        validation_results.append({
-                            "validation_id": f"validation_{service_id}_test_coverage_{int(current_time)}",
-                            "rule_id": "test_coverage_min",
-                            "service_id": service_id,
-                            "status": "passed",
-                            "timestamp": current_time,
-                            "actual_value": test_coverage,
-                            "expected_value": 80.0,
-                            "message": f"Test coverage {test_coverage}% meets threshold 80%",
-                            "details": {
-                                "rule_name": "Minimum Test Coverage",
-                                "rule_type": "coverage",
-                                "severity": "high"
+                        validation_results.append(
+                            {
+                                "validation_id": f"validation_{service_id}_test_coverage_{int(current_time)}",
+                                "rule_id": "test_coverage_min",
+                                "service_id": service_id,
+                                "status": "passed",
+                                "timestamp": current_time,
+                                "actual_value": test_coverage,
+                                "expected_value": 80.0,
+                                "message": f"Test coverage {test_coverage}% meets threshold 80%",
+                                "details": {
+                                    "rule_name": "Minimum Test Coverage",
+                                    "rule_type": "coverage",
+                                    "severity": "high",
+                                },
                             }
-                        })
-            
+                        )
+
             # Check code quality
             if "code_quality" in quality_data:
                 code_quality = quality_data["code_quality"]
                 if isinstance(code_quality, (int, float)):
                     if code_quality < 7.0:
-                        validation_results.append({
-                            "validation_id": f"validation_{service_id}_code_quality_{int(current_time)}",
-                            "rule_id": "code_quality_min",
-                            "service_id": service_id,
-                            "status": "failed",
-                            "timestamp": current_time,
-                            "actual_value": code_quality,
-                            "expected_value": 7.0,
-                            "message": f"Code quality {code_quality} below threshold 7.0",
-                            "details": {
-                                "rule_name": "Minimum Code Quality",
-                                "rule_type": "quality",
-                                "severity": "medium"
+                        validation_results.append(
+                            {
+                                "validation_id": f"validation_{service_id}_code_quality_{int(current_time)}",
+                                "rule_id": "code_quality_min",
+                                "service_id": service_id,
+                                "status": "failed",
+                                "timestamp": current_time,
+                                "actual_value": code_quality,
+                                "expected_value": 7.0,
+                                "message": f"Code quality {code_quality} below threshold 7.0",
+                                "details": {
+                                    "rule_name": "Minimum Code Quality",
+                                    "rule_type": "quality",
+                                    "severity": "medium",
+                                },
                             }
-                        })
+                        )
                     else:
-                        validation_results.append({
-                            "validation_id": f"validation_{service_id}_code_quality_{int(current_time)}",
-                            "rule_id": "code_quality_min",
-                            "service_id": service_id,
-                            "status": "passed",
-                            "timestamp": current_time,
-                            "actual_value": code_quality,
-                            "expected_value": 7.0,
-                            "message": f"Code quality {code_quality} meets threshold 7.0",
-                            "details": {
-                                "rule_name": "Minimum Code Quality",
-                                "rule_type": "quality",
-                                "severity": "medium"
+                        validation_results.append(
+                            {
+                                "validation_id": f"validation_{service_id}_code_quality_{int(current_time)}",
+                                "rule_id": "code_quality_min",
+                                "service_id": service_id,
+                                "status": "passed",
+                                "timestamp": current_time,
+                                "actual_value": code_quality,
+                                "expected_value": 7.0,
+                                "message": f"Code quality {code_quality} meets threshold 7.0",
+                                "details": {
+                                    "rule_name": "Minimum Code Quality",
+                                    "rule_type": "quality",
+                                    "severity": "medium",
+                                },
                             }
-                        })
-            
+                        )
+
             return validation_results
-            
+
         except Exception as e:
-            self.logger.error(f"Failed to validate service quality for {service_id}: {e}")
+            self.logger.error(
+                f"Failed to validate service quality for {service_id}: {e}"
+            )
             return []
-    
+
     def get_validation_summary_legacy(self, service_id: str = None) -> Dict[str, Any]:
         """Get legacy validation summary statistics"""
         try:
@@ -526,14 +573,15 @@ class QualityValidator(BaseValidator):
                 "warnings": 0,
                 "pending": 0,
                 "pass_rate": 0.0,
-                "note": "Legacy validation summary - implement based on stored results"
+                "note": "Legacy validation summary - implement based on stored results",
             }
-            
+
         except Exception as e:
             self.logger.error(f"Failed to get legacy validation summary: {e}")
             return {"error": str(e)}
-    
+
     def _get_current_timestamp(self) -> str:
         """Get current timestamp in ISO format"""
         from datetime import datetime
+
         return datetime.now().isoformat()

--- a/src/core/validation/security_validator.py
+++ b/src/core/validation/security_validator.py
@@ -7,12 +7,18 @@ and following the unified validation framework patterns.
 
 import re
 from typing import Dict, List, Any, Optional
-from .base_validator import BaseValidator, ValidationRule, ValidationSeverity, ValidationStatus, ValidationResult
+from .base_validator import (
+    BaseValidator,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+    ValidationResult,
+)
 
 
 class SecurityValidator(BaseValidator):
     """Validates security-related data and configurations using unified validation framework"""
-    
+
     def __init__(self):
         """Initialize security validator"""
         super().__init__("SecurityValidator")
@@ -21,14 +27,22 @@ class SecurityValidator(BaseValidator):
             "jwt_token": r"^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$",
             "uuid": r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
             "email": r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$",
-            "ip_address": r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+            "ip_address": r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
         }
-        
+
         self.sensitive_fields = [
-            "password", "secret", "key", "token", "credential", "auth",
-            "private", "sensitive", "confidential", "secure"
+            "password",
+            "secret",
+            "key",
+            "token",
+            "credential",
+            "auth",
+            "private",
+            "sensitive",
+            "confidential",
+            "secure",
         ]
-    
+
     def _setup_default_rules(self) -> None:
         """Setup default security validation rules"""
         default_rules = [
@@ -37,73 +51,90 @@ class SecurityValidator(BaseValidator):
                 rule_name="Security Structure",
                 rule_type="security",
                 description="Validate security data structure and format",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="authentication_validation",
                 rule_name="Authentication Validation",
                 rule_type="security",
                 description="Validate authentication mechanisms and credentials",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="authorization_check",
                 rule_name="Authorization Check",
                 rule_type="security",
                 description="Validate authorization rules and permissions",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="data_encryption_validation",
                 rule_name="Data Encryption Validation",
                 rule_type="security",
                 description="Validate encryption methods and key management",
-                severity=ValidationSeverity.WARNING
-            )
+                severity=ValidationSeverity.WARNING,
+            ),
         ]
-        
+
         for rule in default_rules:
             self.add_validation_rule(rule)
-    
-    def validate(self, security_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
-        """Validate security data and return validation results"""
+
+    def validate(
+        self, security_data: Dict[str, Any], **kwargs
+    ) -> List[ValidationResult]:
+        """Validate security data and return validation results.
+
+        Returns:
+            List[ValidationResult]: Validation results produced during security
+            validation.
+        """
         results = []
-        
+
         try:
             # Validate security data structure
             structure_results = self._validate_security_structure(security_data)
             results.extend(structure_results)
-            
+
             # Validate required fields
             required_fields = ["security_level", "authentication_method", "timestamp"]
-            field_results = self._validate_required_fields(security_data, required_fields)
+            field_results = self._validate_required_fields(
+                security_data, required_fields
+            )
             results.extend(field_results)
-            
+
             # Validate security level if present
             if "security_level" in security_data:
-                level_result = self._validate_security_level(security_data["security_level"])
+                level_result = self._validate_security_level(
+                    security_data["security_level"]
+                )
                 if level_result:
                     results.append(level_result)
-            
+
             # Validate authentication if present
             if "authentication" in security_data:
-                auth_results = self._validate_authentication(security_data["authentication"])
+                auth_results = self._validate_authentication(
+                    security_data["authentication"]
+                )
                 results.extend(auth_results)
-            
+
             # Validate authorization if present
             if "authorization" in security_data:
-                authz_results = self._validate_authorization(security_data["authorization"])
+                authz_results = self._validate_authorization(
+                    security_data["authorization"]
+                )
                 results.extend(authz_results)
-            
+
             # Validate encryption if present
             if "encryption" in security_data:
-                encryption_results = self._validate_encryption(security_data["encryption"])
+                encryption_results = self._validate_encryption(
+                    security_data["encryption"]
+                )
                 results.extend(encryption_results)
-            
+
             # Check for sensitive data exposure
             exposure_results = self._check_sensitive_data_exposure(security_data)
             results.extend(exposure_results)
-            
+
             # Add overall success result if no critical errors
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
                 success_result = self._create_result(
@@ -112,10 +143,10 @@ class SecurityValidator(BaseValidator):
                     status=ValidationStatus.PASSED,
                     severity=ValidationSeverity.INFO,
                     message="Security validation passed successfully",
-                    details={"total_checks": len(results)}
+                    details={"total_checks": len(results)},
                 )
                 results.append(success_result)
-            
+
         except Exception as e:
             error_result = self._create_result(
                 rule_id="security_validation_error",
@@ -123,16 +154,18 @@ class SecurityValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.CRITICAL,
                 message=f"Security validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
+                details={"error_type": type(e).__name__},
             )
             results.append(error_result)
-        
+
         return results
-    
-    def _validate_security_structure(self, security_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_security_structure(
+        self, security_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate security data structure and format"""
         results = []
-        
+
         if not isinstance(security_data, dict):
             result = self._create_result(
                 rule_id="security_type",
@@ -141,11 +174,11 @@ class SecurityValidator(BaseValidator):
                 severity=ValidationSeverity.ERROR,
                 message="Security data must be a dictionary",
                 actual_value=type(security_data).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         if len(security_data) == 0:
             result = self._create_result(
                 rule_id="security_empty",
@@ -154,16 +187,18 @@ class SecurityValidator(BaseValidator):
                 severity=ValidationSeverity.WARNING,
                 message="Security data is empty",
                 actual_value=security_data,
-                expected_value="non-empty security data"
+                expected_value="non-empty security data",
             )
             results.append(result)
-        
+
         return results
-    
-    def _validate_security_level(self, security_level: Any) -> Optional[ValidationResult]:
+
+    def _validate_security_level(
+        self, security_level: Any
+    ) -> Optional[ValidationResult]:
         """Validate security level value"""
         valid_levels = ["low", "medium", "high", "critical"]
-        
+
         if not isinstance(security_level, str):
             return self._create_result(
                 rule_id="security_level_type",
@@ -173,9 +208,9 @@ class SecurityValidator(BaseValidator):
                 message="Security level must be a string",
                 field_path="security_level",
                 actual_value=type(security_level).__name__,
-                expected_value="str"
+                expected_value="str",
             )
-        
+
         if security_level.lower() not in valid_levels:
             return self._create_result(
                 rule_id="security_level_value",
@@ -185,15 +220,15 @@ class SecurityValidator(BaseValidator):
                 message=f"Invalid security level: {security_level}",
                 field_path="security_level",
                 actual_value=security_level,
-                expected_value=f"one of {valid_levels}"
+                expected_value=f"one of {valid_levels}",
             )
-        
+
         return None
-    
+
     def _validate_authentication(self, authentication: Any) -> List[ValidationResult]:
         """Validate authentication data"""
         results = []
-        
+
         if not isinstance(authentication, dict):
             result = self._create_result(
                 rule_id="authentication_type",
@@ -203,16 +238,24 @@ class SecurityValidator(BaseValidator):
                 message="Authentication data must be a dictionary",
                 field_path="authentication",
                 actual_value=type(authentication).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate authentication method
         if "method" in authentication:
             method = authentication["method"]
-            valid_methods = ["password", "token", "oauth", "saml", "ldap", "mfa", "biometric"]
-            
+            valid_methods = [
+                "password",
+                "token",
+                "oauth",
+                "saml",
+                "ldap",
+                "mfa",
+                "biometric",
+            ]
+
             if not isinstance(method, str):
                 result = self._create_result(
                     rule_id="auth_method_type",
@@ -222,7 +265,7 @@ class SecurityValidator(BaseValidator):
                     message="Authentication method must be a string",
                     field_path="authentication.method",
                     actual_value=type(method).__name__,
-                    expected_value="str"
+                    expected_value="str",
                 )
                 results.append(result)
             elif method.lower() not in valid_methods:
@@ -234,24 +277,26 @@ class SecurityValidator(BaseValidator):
                     message=f"Invalid authentication method: {method}",
                     field_path="authentication.method",
                     actual_value=method,
-                    expected_value=f"one of {valid_methods}"
+                    expected_value=f"one of {valid_methods}",
                 )
                 results.append(result)
-        
+
         # Validate credentials if present
         if "credentials" in authentication:
             creds = authentication["credentials"]
             cred_results = self._validate_credentials(creds)
             for cred_result in cred_results:
-                cred_result.field_path = f"authentication.credentials.{cred_result.field_path}"
+                cred_result.field_path = (
+                    f"authentication.credentials.{cred_result.field_path}"
+                )
             results.extend(cred_results)
-        
+
         return results
-    
+
     def _validate_credentials(self, credentials: Any) -> List[ValidationResult]:
         """Validate credential data"""
         results = []
-        
+
         if not isinstance(credentials, dict):
             result = self._create_result(
                 rule_id="credentials_type",
@@ -261,11 +306,11 @@ class SecurityValidator(BaseValidator):
                 message="Credentials must be a dictionary",
                 field_path="credentials",
                 actual_value=type(credentials).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Check for password strength if present
         if "password" in credentials:
             password = credentials["password"]
@@ -274,7 +319,7 @@ class SecurityValidator(BaseValidator):
                 if strength_result:
                     strength_result.field_path = "password"
                     results.append(strength_result)
-        
+
         # Check for API key format if present
         if "api_key" in credentials:
             api_key = credentials["api_key"]
@@ -288,12 +333,12 @@ class SecurityValidator(BaseValidator):
                         message="Invalid API key format",
                         field_path="api_key",
                         actual_value=api_key,
-                        expected_value="32-64 character alphanumeric string"
+                        expected_value="32-64 character alphanumeric string",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def _validate_password_strength(self, password: str) -> Optional[ValidationResult]:
         """Validate password strength"""
         if len(password) < 8:
@@ -305,15 +350,15 @@ class SecurityValidator(BaseValidator):
                 message="Password must be at least 8 characters long",
                 field_path="password",
                 actual_value=len(password),
-                expected_value=">= 8"
+                expected_value=">= 8",
             )
-        
+
         # Check for complexity requirements
         has_upper = any(c.isupper() for c in password)
         has_lower = any(c.islower() for c in password)
         has_digit = any(c.isdigit() for c in password)
         has_special = any(c in "!@#$%^&*()_+-=[]{}|;:,.<>?" for c in password)
-        
+
         if not (has_upper and has_lower and has_digit and has_special):
             return self._create_result(
                 rule_id="password_complexity",
@@ -323,15 +368,15 @@ class SecurityValidator(BaseValidator):
                 message="Password must contain uppercase, lowercase, digit, and special character",
                 field_path="password",
                 actual_value="insufficient complexity",
-                expected_value="mixed case, digits, and special characters"
+                expected_value="mixed case, digits, and special characters",
             )
-        
+
         return None
-    
+
     def _validate_authorization(self, authorization: Any) -> List[ValidationResult]:
         """Validate authorization data"""
         results = []
-        
+
         if not isinstance(authorization, dict):
             result = self._create_result(
                 rule_id="authorization_type",
@@ -341,11 +386,11 @@ class SecurityValidator(BaseValidator):
                 message="Authorization data must be a dictionary",
                 field_path="authorization",
                 actual_value=type(authorization).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate roles if present
         if "roles" in authorization:
             roles = authorization["roles"]
@@ -359,7 +404,7 @@ class SecurityValidator(BaseValidator):
                         message="No roles defined for authorization",
                         field_path="authorization.roles",
                         actual_value=roles,
-                        expected_value="non-empty list of roles"
+                        expected_value="non-empty list of roles",
                     )
                     results.append(result)
                 else:
@@ -374,10 +419,10 @@ class SecurityValidator(BaseValidator):
                                 message=f"Role {i} must be a string",
                                 field_path=f"authorization.roles[{i}]",
                                 actual_value=type(role).__name__,
-                                expected_value="str"
+                                expected_value="str",
                             )
                             results.append(result)
-        
+
         # Validate permissions if present
         if "permissions" in authorization:
             permissions = authorization["permissions"]
@@ -391,16 +436,16 @@ class SecurityValidator(BaseValidator):
                         message="No permissions defined for authorization",
                         field_path="authorization.permissions",
                         actual_value=permissions,
-                        expected_value="non-empty list of permissions"
+                        expected_value="non-empty list of permissions",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def _validate_encryption(self, encryption: Any) -> List[ValidationResult]:
         """Validate encryption data"""
         results = []
-        
+
         if not isinstance(encryption, dict):
             result = self._create_result(
                 rule_id="encryption_type",
@@ -410,16 +455,23 @@ class SecurityValidator(BaseValidator):
                 message="Encryption data must be a dictionary",
                 field_path="encryption",
                 actual_value=type(encryption).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate encryption algorithm if present
         if "algorithm" in encryption:
             algorithm = encryption["algorithm"]
-            valid_algorithms = ["AES", "RSA", "ChaCha20", "Ed25519", "SHA-256", "SHA-512"]
-            
+            valid_algorithms = [
+                "AES",
+                "RSA",
+                "ChaCha20",
+                "Ed25519",
+                "SHA-256",
+                "SHA-512",
+            ]
+
             if not isinstance(algorithm, str):
                 result = self._create_result(
                     rule_id="encryption_algorithm_type",
@@ -429,7 +481,7 @@ class SecurityValidator(BaseValidator):
                     message="Encryption algorithm must be a string",
                     field_path="encryption.algorithm",
                     actual_value=type(algorithm).__name__,
-                    expected_value="str"
+                    expected_value="str",
                 )
                 results.append(result)
             elif algorithm not in valid_algorithms:
@@ -441,10 +493,10 @@ class SecurityValidator(BaseValidator):
                     message=f"Unrecognized encryption algorithm: {algorithm}",
                     field_path="encryption.algorithm",
                     actual_value=algorithm,
-                    expected_value=f"one of {valid_algorithms}"
+                    expected_value=f"one of {valid_algorithms}",
                 )
                 results.append(result)
-        
+
         # Validate key size if present
         if "key_size" in encryption:
             key_size = encryption["key_size"]
@@ -458,16 +510,16 @@ class SecurityValidator(BaseValidator):
                         message=f"Encryption key size too small: {key_size} bits",
                         field_path="encryption.key_size",
                         actual_value=f"{key_size} bits",
-                        expected_value=">= 128 bits"
+                        expected_value=">= 128 bits",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def _check_sensitive_data_exposure(self, data: Any) -> List[ValidationResult]:
         """Check for potential sensitive data exposure"""
         results = []
-        
+
         if isinstance(data, dict):
             for key, value in data.items():
                 # Check if field name suggests sensitive data
@@ -484,17 +536,17 @@ class SecurityValidator(BaseValidator):
                                 message=f"Potential sensitive data exposure in field '{key}'",
                                 field_path=key,
                                 actual_value="sensitive data detected",
-                                expected_value="masked or encrypted value"
+                                expected_value="masked or encrypted value",
                             )
                             results.append(result)
-                
+
                 # Recursively check nested structures
                 if isinstance(value, (dict, list)):
                     nested_results = self._check_sensitive_data_exposure(value)
                     for nested_result in nested_results:
                         nested_result.field_path = f"{key}.{nested_result.field_path}"
                     results.extend(nested_results)
-        
+
         elif isinstance(data, list):
             for i, item in enumerate(data):
                 if isinstance(item, (dict, list)):
@@ -502,9 +554,9 @@ class SecurityValidator(BaseValidator):
                     for nested_result in nested_results:
                         nested_result.field_path = f"[{i}].{nested_result.field_path}"
                     results.extend(nested_results)
-        
+
         return results
-    
+
     def _looks_like_sensitive_data(self, value: str) -> bool:
         """Check if a string value looks like sensitive data"""
         # Check for common patterns
@@ -516,13 +568,13 @@ class SecurityValidator(BaseValidator):
             return True
         if re.match(self.security_patterns["email"], value):
             return True
-        
+
         # Check for long random-looking strings
         if len(value) > 20 and value.isalnum():
             return True
-        
+
         return False
-    
+
     def add_security_pattern(self, pattern_name: str, pattern: str) -> bool:
         """Add a custom security pattern"""
         try:
@@ -532,7 +584,7 @@ class SecurityValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to add security pattern: {e}")
             return False
-    
+
     def add_sensitive_field(self, field_name: str) -> bool:
         """Add a field name to the sensitive fields list"""
         try:
@@ -543,7 +595,7 @@ class SecurityValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to add sensitive field: {e}")
             return False
-    
+
     # Security Policy Validation functionality integration (from duplicate policy_validator.py)
     def validate_security_policy_legacy(self, policy: Dict[str, Any]) -> Dict[str, Any]:
         """Legacy security policy validation method (from duplicate policy_validator.py)"""
@@ -553,30 +605,48 @@ class SecurityValidator(BaseValidator):
             compliance_score = 100.0
 
             # Validate password policy
-            password_score, pw_warnings, pw_errors = self._validate_password_policy_legacy(policy)
+            (
+                password_score,
+                pw_warnings,
+                pw_errors,
+            ) = self._validate_password_policy_legacy(policy)
             warnings.extend(pw_warnings)
             errors.extend(pw_errors)
             compliance_score -= (100 - password_score) * 0.3
 
             # Validate authentication policy
-            auth_score, auth_warnings, auth_errors = self._validate_authentication_policy_legacy(policy)
+            (
+                auth_score,
+                auth_warnings,
+                auth_errors,
+            ) = self._validate_authentication_policy_legacy(policy)
             warnings.extend(auth_warnings)
             errors.extend(auth_errors)
             compliance_score -= (100 - auth_score) * 0.25
 
             # Validate session policy
-            sess_score, sess_warnings, sess_errors = self._validate_session_policy_legacy(policy)
+            (
+                sess_score,
+                sess_warnings,
+                sess_errors,
+            ) = self._validate_session_policy_legacy(policy)
             warnings.extend(sess_warnings)
             errors.extend(sess_errors)
             compliance_score -= (100 - sess_score) * 0.2
 
             # Validate security controls
-            ctrl_score, ctrl_warnings, ctrl_errors = self._validate_security_controls_legacy(policy)
+            (
+                ctrl_score,
+                ctrl_warnings,
+                ctrl_errors,
+            ) = self._validate_security_controls_legacy(policy)
             warnings.extend(ctrl_warnings)
             errors.extend(ctrl_errors)
             compliance_score -= (100 - ctrl_score) * 0.25
 
-            recommendations = self._generate_recommendations_legacy(warnings, errors, compliance_score)
+            recommendations = self._generate_recommendations_legacy(
+                warnings, errors, compliance_score
+            )
             is_valid = len(errors) == 0 and compliance_score >= 80.0
 
             return {
@@ -586,7 +656,7 @@ class SecurityValidator(BaseValidator):
                 "compliance_score": max(0.0, compliance_score),
                 "recommendations": recommendations,
             }
-            
+
         except Exception as e:
             self.logger.error(f"Security policy validation failed: {e}")
             return {
@@ -596,7 +666,7 @@ class SecurityValidator(BaseValidator):
                 "compliance_score": 0.0,
                 "recommendations": ["Fix validation system errors"],
             }
-    
+
     def _validate_password_policy_legacy(self, policy: Dict[str, Any]) -> tuple:
         """Validate password policy (from duplicate policy_validator.py)"""
         score = 100.0
@@ -608,7 +678,9 @@ class SecurityValidator(BaseValidator):
             errors.append("Password minimum length must be at least 8 characters")
             score -= 30
         elif min_length < 12:
-            warnings.append("Consider increasing password minimum length to 12+ characters")
+            warnings.append(
+                "Consider increasing password minimum length to 12+ characters"
+            )
             score -= 10
 
         if not policy.get("require_special_chars", False):
@@ -630,7 +702,7 @@ class SecurityValidator(BaseValidator):
             score -= 10
 
         return max(0.0, score), warnings, errors
-    
+
     def _validate_authentication_policy_legacy(self, policy: Dict[str, Any]) -> tuple:
         """Validate authentication policy (from duplicate policy_validator.py)"""
         score = 100.0
@@ -650,7 +722,7 @@ class SecurityValidator(BaseValidator):
             score -= 30
 
         return max(0.0, score), warnings, errors
-    
+
     def _validate_session_policy_legacy(self, policy: Dict[str, Any]) -> tuple:
         """Validate session policy (from duplicate policy_validator.py)"""
         score = 100.0
@@ -666,7 +738,7 @@ class SecurityValidator(BaseValidator):
             score -= 20
 
         return max(0.0, score), warnings, errors
-    
+
     def _validate_security_controls_legacy(self, policy: Dict[str, Any]) -> tuple:
         """Validate security controls (from duplicate policy_validator.py)"""
         score = 100.0
@@ -681,8 +753,10 @@ class SecurityValidator(BaseValidator):
             score -= 30
 
         return max(0.0, score), warnings, errors
-    
-    def _generate_recommendations_legacy(self, warnings: List[str], errors: List[str], compliance_score: float) -> List[str]:
+
+    def _generate_recommendations_legacy(
+        self, warnings: List[str], errors: List[str], compliance_score: float
+    ) -> List[str]:
         """Generate recommendations (from duplicate policy_validator.py)"""
         recommendations: List[str] = []
         for error in errors:
@@ -690,45 +764,58 @@ class SecurityValidator(BaseValidator):
         for warning in warnings:
             recommendations.append(f"IMPROVE: {warning}")
         if compliance_score < 70:
-            recommendations.extend([
-                "Conduct comprehensive security review",
-                "Implement security awareness training",
-            ])
+            recommendations.extend(
+                [
+                    "Conduct comprehensive security review",
+                    "Implement security awareness training",
+                ]
+            )
         elif compliance_score < 85:
-            recommendations.extend([
-                "Review and update security policies",
-                "Conduct security assessment",
-            ])
+            recommendations.extend(
+                [
+                    "Review and update security policies",
+                    "Conduct security assessment",
+                ]
+            )
         else:
-            recommendations.extend([
-                "Maintain current security posture",
-                "Schedule regular security reviews",
-            ])
+            recommendations.extend(
+                [
+                    "Maintain current security posture",
+                    "Schedule regular security reviews",
+                ]
+            )
         return recommendations
-    
+
     def get_security_policy_summary(self, policy: Dict[str, Any]) -> Dict[str, Any]:
         """Get security policy validation summary"""
         try:
             # Use both validation methods
             unified_results = self.validate(policy)
             legacy_results = self.validate_security_policy_legacy(policy)
-            
+
             return {
                 "unified_validation": {
                     "total": len(unified_results),
-                    "passed": len([r for r in unified_results if r.status.value == "passed"]),
-                    "failed": len([r for r in unified_results if r.status.value == "failed"]),
-                    "warnings": len([r for r in unified_results if r.severity.value == "warning"])
+                    "passed": len(
+                        [r for r in unified_results if r.status.value == "passed"]
+                    ),
+                    "failed": len(
+                        [r for r in unified_results if r.status.value == "failed"]
+                    ),
+                    "warnings": len(
+                        [r for r in unified_results if r.severity.value == "warning"]
+                    ),
                 },
                 "legacy_validation": legacy_results,
-                "timestamp": self._get_current_timestamp()
+                "timestamp": self._get_current_timestamp(),
             }
-            
+
         except Exception as e:
             self.logger.error(f"Failed to get security policy summary: {e}")
             return {"error": str(e)}
-    
+
     def _get_current_timestamp(self) -> str:
         """Get current timestamp in ISO format"""
         from datetime import datetime
+
         return datetime.now().isoformat()

--- a/src/core/validation/storage_validator.py
+++ b/src/core/validation/storage_validator.py
@@ -6,22 +6,40 @@ and following the unified validation framework patterns.
 """
 
 from typing import Dict, List, Any, Optional
-from .base_validator import BaseValidator, ValidationRule, ValidationSeverity, ValidationStatus, ValidationResult
+from .base_validator import (
+    BaseValidator,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+    ValidationResult,
+)
 
 
 class StorageValidator(BaseValidator):
     """Validates storage configurations and data persistence using unified validation framework"""
-    
+
     def __init__(self):
         """Initialize storage validator"""
         super().__init__("StorageValidator")
         self.storage_types = [
-            "file", "database", "cache", "cloud", "memory", "network", "archive"
+            "file",
+            "database",
+            "cache",
+            "cloud",
+            "memory",
+            "network",
+            "archive",
         ]
         self.database_types = [
-            "sqlite", "postgresql", "mysql", "mongodb", "redis", "elasticsearch", "dynamodb"
+            "sqlite",
+            "postgresql",
+            "mysql",
+            "mongodb",
+            "redis",
+            "elasticsearch",
+            "dynamodb",
         ]
-    
+
     def _setup_default_rules(self) -> None:
         """Setup default storage validation rules"""
         default_rules = [
@@ -30,72 +48,84 @@ class StorageValidator(BaseValidator):
                 rule_name="Storage Structure",
                 rule_type="storage",
                 description="Validate storage configuration structure",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="storage_type_validation",
                 rule_name="Storage Type Validation",
                 rule_type="storage",
                 description="Validate storage type and configuration",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="connection_validation",
                 rule_name="Connection Validation",
                 rule_type="storage",
                 description="Validate storage connection parameters",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="performance_validation",
                 rule_name="Performance Validation",
                 rule_type="storage",
                 description="Validate storage performance settings",
-                severity=ValidationSeverity.WARNING
-            )
+                severity=ValidationSeverity.WARNING,
+            ),
         ]
-        
+
         for rule in default_rules:
             self.add_validation_rule(rule)
-    
-    def validate(self, storage_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
-        """Validate storage data and return validation results"""
+
+    def validate(
+        self, storage_data: Dict[str, Any], **kwargs
+    ) -> List[ValidationResult]:
+        """Validate storage data and return validation results.
+
+        Returns:
+            List[ValidationResult]: Validation results produced during storage
+            validation.
+        """
         results = []
-        
+
         try:
             # Validate storage data structure
             structure_results = self._validate_storage_structure(storage_data)
             results.extend(structure_results)
-            
+
             # Validate required fields
             required_fields = ["type", "name", "configuration"]
-            field_results = self._validate_required_fields(storage_data, required_fields)
+            field_results = self._validate_required_fields(
+                storage_data, required_fields
+            )
             results.extend(field_results)
-            
+
             # Validate storage type if present
             if "type" in storage_data:
                 type_result = self._validate_storage_type(storage_data["type"])
                 if type_result:
                     results.append(type_result)
-            
+
             # Validate configuration if present
             if "configuration" in storage_data:
                 config_results = self._validate_storage_configuration(
-                    storage_data["configuration"], 
-                    storage_data.get("type")
+                    storage_data["configuration"], storage_data.get("type")
                 )
                 results.extend(config_results)
-            
+
             # Validate connection settings if present
             if "connection" in storage_data:
-                connection_results = self._validate_connection_settings(storage_data["connection"])
+                connection_results = self._validate_connection_settings(
+                    storage_data["connection"]
+                )
                 results.extend(connection_results)
-            
+
             # Validate performance settings if present
             if "performance" in storage_data:
-                performance_results = self._validate_performance_settings(storage_data["performance"])
+                performance_results = self._validate_performance_settings(
+                    storage_data["performance"]
+                )
                 results.extend(performance_results)
-            
+
             # Add overall success result if no critical errors
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
                 success_result = self._create_result(
@@ -104,10 +134,10 @@ class StorageValidator(BaseValidator):
                     status=ValidationStatus.PASSED,
                     severity=ValidationSeverity.INFO,
                     message="Storage validation passed successfully",
-                    details={"total_checks": len(results)}
+                    details={"total_checks": len(results)},
                 )
                 results.append(success_result)
-            
+
         except Exception as e:
             error_result = self._create_result(
                 rule_id="storage_validation_error",
@@ -115,16 +145,18 @@ class StorageValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.CRITICAL,
                 message=f"Storage validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
+                details={"error_type": type(e).__name__},
             )
             results.append(error_result)
-        
+
         return results
-    
-    def _validate_storage_structure(self, storage_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_storage_structure(
+        self, storage_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate storage data structure and format"""
         results = []
-        
+
         if not isinstance(storage_data, dict):
             result = self._create_result(
                 rule_id="storage_type",
@@ -133,11 +165,11 @@ class StorageValidator(BaseValidator):
                 severity=ValidationSeverity.ERROR,
                 message="Storage data must be a dictionary",
                 actual_value=type(storage_data).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         if len(storage_data) == 0:
             result = self._create_result(
                 rule_id="storage_empty",
@@ -146,12 +178,12 @@ class StorageValidator(BaseValidator):
                 severity=ValidationSeverity.WARNING,
                 message="Storage data is empty",
                 actual_value=storage_data,
-                expected_value="non-empty storage data"
+                expected_value="non-empty storage data",
             )
             results.append(result)
-        
+
         return results
-    
+
     def _validate_storage_type(self, storage_type: Any) -> Optional[ValidationResult]:
         """Validate storage type value"""
         if not isinstance(storage_type, str):
@@ -163,9 +195,9 @@ class StorageValidator(BaseValidator):
                 message="Storage type must be a string",
                 field_path="type",
                 actual_value=type(storage_type).__name__,
-                expected_value="str"
+                expected_value="str",
             )
-        
+
         if storage_type.lower() not in self.storage_types:
             return self._create_result(
                 rule_id="storage_type_invalid",
@@ -175,19 +207,17 @@ class StorageValidator(BaseValidator):
                 message=f"Invalid storage type: {storage_type}",
                 field_path="type",
                 actual_value=storage_type,
-                expected_value=f"one of {self.storage_types}"
+                expected_value=f"one of {self.storage_types}",
             )
-        
+
         return None
-    
+
     def _validate_storage_configuration(
-        self, 
-        configuration: Any, 
-        storage_type: str = None
+        self, configuration: Any, storage_type: str = None
     ) -> List[ValidationResult]:
         """Validate storage configuration"""
         results = []
-        
+
         if not isinstance(configuration, dict):
             result = self._create_result(
                 rule_id="configuration_type",
@@ -197,11 +227,11 @@ class StorageValidator(BaseValidator):
                 message="Storage configuration must be a dictionary",
                 field_path="configuration",
                 actual_value=type(configuration).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate based on storage type
         if storage_type == "database":
             db_results = self._validate_database_configuration(configuration)
@@ -215,13 +245,15 @@ class StorageValidator(BaseValidator):
         elif storage_type == "cloud":
             cloud_results = self._validate_cloud_configuration(configuration)
             results.extend(cloud_results)
-        
+
         return results
-    
-    def _validate_database_configuration(self, configuration: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_database_configuration(
+        self, configuration: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate database-specific configuration"""
         results = []
-        
+
         # Validate database type
         if "database_type" in configuration:
             db_type = configuration["database_type"]
@@ -235,10 +267,10 @@ class StorageValidator(BaseValidator):
                         message=f"Invalid database type: {db_type}",
                         field_path="configuration.database_type",
                         actual_value=db_type,
-                        expected_value=f"one of {self.database_types}"
+                        expected_value=f"one of {self.database_types}",
                     )
                     results.append(result)
-        
+
         # Validate connection string if present
         if "connection_string" in configuration:
             conn_string = configuration["connection_string"]
@@ -252,25 +284,29 @@ class StorageValidator(BaseValidator):
                         message="Database connection string cannot be empty",
                         field_path="configuration.connection_string",
                         actual_value=conn_string,
-                        expected_value="non-empty connection string"
+                        expected_value="non-empty connection string",
                     )
                     results.append(result)
-        
+
         # Validate pool settings if present
         if "pool_settings" in configuration:
             pool_settings = configuration["pool_settings"]
             if isinstance(pool_settings, dict):
                 pool_results = self._validate_pool_settings(pool_settings)
                 for pool_result in pool_results:
-                    pool_result.field_path = f"configuration.pool_settings.{pool_result.field_path}"
+                    pool_result.field_path = (
+                        f"configuration.pool_settings.{pool_result.field_path}"
+                    )
                 results.extend(pool_results)
-        
+
         return results
-    
-    def _validate_file_configuration(self, configuration: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_file_configuration(
+        self, configuration: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate file storage configuration"""
         results = []
-        
+
         # Validate file path if present
         if "file_path" in configuration:
             file_path = configuration["file_path"]
@@ -284,15 +320,15 @@ class StorageValidator(BaseValidator):
                         message="File path cannot be empty",
                         field_path="configuration.file_path",
                         actual_value=file_path,
-                        expected_value="non-empty file path"
+                        expected_value="non-empty file path",
                     )
                     results.append(result)
-        
+
         # Validate file format if present
         if "file_format" in configuration:
             file_format = configuration["file_format"]
             valid_formats = ["json", "csv", "xml", "yaml", "pickle", "binary"]
-            
+
             if isinstance(file_format, str):
                 if file_format.lower() not in valid_formats:
                     result = self._create_result(
@@ -303,16 +339,18 @@ class StorageValidator(BaseValidator):
                         message=f"Invalid file format: {file_format}",
                         field_path="configuration.file_format",
                         actual_value=file_format,
-                        expected_value=f"one of {valid_formats}"
+                        expected_value=f"one of {valid_formats}",
                     )
                     results.append(result)
-        
+
         return results
-    
-    def _validate_cache_configuration(self, configuration: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_cache_configuration(
+        self, configuration: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate cache storage configuration"""
         results = []
-        
+
         # Validate TTL if present
         if "ttl" in configuration:
             ttl = configuration["ttl"]
@@ -326,10 +364,10 @@ class StorageValidator(BaseValidator):
                         message="TTL must be greater than 0",
                         field_path="configuration.ttl",
                         actual_value=ttl,
-                        expected_value="> 0"
+                        expected_value="> 0",
                     )
                     results.append(result)
-        
+
         # Validate max size if present
         if "max_size" in configuration:
             max_size = configuration["max_size"]
@@ -343,21 +381,23 @@ class StorageValidator(BaseValidator):
                         message="Max size must be greater than 0",
                         field_path="configuration.max_size",
                         actual_value=max_size,
-                        expected_value="> 0"
+                        expected_value="> 0",
                     )
                     results.append(result)
-        
+
         return results
-    
-    def _validate_cloud_configuration(self, configuration: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_cloud_configuration(
+        self, configuration: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate cloud storage configuration"""
         results = []
-        
+
         # Validate provider if present
         if "provider" in configuration:
             provider = configuration["provider"]
             valid_providers = ["aws", "azure", "gcp", "digitalocean", "linode"]
-            
+
             if isinstance(provider, str):
                 if provider.lower() not in valid_providers:
                     result = self._create_result(
@@ -368,10 +408,10 @@ class StorageValidator(BaseValidator):
                         message=f"Invalid cloud provider: {provider}",
                         field_path="configuration.provider",
                         actual_value=provider,
-                        expected_value=f"one of {valid_providers}"
+                        expected_value=f"one of {valid_providers}",
                     )
                     results.append(result)
-        
+
         # Validate region if present
         if "region" in configuration:
             region = configuration["region"]
@@ -385,16 +425,18 @@ class StorageValidator(BaseValidator):
                         message="Cloud region cannot be empty",
                         field_path="configuration.region",
                         actual_value=region,
-                        expected_value="non-empty region"
+                        expected_value="non-empty region",
                     )
                     results.append(result)
-        
+
         return results
-    
-    def _validate_pool_settings(self, pool_settings: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_pool_settings(
+        self, pool_settings: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate database connection pool settings"""
         results = []
-        
+
         # Validate min connections
         if "min_connections" in pool_settings:
             min_conn = pool_settings["min_connections"]
@@ -408,10 +450,10 @@ class StorageValidator(BaseValidator):
                         message="Min connections cannot be negative",
                         field_path="min_connections",
                         actual_value=min_conn,
-                        expected_value=">= 0"
+                        expected_value=">= 0",
                     )
                     results.append(result)
-        
+
         # Validate max connections
         if "max_connections" in pool_settings:
             max_conn = pool_settings["max_connections"]
@@ -425,10 +467,10 @@ class StorageValidator(BaseValidator):
                         message="Max connections must be greater than 0",
                         field_path="max_connections",
                         actual_value=max_conn,
-                        expected_value="> 0"
+                        expected_value="> 0",
                     )
                     results.append(result)
-                
+
                 # Check if max > min
                 min_conn = pool_settings.get("min_connections", 0)
                 if isinstance(min_conn, int) and max_conn < min_conn:
@@ -440,16 +482,16 @@ class StorageValidator(BaseValidator):
                         message="Max connections must be >= min connections",
                         field_path="max_connections",
                         actual_value=f"{max_conn} < {min_conn}",
-                        expected_value="max_connections >= min_connections"
+                        expected_value="max_connections >= min_connections",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def _validate_connection_settings(self, connection: Any) -> List[ValidationResult]:
         """Validate connection settings"""
         results = []
-        
+
         if not isinstance(connection, dict):
             result = self._create_result(
                 rule_id="connection_type",
@@ -459,11 +501,11 @@ class StorageValidator(BaseValidator):
                 message="Connection settings must be a dictionary",
                 field_path="connection",
                 actual_value=type(connection).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate timeout if present
         if "timeout" in connection:
             timeout = connection["timeout"]
@@ -477,10 +519,10 @@ class StorageValidator(BaseValidator):
                         message="Connection timeout must be greater than 0",
                         field_path="connection.timeout",
                         actual_value=timeout,
-                        expected_value="> 0"
+                        expected_value="> 0",
                     )
                     results.append(result)
-        
+
         # Validate retry settings if present
         if "retry_attempts" in connection:
             retry_attempts = connection["retry_attempts"]
@@ -494,16 +536,18 @@ class StorageValidator(BaseValidator):
                         message="Retry attempts cannot be negative",
                         field_path="connection.retry_attempts",
                         actual_value=retry_attempts,
-                        expected_value=">= 0"
+                        expected_value=">= 0",
                     )
                     results.append(result)
-        
+
         return results
-    
-    def _validate_performance_settings(self, performance: Any) -> List[ValidationResult]:
+
+    def _validate_performance_settings(
+        self, performance: Any
+    ) -> List[ValidationResult]:
         """Validate performance settings"""
         results = []
-        
+
         if not isinstance(performance, dict):
             result = self._create_result(
                 rule_id="performance_type",
@@ -513,11 +557,11 @@ class StorageValidator(BaseValidator):
                 message="Performance settings must be a dictionary",
                 field_path="performance",
                 actual_value=type(performance).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate batch size if present
         if "batch_size" in performance:
             batch_size = performance["batch_size"]
@@ -531,15 +575,15 @@ class StorageValidator(BaseValidator):
                         message="Batch size must be greater than 0",
                         field_path="performance.batch_size",
                         actual_value=batch_size,
-                        expected_value="> 0"
+                        expected_value="> 0",
                     )
                     results.append(result)
-        
+
         # Validate compression if present
         if "compression" in performance:
             compression = performance["compression"]
             valid_compression = ["none", "gzip", "lz4", "zstd", "snappy"]
-            
+
             if isinstance(compression, str):
                 if compression.lower() not in valid_compression:
                     result = self._create_result(
@@ -550,12 +594,12 @@ class StorageValidator(BaseValidator):
                         message=f"Invalid compression type: {compression}",
                         field_path="performance.compression",
                         actual_value=compression,
-                        expected_value=f"one of {valid_compression}"
+                        expected_value=f"one of {valid_compression}",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def add_storage_type(self, storage_type: str) -> bool:
         """Add a custom storage type"""
         try:
@@ -566,7 +610,7 @@ class StorageValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to add storage type: {e}")
             return False
-    
+
     def add_database_type(self, database_type: str) -> bool:
         """Add a custom database type"""
         try:
@@ -577,31 +621,31 @@ class StorageValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to add database type: {e}")
             return False
-    
+
     def validate_data_integrity(self, data: Any, checksum: str) -> ValidationResult:
         """Validate data integrity using checksum (from PersistentStorageValidator)"""
         try:
             import hashlib
             import json
-            
+
             # Calculate checksum
             data_str = json.dumps(data, sort_keys=True)
             calculated_checksum = hashlib.sha256(data_str.encode()).hexdigest()
-            
+
             # Compare checksums
             if calculated_checksum == checksum:
-                            return ValidationResult(
-                rule_id="data_integrity",
-                rule_name="Data Integrity Validation",
-                status=ValidationStatus.PASSED,
-                severity=ValidationSeverity.INFO,
-                message="Data integrity validation passed",
-                details={
-                    "calculated_checksum": calculated_checksum,
-                    "provided_checksum": checksum,
-                    "match": True
-                }
-            )
+                return ValidationResult(
+                    rule_id="data_integrity",
+                    rule_name="Data Integrity Validation",
+                    status=ValidationStatus.PASSED,
+                    severity=ValidationSeverity.INFO,
+                    message="Data integrity validation passed",
+                    details={
+                        "calculated_checksum": calculated_checksum,
+                        "provided_checksum": checksum,
+                        "match": True,
+                    },
+                )
             else:
                 return ValidationResult(
                     rule_id="data_integrity",
@@ -612,10 +656,10 @@ class StorageValidator(BaseValidator):
                     details={
                         "calculated_checksum": calculated_checksum,
                         "provided_checksum": checksum,
-                        "match": False
-                    }
+                        "match": False,
+                    },
                 )
-                
+
         except Exception as e:
             return ValidationResult(
                 rule_id="data_integrity",
@@ -623,18 +667,18 @@ class StorageValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.ERROR,
                 message=f"Data integrity validation error: {str(e)}",
-                details={"error": str(e)}
+                details={"error": str(e)},
             )
-    
+
     def calculate_checksum(self, data: Any) -> str:
         """Calculate checksum for data (from PersistentStorageValidator)"""
         try:
             import hashlib
             import json
-            
+
             data_str = json.dumps(data, sort_keys=True)
             return hashlib.sha256(data_str.encode()).hexdigest()
-            
+
         except Exception as e:
             self.logger.error(f"Failed to calculate checksum: {e}")
             return ""

--- a/src/core/validation/task_validator.py
+++ b/src/core/validation/task_validator.py
@@ -6,24 +6,44 @@ and following the unified validation framework patterns.
 """
 
 from typing import Dict, List, Any, Optional
-from .base_validator import BaseValidator, ValidationRule, ValidationSeverity, ValidationStatus, ValidationResult
+from .base_validator import (
+    BaseValidator,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+    ValidationResult,
+)
 
 
 class TaskValidator(BaseValidator):
     """Validates task data and assignments using unified validation framework"""
-    
+
     def __init__(self):
         """Initialize task validator"""
         super().__init__("TaskValidator")
         self.task_statuses = [
-            "pending", "assigned", "in_progress", "review", "completed", "cancelled", "failed"
+            "pending",
+            "assigned",
+            "in_progress",
+            "review",
+            "completed",
+            "cancelled",
+            "failed",
         ]
         self.task_priorities = ["low", "medium", "high", "critical", "urgent"]
         self.task_types = [
-            "development", "testing", "documentation", "deployment", "maintenance", 
-            "research", "bug_fix", "feature", "refactoring", "review"
+            "development",
+            "testing",
+            "documentation",
+            "deployment",
+            "maintenance",
+            "research",
+            "bug_fix",
+            "feature",
+            "refactoring",
+            "review",
         ]
-    
+
     def _setup_default_rules(self) -> None:
         """Setup default task validation rules"""
         default_rules = [
@@ -32,85 +52,94 @@ class TaskValidator(BaseValidator):
                 rule_name="Task Structure",
                 rule_type="task",
                 description="Validate task data structure and format",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="task_assignment_validation",
                 rule_name="Task Assignment Validation",
                 rule_type="task",
                 description="Validate task assignment and ownership",
-                severity=ValidationSeverity.ERROR
+                severity=ValidationSeverity.ERROR,
             ),
             ValidationRule(
                 rule_id="task_dependencies_validation",
                 rule_name="Task Dependencies Validation",
                 rule_type="task",
                 description="Validate task dependencies and relationships",
-                severity=ValidationSeverity.WARNING
+                severity=ValidationSeverity.WARNING,
             ),
             ValidationRule(
                 rule_id="task_progress_validation",
                 rule_name="Task Progress Validation",
                 rule_type="task",
                 description="Validate task progress and timeline",
-                severity=ValidationSeverity.WARNING
-            )
+                severity=ValidationSeverity.WARNING,
+            ),
         ]
-        
+
         for rule in default_rules:
             self.add_validation_rule(rule)
-    
+
     def validate(self, task_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
-        """Validate task data and return validation results"""
+        """Validate task data and return validation results.
+
+        Returns:
+            List[ValidationResult]: Validation results produced during task
+            validation.
+        """
         results = []
-        
+
         try:
             # Validate task data structure
             structure_results = self._validate_task_structure(task_data)
             results.extend(structure_results)
-            
+
             # Validate required fields
             required_fields = ["id", "title", "description", "status", "priority"]
             field_results = self._validate_required_fields(task_data, required_fields)
             results.extend(field_results)
-            
+
             # Validate task status if present
             if "status" in task_data:
                 status_result = self._validate_task_status(task_data["status"])
                 if status_result:
                     results.append(status_result)
-            
+
             # Validate task priority if present
             if "priority" in task_data:
                 priority_result = self._validate_task_priority(task_data["priority"])
                 if priority_result:
                     results.append(priority_result)
-            
+
             # Validate task type if present
             if "type" in task_data:
                 type_result = self._validate_task_type(task_data["type"])
                 if type_result:
                     results.append(type_result)
-            
+
             # Validate assignment if present
             if "assignment" in task_data:
-                assignment_results = self._validate_task_assignment(task_data["assignment"])
+                assignment_results = self._validate_task_assignment(
+                    task_data["assignment"]
+                )
                 results.extend(assignment_results)
-            
+
             # Validate dependencies if present
             if "dependencies" in task_data:
-                dependency_results = self._validate_task_dependencies(task_data["dependencies"])
+                dependency_results = self._validate_task_dependencies(
+                    task_data["dependencies"]
+                )
                 results.extend(dependency_results)
-            
+
             # Validate progress if present
             if "progress" in task_data:
                 progress_results = self._validate_task_progress(task_data["progress"])
                 results.extend(progress_results)
-            
+
             # Check task consistency
             consistency_results = self._validate_task_consistency(task_data)
             results.extend(consistency_results)
-            
+
             # Add overall success result if no critical errors
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
                 success_result = self._create_result(
@@ -119,10 +148,10 @@ class TaskValidator(BaseValidator):
                     status=ValidationStatus.PASSED,
                     severity=ValidationSeverity.INFO,
                     message="Task validation passed successfully",
-                    details={"total_checks": len(results)}
+                    details={"total_checks": len(results)},
                 )
                 results.append(success_result)
-            
+
         except Exception as e:
             error_result = self._create_result(
                 rule_id="task_validation_error",
@@ -130,16 +159,18 @@ class TaskValidator(BaseValidator):
                 status=ValidationStatus.FAILED,
                 severity=ValidationSeverity.CRITICAL,
                 message=f"Task validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
+                details={"error_type": type(e).__name__},
             )
             results.append(error_result)
-        
+
         return results
-    
-    def _validate_task_structure(self, task_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_task_structure(
+        self, task_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate task data structure and format"""
         results = []
-        
+
         if not isinstance(task_data, dict):
             result = self._create_result(
                 rule_id="task_type",
@@ -148,11 +179,11 @@ class TaskValidator(BaseValidator):
                 severity=ValidationSeverity.ERROR,
                 message="Task data must be a dictionary",
                 actual_value=type(task_data).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         if len(task_data) == 0:
             result = self._create_result(
                 rule_id="task_empty",
@@ -161,12 +192,12 @@ class TaskValidator(BaseValidator):
                 severity=ValidationSeverity.WARNING,
                 message="Task data is empty",
                 actual_value=task_data,
-                expected_value="non-empty task data"
+                expected_value="non-empty task data",
             )
             results.append(result)
-        
+
         return results
-    
+
     def _validate_task_status(self, status: Any) -> Optional[ValidationResult]:
         """Validate task status value"""
         if not isinstance(status, str):
@@ -178,9 +209,9 @@ class TaskValidator(BaseValidator):
                 message="Task status must be a string",
                 field_path="status",
                 actual_value=type(status).__name__,
-                expected_value="str"
+                expected_value="str",
             )
-        
+
         if status.lower() not in self.task_statuses:
             return self._create_result(
                 rule_id="status_invalid",
@@ -190,11 +221,11 @@ class TaskValidator(BaseValidator):
                 message=f"Invalid task status: {status}",
                 field_path="status",
                 actual_value=status,
-                expected_value=f"one of {self.task_statuses}"
+                expected_value=f"one of {self.task_statuses}",
             )
-        
+
         return None
-    
+
     def _validate_task_priority(self, priority: Any) -> Optional[ValidationResult]:
         """Validate task priority value"""
         if not isinstance(priority, str):
@@ -206,9 +237,9 @@ class TaskValidator(BaseValidator):
                 message="Task priority must be a string",
                 field_path="priority",
                 actual_value=type(priority).__name__,
-                expected_value="str"
+                expected_value="str",
             )
-        
+
         if priority.lower() not in self.task_priorities:
             return self._create_result(
                 rule_id="priority_invalid",
@@ -218,11 +249,11 @@ class TaskValidator(BaseValidator):
                 message=f"Invalid task priority: {priority}",
                 field_path="priority",
                 actual_value=priority,
-                expected_value=f"one of {self.task_priorities}"
+                expected_value=f"one of {self.task_priorities}",
             )
-        
+
         return None
-    
+
     def _validate_task_type(self, task_type: Any) -> Optional[ValidationResult]:
         """Validate task type value"""
         if not isinstance(task_type, str):
@@ -234,9 +265,9 @@ class TaskValidator(BaseValidator):
                 message="Task type must be a string",
                 field_path="type",
                 actual_value=type(task_type).__name__,
-                expected_value="str"
+                expected_value="str",
             )
-        
+
         if task_type.lower() not in self.task_types:
             return self._create_result(
                 rule_id="type_invalid",
@@ -246,15 +277,15 @@ class TaskValidator(BaseValidator):
                 message=f"Invalid task type: {task_type}",
                 field_path="type",
                 actual_value=task_type,
-                expected_value=f"one of {self.task_types}"
+                expected_value=f"one of {self.task_types}",
             )
-        
+
         return None
-    
+
     def _validate_task_assignment(self, assignment: Any) -> List[ValidationResult]:
         """Validate task assignment data"""
         results = []
-        
+
         if not isinstance(assignment, dict):
             result = self._create_result(
                 rule_id="assignment_type",
@@ -264,11 +295,11 @@ class TaskValidator(BaseValidator):
                 message="Task assignment must be a dictionary",
                 field_path="assignment",
                 actual_value=type(assignment).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate assignee if present
         if "assignee" in assignment:
             assignee = assignment["assignee"]
@@ -282,17 +313,18 @@ class TaskValidator(BaseValidator):
                         message="Task assignee cannot be empty",
                         field_path="assignment.assignee",
                         actual_value=assignee,
-                        expected_value="non-empty assignee"
+                        expected_value="non-empty assignee",
                     )
                     results.append(result)
-        
+
         # Validate assignment date if present
         if "assigned_date" in assignment:
             assigned_date = assignment["assigned_date"]
             if isinstance(assigned_date, str):
                 try:
                     from datetime import datetime
-                    datetime.fromisoformat(assigned_date.replace('Z', '+00:00'))
+
+                    datetime.fromisoformat(assigned_date.replace("Z", "+00:00"))
                 except ValueError:
                     result = self._create_result(
                         rule_id="assigned_date_format",
@@ -302,10 +334,10 @@ class TaskValidator(BaseValidator):
                         message="Invalid assigned date format. Use ISO format (YYYY-MM-DDTHH:MM:SS)",
                         field_path="assignment.assigned_date",
                         actual_value=assigned_date,
-                        expected_value="ISO format date string"
+                        expected_value="ISO format date string",
                     )
                     results.append(result)
-        
+
         # Validate estimated effort if present
         if "estimated_effort" in assignment:
             estimated_effort = assignment["estimated_effort"]
@@ -319,16 +351,16 @@ class TaskValidator(BaseValidator):
                         message="Estimated effort must be greater than 0",
                         field_path="assignment.estimated_effort",
                         actual_value=estimated_effort,
-                        expected_value="> 0"
+                        expected_value="> 0",
                     )
                     results.append(result)
-        
+
         return results
-    
+
     def _validate_task_dependencies(self, dependencies: Any) -> List[ValidationResult]:
         """Validate task dependencies"""
         results = []
-        
+
         if not isinstance(dependencies, list):
             result = self._create_result(
                 rule_id="dependencies_type",
@@ -338,11 +370,11 @@ class TaskValidator(BaseValidator):
                 message="Task dependencies must be a list",
                 field_path="dependencies",
                 actual_value=type(dependencies).__name__,
-                expected_value="list"
+                expected_value="list",
             )
             results.append(result)
             return results
-        
+
         # Validate each dependency
         for i, dependency in enumerate(dependencies):
             if isinstance(dependency, dict):
@@ -358,15 +390,15 @@ class TaskValidator(BaseValidator):
                             message=f"Dependency {i} task ID must be a non-empty string",
                             field_path=f"dependencies[{i}].task_id",
                             actual_value=task_id,
-                            expected_value="non-empty string"
+                            expected_value="non-empty string",
                         )
                         results.append(result)
-                
+
                 # Validate dependency type if present
                 if "type" in dependency:
                     dep_type = dependency["type"]
                     valid_dep_types = ["blocks", "blocked_by", "related", "requires"]
-                    
+
                     if isinstance(dep_type, str):
                         if dep_type.lower() not in valid_dep_types:
                             result = self._create_result(
@@ -377,7 +409,7 @@ class TaskValidator(BaseValidator):
                                 message=f"Invalid dependency type: {dep_type}",
                                 field_path=f"dependencies[{i}].type",
                                 actual_value=dep_type,
-                                expected_value=f"one of {valid_dep_types}"
+                                expected_value=f"one of {valid_dep_types}",
                             )
                             results.append(result)
             else:
@@ -389,16 +421,16 @@ class TaskValidator(BaseValidator):
                     message=f"Dependency {i} must be a dictionary",
                     field_path=f"dependencies[{i}]",
                     actual_value=type(dependency).__name__,
-                    expected_value="dict"
+                    expected_value="dict",
                 )
                 results.append(result)
-        
+
         return results
-    
+
     def _validate_task_progress(self, progress: Any) -> List[ValidationResult]:
         """Validate task progress data"""
         results = []
-        
+
         if not isinstance(progress, dict):
             result = self._create_result(
                 rule_id="progress_type",
@@ -408,11 +440,11 @@ class TaskValidator(BaseValidator):
                 message="Task progress must be a dictionary",
                 field_path="progress",
                 actual_value=type(progress).__name__,
-                expected_value="dict"
+                expected_value="dict",
             )
             results.append(result)
             return results
-        
+
         # Validate completion percentage if present
         if "completion_percentage" in progress:
             completion = progress["completion_percentage"]
@@ -426,10 +458,10 @@ class TaskValidator(BaseValidator):
                         message="Completion percentage must be between 0 and 100",
                         field_path="progress.completion_percentage",
                         actual_value=completion,
-                        expected_value="0 <= completion <= 100"
+                        expected_value="0 <= completion <= 100",
                     )
                     results.append(result)
-        
+
         # Validate time spent if present
         if "time_spent" in progress:
             time_spent = progress["time_spent"]
@@ -443,10 +475,10 @@ class TaskValidator(BaseValidator):
                         message="Time spent cannot be negative",
                         field_path="progress.time_spent",
                         actual_value=time_spent,
-                        expected_value=">= 0"
+                        expected_value=">= 0",
                     )
                     results.append(result)
-        
+
         # Validate milestones if present
         if "milestones" in progress:
             milestones = progress["milestones"]
@@ -465,7 +497,7 @@ class TaskValidator(BaseValidator):
                                     message=f"Milestone {i} completed must be a boolean",
                                     field_path=f"progress.milestones[{i}].completed",
                                     actual_value=type(completed).__name__,
-                                    expected_value="bool"
+                                    expected_value="bool",
                                 )
                                 results.append(result)
                     else:
@@ -477,21 +509,23 @@ class TaskValidator(BaseValidator):
                             message=f"Milestone {i} must be a dictionary",
                             field_path=f"progress.milestones[{i}]",
                             actual_value=type(milestone).__name__,
-                            expected_value="dict"
+                            expected_value="dict",
                         )
                         results.append(result)
-        
+
         return results
-    
-    def _validate_task_consistency(self, task_data: Dict[str, Any]) -> List[ValidationResult]:
+
+    def _validate_task_consistency(
+        self, task_data: Dict[str, Any]
+    ) -> List[ValidationResult]:
         """Validate task consistency and logic"""
         results = []
-        
+
         # Check if completed tasks have completion date
         if "status" in task_data and "completion_date" in task_data:
             status = task_data["status"]
             completion_date = task_data["completion_date"]
-            
+
             if isinstance(status, str) and isinstance(completion_date, str):
                 if status.lower() == "completed" and not completion_date:
                     result = self._create_result(
@@ -502,15 +536,15 @@ class TaskValidator(BaseValidator):
                         message="Completed task should have a completion date",
                         field_path="completion_date",
                         actual_value="missing",
-                        expected_value="completion date for completed task"
+                        expected_value="completion date for completed task",
                     )
                     results.append(result)
-        
+
         # Check if estimated effort is reasonable compared to actual effort
         if "estimated_effort" in task_data and "actual_effort" in task_data:
             estimated = task_data["estimated_effort"]
             actual = task_data["actual_effort"]
-            
+
             if isinstance(estimated, (int, float)) and isinstance(actual, (int, float)):
                 if estimated > 0 and actual > 0:
                     ratio = actual / estimated
@@ -523,15 +557,15 @@ class TaskValidator(BaseValidator):
                             message=f"Actual effort ({actual}) is {ratio:.1f}x estimated effort ({estimated})",
                             field_path="effort_estimation",
                             actual_value=f"ratio: {ratio:.1f}",
-                            expected_value="ratio <= 3.0"
+                            expected_value="ratio <= 3.0",
                         )
                         results.append(result)
-        
+
         # Check if task dependencies are valid
         if "dependencies" in task_data and "id" in task_data:
             dependencies = task_data["dependencies"]
             task_id = task_data["id"]
-            
+
             if isinstance(dependencies, list) and isinstance(task_id, str):
                 # Check for self-referencing dependencies
                 for dependency in dependencies:
@@ -545,12 +579,12 @@ class TaskValidator(BaseValidator):
                                 message="Task cannot depend on itself",
                                 field_path="dependencies",
                                 actual_value=f"self-reference: {task_id}",
-                                expected_value="different task ID"
+                                expected_value="different task ID",
                             )
                             results.append(result)
-        
+
         return results
-    
+
     def add_task_status(self, status: str) -> bool:
         """Add a custom task status"""
         try:
@@ -561,7 +595,7 @@ class TaskValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to add task status: {e}")
             return False
-    
+
     def add_task_priority(self, priority: str) -> bool:
         """Add a custom task priority"""
         try:
@@ -572,7 +606,7 @@ class TaskValidator(BaseValidator):
         except Exception as e:
             self.logger.error(f"Failed to add task priority: {e}")
             return False
-    
+
     def add_task_type(self, task_type: str) -> bool:
         """Add a custom task type"""
         try:

--- a/src/core/workflow/validation/__init__.py
+++ b/src/core/workflow/validation/__init__.py
@@ -12,10 +12,16 @@ Components:
 """
 
 from .workflow_validator import WorkflowValidator
+from .structure_validator import WorkflowStructureValidator
+from .execution_validator import WorkflowExecutionValidator
+from .performance_validator import WorkflowPerformanceValidator
 from .workflow_validation_manager import WorkflowValidationManager
 
 __all__ = [
     'WorkflowValidator',
+    'WorkflowStructureValidator',
+    'WorkflowExecutionValidator',
+    'WorkflowPerformanceValidator',
     'WorkflowValidationManager'
 ]
 

--- a/src/core/workflow/validation/execution_validator.py
+++ b/src/core/workflow/validation/execution_validator.py
@@ -1,0 +1,143 @@
+"""Workflow execution validation logic."""
+
+from typing import List
+
+from src.core.validation import (
+    BaseValidator,
+    ValidationResult,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+)
+from ..types.workflow_enums import WorkflowStatus, TaskStatus
+from ..types.workflow_models import WorkflowExecution, WorkflowStep
+
+
+class WorkflowExecutionValidator(BaseValidator):
+    """Validate workflow execution state and transitions."""
+
+    def __init__(self) -> None:
+        super().__init__("WorkflowExecutionValidator")
+
+    def _setup_default_rules(self) -> None:  # pragma: no cover - simple rule setup
+        self.add_validation_rule(
+            ValidationRule(
+                rule_id="workflow_execution",
+                rule_name="Workflow Execution Validation",
+                rule_type="workflow",
+                description="Validate workflow execution state and transitions",
+                severity=ValidationSeverity.ERROR,
+            )
+        )
+
+    def validate(self, execution: WorkflowExecution, **_) -> List[ValidationResult]:
+        results: List[ValidationResult] = []
+
+        try:
+            if execution.status not in WorkflowStatus:
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_execution",
+                        rule_name="Workflow Execution Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message="Invalid workflow execution status",
+                        details={
+                            "status": execution.status,
+                            "valid_statuses": [s.value for s in WorkflowStatus],
+                        },
+                    )
+                )
+
+            if execution.steps:
+                results.extend(self._validate_step_execution_states(execution.steps))
+
+            if execution.start_time and execution.end_time:
+                results.extend(self._validate_execution_timing(execution))
+
+            if not any(r.severity == ValidationSeverity.ERROR for r in results):
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_execution",
+                        rule_name="Workflow Execution Validation",
+                        status=ValidationStatus.PASSED,
+                        severity=ValidationSeverity.INFO,
+                        message="Workflow execution validation passed",
+                        details={
+                            "status": execution.status.value,
+                            "step_count": len(execution.steps),
+                        },
+                    )
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            results.append(
+                self._create_result(
+                    rule_id="workflow_execution",
+                    rule_name="Workflow Execution Validation",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.CRITICAL,
+                    message=f"Execution validation error: {e}",
+                    details={"error_type": type(e).__name__},
+                )
+            )
+
+        return results
+
+    def _validate_step_execution_states(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
+        results: List[ValidationResult] = []
+
+        for i, step in enumerate(steps):
+            if step.status not in TaskStatus:
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_execution",
+                        rule_name="Workflow Execution Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Step {i} has invalid execution status",
+                        details={
+                            "step_index": i,
+                            "step_id": step.step_id,
+                            "status": step.status,
+                        },
+                    )
+                )
+
+            if step.start_time and step.end_time and step.start_time > step.end_time:
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_execution",
+                        rule_name="Workflow Execution Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.WARNING,
+                        message=f"Step {i} has inconsistent timing",
+                        details={
+                            "step_index": i,
+                            "step_id": step.step_id,
+                            "start_time": step.start_time,
+                            "end_time": step.end_time,
+                        },
+                    )
+                )
+
+        return results
+
+    def _validate_execution_timing(self, execution: WorkflowExecution) -> List[ValidationResult]:
+        results: List[ValidationResult] = []
+
+        if execution.start_time > execution.end_time:
+            results.append(
+                self._create_result(
+                    rule_id="workflow_execution",
+                    rule_name="Workflow Execution Validation",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.WARNING,
+                    message="Workflow execution has inconsistent timing",
+                    details={
+                        "start_time": execution.start_time,
+                        "end_time": execution.end_time,
+                    },
+                )
+            )
+
+        return results

--- a/src/core/workflow/validation/performance_validator.py
+++ b/src/core/workflow/validation/performance_validator.py
@@ -1,0 +1,95 @@
+"""Workflow performance validation logic."""
+
+from typing import List
+
+from src.core.validation import (
+    BaseValidator,
+    ValidationResult,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+)
+from ..types.workflow_models import WorkflowDefinition, WorkflowExecution
+
+
+class WorkflowPerformanceValidator(BaseValidator):
+    """Validate workflow performance metrics."""
+
+    def __init__(self) -> None:
+        super().__init__("WorkflowPerformanceValidator")
+
+    def _setup_default_rules(self) -> None:  # pragma: no cover - simple rule setup
+        self.add_validation_rule(
+            ValidationRule(
+                rule_id="performance_metrics",
+                rule_name="Performance Metrics Validation",
+                rule_type="workflow",
+                description="Validate workflow performance and optimization",
+                severity=ValidationSeverity.WARNING,
+            )
+        )
+
+    def validate(
+        self, workflow_def: WorkflowDefinition, execution: WorkflowExecution, **_
+    ) -> List[ValidationResult]:
+        results: List[ValidationResult] = []
+
+        try:
+            total_estimated = sum(step.estimated_duration for step in workflow_def.steps)
+
+            if execution.start_time and execution.end_time:
+                actual_duration = (
+                    execution.end_time - execution.start_time
+                ).total_seconds()
+                variance_threshold = total_estimated * 0.2
+                if abs(actual_duration - total_estimated) > variance_threshold:
+                    results.append(
+                        self._create_result(
+                            rule_id="performance_metrics",
+                            rule_name="Performance Metrics Validation",
+                            status=ValidationStatus.PASSED,
+                            severity=ValidationSeverity.WARNING,
+                            message="Workflow execution time differs significantly from estimate",
+                            details={
+                                "estimated_duration": total_estimated,
+                                "actual_duration": actual_duration,
+                                "variance": abs(actual_duration - total_estimated),
+                                "threshold": variance_threshold,
+                            },
+                        )
+                    )
+
+            long_steps = [
+                step
+                for step in workflow_def.steps
+                if step.estimated_duration > 300
+            ]
+            if long_steps:
+                results.append(
+                    self._create_result(
+                        rule_id="performance_metrics",
+                        rule_name="Performance Metrics Validation",
+                        status=ValidationStatus.PASSED,
+                        severity=ValidationSeverity.INFO,
+                        message="Long-running steps detected - consider optimization",
+                        details={
+                            "long_steps": [
+                                {"step_id": s.step_id, "duration": s.estimated_duration}
+                                for s in long_steps
+                            ]
+                        },
+                    )
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            results.append(
+                self._create_result(
+                    rule_id="performance_metrics",
+                    rule_name="Performance Metrics Validation",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.WARNING,
+                    message=f"Performance validation error: {e}",
+                    details={"error_type": type(e).__name__},
+                )
+            )
+
+        return results

--- a/src/core/workflow/validation/structure_validator.py
+++ b/src/core/workflow/validation/structure_validator.py
@@ -1,0 +1,249 @@
+"""Workflow structure validation logic."""
+
+from typing import List
+
+from src.core.validation import (
+    BaseValidator,
+    ValidationResult,
+    ValidationRule,
+    ValidationSeverity,
+    ValidationStatus,
+)
+from ..types.workflow_enums import WorkflowType
+from ..types.workflow_models import WorkflowDefinition, WorkflowStep
+
+
+class WorkflowStructureValidator(BaseValidator):
+    """Validate workflow definitions and step dependencies."""
+
+    def __init__(self) -> None:
+        super().__init__("WorkflowStructureValidator")
+
+    def _setup_default_rules(self) -> None:  # pragma: no cover - simple rule setup
+        self.add_validation_rule(
+            ValidationRule(
+                rule_id="workflow_structure",
+                rule_name="Workflow Structure Validation",
+                rule_type="workflow",
+                description="Validate workflow definition structure and integrity",
+                severity=ValidationSeverity.ERROR,
+            )
+        )
+        self.add_validation_rule(
+            ValidationRule(
+                rule_id="step_dependencies",
+                rule_name="Step Dependencies Validation",
+                rule_type="workflow",
+                description="Validate workflow step dependencies and cycles",
+                severity=ValidationSeverity.ERROR,
+            )
+        )
+
+    def validate(self, workflow_def: WorkflowDefinition, **_) -> List[ValidationResult]:
+        results: List[ValidationResult] = []
+
+        try:
+            if not workflow_def.workflow_id or not workflow_def.name:
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_structure",
+                        rule_name="Workflow Structure Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message="Workflow must have valid ID and name",
+                        details={
+                            "workflow_id": workflow_def.workflow_id,
+                            "name": workflow_def.name,
+                        },
+                    )
+                )
+
+            if not workflow_def.steps:
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_structure",
+                        rule_name="Workflow Structure Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message="Workflow must have at least one step",
+                        details={"step_count": len(workflow_def.steps)},
+                    )
+                )
+            else:
+                results.extend(self._validate_workflow_steps(workflow_def.steps))
+                results.extend(self._validate_step_dependencies(workflow_def.steps))
+
+            if workflow_def.workflow_type not in WorkflowType:
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_structure",
+                        rule_name="Workflow Structure Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message="Invalid workflow type",
+                        details={
+                            "workflow_type": workflow_def.workflow_type,
+                            "valid_types": [t.value for t in WorkflowType],
+                        },
+                    )
+                )
+
+            if not any(r.severity == ValidationSeverity.ERROR for r in results):
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_structure",
+                        rule_name="Workflow Structure Validation",
+                        status=ValidationStatus.PASSED,
+                        severity=ValidationSeverity.INFO,
+                        message="Workflow definition validation passed",
+                        details={
+                            "step_count": len(workflow_def.steps),
+                            "workflow_type": workflow_def.workflow_type.value,
+                        },
+                    )
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            results.append(
+                self._create_result(
+                    rule_id="workflow_structure",
+                    rule_name="Workflow Structure Validation",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.CRITICAL,
+                    message=f"Workflow validation error: {e}",
+                    details={"error_type": type(e).__name__},
+                )
+            )
+
+        return results
+
+    def _validate_workflow_steps(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
+        results: List[ValidationResult] = []
+
+        for i, step in enumerate(steps):
+            if not step.step_id or not step.step_id.strip():
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_structure",
+                        rule_name="Workflow Structure Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Step {i} must have valid ID",
+                        details={"step_index": i, "step_id": step.step_id},
+                    )
+                )
+
+            if not step.name or not step.name.strip():
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_structure",
+                        rule_name="Workflow Structure Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Step {i} must have valid name",
+                        details={"step_index": i, "step_name": step.name},
+                    )
+                )
+
+            if not step.step_type or not step.step_type.strip():
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_structure",
+                        rule_name="Workflow Structure Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Step {i} must have valid type",
+                        details={"step_index": i, "step_type": step.step_type},
+                    )
+                )
+
+            if step.estimated_duration < 0:
+                results.append(
+                    self._create_result(
+                        rule_id="workflow_structure",
+                        rule_name="Workflow Structure Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.WARNING,
+                        message=f"Step {i} has negative estimated duration",
+                        details={
+                            "step_index": i,
+                            "estimated_duration": step.estimated_duration,
+                        },
+                    )
+                )
+
+        return results
+
+    def _validate_step_dependencies(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
+        results: List[ValidationResult] = []
+        step_ids = {step.step_id for step in steps}
+
+        for i, step in enumerate(steps):
+            for dep in step.dependencies:
+                if dep not in step_ids:
+                    results.append(
+                        self._create_result(
+                            rule_id="step_dependencies",
+                            rule_name="Step Dependencies Validation",
+                            status=ValidationStatus.FAILED,
+                            severity=ValidationSeverity.ERROR,
+                            message=f"Step {i} references non-existent dependency: {dep}",
+                            details={
+                                "step_index": i,
+                                "step_id": step.step_id,
+                                "invalid_dependency": dep,
+                            },
+                        )
+                    )
+
+            if step.step_id in step.dependencies:
+                results.append(
+                    self._create_result(
+                        rule_id="step_dependencies",
+                        rule_name="Step Dependencies Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Step {i} has self-dependency",
+                        details={"step_index": i, "step_id": step.step_id},
+                    )
+                )
+
+        results.extend(self._detect_dependency_cycles(steps))
+        return results
+
+    def _detect_dependency_cycles(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
+        results: List[ValidationResult] = []
+
+        for i, step in enumerate(steps):
+            visited = set()
+            if self._has_cycle_recursive(step, steps, visited, set()):
+                results.append(
+                    self._create_result(
+                        rule_id="step_dependencies",
+                        rule_name="Step Dependencies Validation",
+                        status=ValidationStatus.FAILED,
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Circular dependency detected involving step {i}",
+                        details={"step_index": i, "step_id": step.step_id},
+                    )
+                )
+
+        return results
+
+    def _has_cycle_recursive(
+        self, step: WorkflowStep, all_steps: List[WorkflowStep], visited: set, path: set
+    ) -> bool:
+        if step.step_id in path:
+            return True
+        if step.step_id in visited:
+            return False
+
+        visited.add(step.step_id)
+        path.add(step.step_id)
+
+        for dep_id in step.dependencies:
+            dep_step = next((s for s in all_steps if s.step_id == dep_id), None)
+            if dep_step and self._has_cycle_recursive(dep_step, all_steps, visited, path):
+                return True
+
+        path.remove(step.step_id)
+        return False

--- a/src/core/workflow/validation/workflow_validator.py
+++ b/src/core/workflow/validation/workflow_validator.py
@@ -1,414 +1,48 @@
-#!/usr/bin/env python3
-"""
-Workflow Validator - Unified Validation Framework Integration
+"""Coordinator for workflow validation."""
 
-This module provides workflow-specific validation by extending the existing
-Unified Validation Framework. It adds workflow-specific validation rules
-and integrates with the workflow engine for real-time validation.
+from typing import Any, Dict, List
 
-Author: Agent-1 (Core Engine Development)
-License: MIT
-"""
+from src.core.validation import BaseValidator, ValidationResult
 
-import sys
-import os
-from pathlib import Path
-from typing import Dict, List, Any, Optional
-
-# Add the src directory to the Python path for validation framework access
-current_dir = Path.cwd()
-sys.path.insert(0, str(current_dir))
-
-from src.core.validation import BaseValidator, ValidationResult, ValidationSeverity, ValidationStatus, ValidationRule
-from ..types.workflow_enums import WorkflowStatus, TaskStatus, WorkflowType
-from ..types.workflow_models import WorkflowDefinition, WorkflowExecution, WorkflowStep
+from .structure_validator import WorkflowStructureValidator
+from .execution_validator import WorkflowExecutionValidator
+from .performance_validator import WorkflowPerformanceValidator
+from ..types.workflow_models import WorkflowDefinition, WorkflowExecution
 
 
 class WorkflowValidator(BaseValidator):
-    """Workflow-specific validator extending the Unified Validation Framework"""
-    
-    def __init__(self):
-        """Initialize workflow validator"""
+    """Aggregate workflow validator that delegates to specialized validators."""
+
+    def __init__(self) -> None:
+        self.structure_validator = WorkflowStructureValidator()
+        self.execution_validator = WorkflowExecutionValidator()
+        self.performance_validator = WorkflowPerformanceValidator()
         super().__init__("WorkflowValidator")
-        self._setup_workflow_rules()
-    
-    def _setup_workflow_rules(self) -> None:
-        """Setup workflow-specific validation rules"""
-        workflow_rules = [
-            ValidationRule(
-                rule_id="workflow_structure",
-                rule_name="Workflow Structure Validation",
-                rule_type="workflow",
-                description="Validate workflow definition structure and integrity",
-                severity=ValidationSeverity.ERROR
-            ),
-            ValidationRule(
-                rule_id="step_dependencies",
-                rule_name="Step Dependencies Validation",
-                rule_type="workflow",
-                description="Validate workflow step dependencies and cycles",
-                severity=ValidationSeverity.ERROR
-            ),
-            ValidationRule(
-                rule_id="workflow_execution",
-                rule_name="Workflow Execution Validation",
-                rule_type="workflow",
-                description="Validate workflow execution state and transitions",
-                severity=ValidationSeverity.ERROR
-            ),
-            ValidationRule(
-                rule_id="performance_metrics",
-                rule_name="Performance Metrics Validation",
-                rule_type="workflow",
-                description="Validate workflow performance and optimization",
-                severity=ValidationSeverity.WARNING
-            )
-        ]
-        
-        for rule in workflow_rules:
-            self.add_validation_rule(rule)
-    
-    def validate_workflow_definition(self, workflow_def: WorkflowDefinition) -> List[ValidationResult]:
-        """Validate workflow definition structure and integrity"""
-        results = []
-        
-        try:
-            # Validate basic structure
-            if not workflow_def.workflow_id or not workflow_def.name:
-                results.append(self._create_result(
-                    rule_id="workflow_structure",
-                    rule_name="Workflow Structure Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message="Workflow must have valid ID and name",
-                    details={"workflow_id": workflow_def.workflow_id, "name": workflow_def.name}
-                ))
-            
-            # Validate steps
-            if not workflow_def.steps:
-                results.append(self._create_result(
-                    rule_id="workflow_structure",
-                    rule_name="Workflow Structure Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message="Workflow must have at least one step",
-                    details={"step_count": len(workflow_def.steps)}
-                ))
-            else:
-                # Validate individual steps
-                step_results = self._validate_workflow_steps(workflow_def.steps)
-                results.extend(step_results)
-                
-                # Validate step dependencies
-                dependency_results = self._validate_step_dependencies(workflow_def.steps)
-                results.extend(dependency_results)
-            
-            # Validate workflow type
-            if workflow_def.workflow_type not in WorkflowType:
-                results.append(self._create_result(
-                    rule_id="workflow_structure",
-                    rule_name="Workflow Structure Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message="Invalid workflow type",
-                    details={"workflow_type": workflow_def.workflow_type, "valid_types": [t.value for t in WorkflowType]}
-                ))
-            
-            # Add success result if no critical errors
-            if not any(r.severity == ValidationSeverity.ERROR for r in results):
-                results.append(self._create_result(
-                    rule_id="workflow_structure",
-                    rule_name="Workflow Structure Validation",
-                    status=ValidationStatus.PASSED,
-                    severity=ValidationSeverity.INFO,
-                    message="Workflow definition validation passed",
-                    details={"step_count": len(workflow_def.steps), "workflow_type": workflow_def.workflow_type.value}
-                ))
-            
-        except Exception as e:
-            results.append(self._create_result(
-                rule_id="workflow_structure",
-                rule_name="Workflow Structure Validation",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.CRITICAL,
-                message=f"Workflow validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
-            ))
-        
-        return results
-    
-    def validate_workflow_execution(self, execution: WorkflowExecution) -> List[ValidationResult]:
-        """Validate workflow execution state and transitions"""
-        results = []
-        
-        try:
-            # Validate execution state
-            if execution.status not in WorkflowStatus:
-                results.append(self._create_result(
-                    rule_id="workflow_execution",
-                    rule_name="Workflow Execution Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message="Invalid workflow execution status",
-                    details={"status": execution.status, "valid_statuses": [s.value for s in WorkflowStatus]}
-                ))
-            
-            # Validate step execution states
-            if execution.steps:
-                step_execution_results = self._validate_step_execution_states(execution.steps)
-                results.extend(step_execution_results)
-            
-            # Validate execution timing
-            if execution.start_time and execution.end_time:
-                timing_results = self._validate_execution_timing(execution)
-                results.extend(timing_results)
-            
-            # Add success result if no critical errors
-            if not any(r.severity == ValidationSeverity.ERROR for r in results):
-                results.append(self._create_result(
-                    rule_id="workflow_execution",
-                    rule_name="Workflow Execution Validation",
-                    status=ValidationStatus.PASSED,
-                    severity=ValidationSeverity.INFO,
-                    message="Workflow execution validation passed",
-                    details={"status": execution.status.value, "step_count": len(execution.steps)}
-                ))
-            
-        except Exception as e:
-            results.append(self._create_result(
-                rule_id="workflow_execution",
-                rule_name="Workflow Execution Validation",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.CRITICAL,
-                message=f"Execution validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
-            ))
-        
-        return results
-    
-    def _validate_workflow_steps(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
-        """Validate individual workflow steps"""
-        results = []
-        
-        for i, step in enumerate(steps):
-            # Validate step ID
-            if not step.step_id or not step.step_id.strip():
-                results.append(self._create_result(
-                    rule_id="workflow_structure",
-                    rule_name="Workflow Structure Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Step {i} must have valid ID",
-                    details={"step_index": i, "step_id": step.step_id}
-                ))
-            
-            # Validate step name
-            if not step.name or not step.name.strip():
-                results.append(self._create_result(
-                    rule_id="workflow_structure",
-                    rule_name="Workflow Structure Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Step {i} must have valid name",
-                    details={"step_index": i, "step_name": step.name}
-                ))
-            
-            # Validate step type
-            if not step.step_type or not step.step_type.strip():
-                results.append(self._create_result(
-                    rule_id="workflow_structure",
-                    rule_name="Workflow Structure Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Step {i} must have valid type",
-                    details={"step_index": i, "step_type": step.step_type}
-                ))
-            
-            # Validate estimated duration
-            if step.estimated_duration < 0:
-                results.append(self._create_result(
-                    rule_id="workflow_structure",
-                    rule_name="Workflow Structure Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.WARNING,
-                    message=f"Step {i} has negative estimated duration",
-                    details={"step_index": i, "estimated_duration": step.estimated_duration}
-                ))
-        
-        return results
-    
-    def _validate_step_dependencies(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
-        """Validate step dependencies and detect cycles"""
-        results = []
-        
-        # Create step ID mapping
-        step_ids = {step.step_id for step in steps}
-        
-        for i, step in enumerate(steps):
-            # Validate dependency references
-            for dep in step.dependencies:
-                if dep not in step_ids:
-                    results.append(self._create_result(
-                        rule_id="step_dependencies",
-                        rule_name="Step Dependencies Validation",
-                        status=ValidationStatus.FAILED,
-                        severity=ValidationSeverity.ERROR,
-                        message=f"Step {i} references non-existent dependency: {dep}",
-                        details={"step_index": i, "step_id": step.step_id, "invalid_dependency": dep}
-                    ))
-            
-            # Check for self-dependencies
-            if step.step_id in step.dependencies:
-                results.append(self._create_result(
-                    rule_id="step_dependencies",
-                    rule_name="Step Dependencies Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Step {i} has self-dependency",
-                    details={"step_index": i, "step_id": step.step_id}
-                ))
-        
-        # Detect cycles (simplified cycle detection)
-        cycle_results = self._detect_dependency_cycles(steps)
-        results.extend(cycle_results)
-        
-        return results
-    
-    def _detect_dependency_cycles(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
-        """Detect circular dependencies in workflow steps"""
-        results = []
-        
-        # Simple cycle detection - check for obvious cycles
-        for i, step in enumerate(steps):
-            visited = set()
-            if self._has_cycle_recursive(step, steps, visited, set()):
-                results.append(self._create_result(
-                    rule_id="step_dependencies",
-                    rule_name="Step Dependencies Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Circular dependency detected involving step {i}",
-                    details={"step_index": i, "step_id": step.step_id}
-                ))
-        
-        return results
-    
-    def _has_cycle_recursive(self, step: WorkflowStep, all_steps: List[WorkflowStep], visited: set, path: set) -> bool:
-        """Recursively check for cycles in dependency graph"""
-        if step.step_id in path:
-            return True
-        
-        if step.step_id in visited:
-            return False
-        
-        visited.add(step.step_id)
-        path.add(step.step_id)
-        
-        for dep_id in step.dependencies:
-            dep_step = next((s for s in all_steps if s.step_id == dep_id), None)
-            if dep_step and self._has_cycle_recursive(dep_step, all_steps, visited, path):
-                return True
-        
-        path.remove(step.step_id)
-        return False
-    
-    def _validate_step_execution_states(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
-        """Validate step execution states during workflow execution"""
-        results = []
-        
-        for i, step in enumerate(steps):
-            if step.status not in TaskStatus:
-                results.append(self._create_result(
-                    rule_id="workflow_execution",
-                    rule_name="Workflow Execution Validation",
-                    status=ValidationStatus.FAILED,
-                    severity=ValidationSeverity.ERROR,
-                    message=f"Step {i} has invalid execution status",
-                    details={"step_index": i, "step_id": step.step_id, "status": step.status}
-                ))
-            
-            # Validate timing consistency
-            if step.start_time and step.end_time:
-                if step.start_time > step.end_time:
-                    results.append(self._create_result(
-                        rule_id="workflow_execution",
-                        rule_name="Workflow Execution Validation",
-                        status=ValidationStatus.FAILED,
-                        severity=ValidationSeverity.WARNING,
-                        message=f"Step {i} has inconsistent timing",
-                        details={"step_index": i, "step_id": step.step_id, "start_time": step.start_time, "end_time": step.end_time}
-                    ))
-        
-        return results
-    
-    def _validate_execution_timing(self, execution: WorkflowExecution) -> List[ValidationResult]:
-        """Validate workflow execution timing"""
-        results = []
-        
-        # Validate start time is before end time
-        if execution.start_time > execution.end_time:
-            results.append(self._create_result(
-                rule_id="workflow_execution",
-                rule_name="Workflow Execution Validation",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.WARNING,
-                message="Workflow execution has inconsistent timing",
-                details={"start_time": execution.start_time, "end_time": execution.end_time}
-            ))
-        
-        return results
-    
-    def validate_workflow_performance(self, workflow_def: WorkflowDefinition, execution: WorkflowExecution) -> List[ValidationResult]:
-        """Validate workflow performance metrics"""
-        results = []
-        
-        try:
-            # Calculate total estimated duration
-            total_estimated = sum(step.estimated_duration for step in workflow_def.steps)
-            
-            # Check if actual execution time is reasonable
-            if execution.start_time and execution.end_time:
-                actual_duration = (execution.end_time - execution.start_time).total_seconds()
-                
-                # Allow 20% variance
-                variance_threshold = total_estimated * 0.2
-                if abs(actual_duration - total_estimated) > variance_threshold:
-                    results.append(self._create_result(
-                        rule_id="performance_metrics",
-                        rule_name="Performance Metrics Validation",
-                        status=ValidationStatus.PASSED,
-                        severity=ValidationSeverity.WARNING,
-                        message="Workflow execution time differs significantly from estimate",
-                        details={
-                            "estimated_duration": total_estimated,
-                            "actual_duration": actual_duration,
-                            "variance": abs(actual_duration - total_estimated),
-                            "threshold": variance_threshold
-                        }
-                    ))
-            
-            # Check for performance optimization opportunities
-            long_steps = [step for step in workflow_def.steps if step.estimated_duration > 300]  # 5 minutes
-            if long_steps:
-                results.append(self._create_result(
-                    rule_id="performance_metrics",
-                    rule_name="Performance Metrics Validation",
-                    status=ValidationStatus.PASSED,
-                    severity=ValidationSeverity.LOW,
-                    message="Long-running steps detected - consider optimization",
-                    details={
-                        "long_steps": [{"step_id": s.step_id, "duration": s.estimated_duration} for s in long_steps]
-                    }
-                ))
-            
-        except Exception as e:
-            results.append(self._create_result(
-                rule_id="performance_metrics",
-                rule_name="Performance Metrics Validation",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.WARNING,
-                message=f"Performance validation error: {str(e)}",
-                details={"error_type": type(e).__name__}
-            ))
-        
+
+    def _setup_default_rules(self) -> None:  # pragma: no cover - simple delegation
+        for validator in (
+            self.structure_validator,
+            self.execution_validator,
+            self.performance_validator,
+        ):
+            for rule in validator.get_validation_rules().values():
+                self.add_validation_rule(rule)
+
+    def validate(self, data: Dict[str, Any], **_) -> List[ValidationResult]:
+        results: List[ValidationResult] = []
+
+        definition: WorkflowDefinition | None = data.get("definition")
+        execution: WorkflowExecution | None = data.get("execution")
+
+        if definition is not None:
+            results.extend(self.structure_validator.validate(definition))
+        if execution is not None:
+            results.extend(self.execution_validator.validate(execution))
+        if definition is not None and execution is not None:
+            results.extend(self.performance_validator.validate(definition, execution))
+
+        self.validation_history.extend(results)
+        if len(self.validation_history) > 1000:
+            self.validation_history = self.validation_history[-1000:]
+
         return results


### PR DESCRIPTION
## Summary
- extract validation enums and dataclasses into dedicated `models` module
- split monolithic workflow validator into structure, execution, and performance validators coordinated by a lightweight wrapper
- streamline base validator by importing shared models and delegating rule aggregation

## Testing
- `pre-commit run --files src/core/validation/models.py src/core/validation/base_validator.py src/core/validation/__init__.py src/core/workflow/validation/workflow_validator.py src/core/workflow/validation/structure_validator.py src/core/workflow/validation/execution_validator.py src/core/workflow/validation/performance_validator.py src/core/workflow/validation/__init__.py` (interrupted: KeyboardInterrupt)
- `pytest` (errors: ModuleNotFoundError: No module named 'flask', plus other missing dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68ad9ac7ccf88329bb8f687f9a7dc144