### PR TITLE
Forward kwargs to orchestrator and extract deprecated compatibility mixin

### DIFF
--- a/src/core/performance/orchestrator_compat.py
+++ b/src/core/performance/orchestrator_compat.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Legacy compatibility mixin for :class:`UnifiedPerformanceOrchestrator`.
+
+Provides deprecated methods that wrap newer orchestrator APIs to maintain
+backward compatibility with existing callers.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, List, Optional
+
+from .performance_models import BenchmarkResult, SystemPerformanceReport
+
+
+class OrchestratorCompatibilityMixin:
+    """Deprecated wrappers exposing the legacy interface."""
+
+    def run_benchmarks(self, benchmark_types: Optional[List[str]] = None) -> List[BenchmarkResult]:
+        """Run multiple benchmarks sequentially.
+
+        This method mirrors legacy behaviour and is maintained for backward
+        compatibility. It emits a ``DeprecationWarning`` advising callers to
+        switch to :meth:`run_performance_benchmark`.
+        """
+        warnings.warn(
+            "run_benchmarks() is deprecated; use run_performance_benchmark() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        results: List[BenchmarkResult] = []
+        types = benchmark_types or list(self.performance_core.benchmarking_manager.benchmark_configs.keys())
+        for b_type in types:
+            try:
+                results.append(self.run_performance_benchmark(b_type))
+            except Exception as exc:  # noqa: BLE001
+                self.logger.error(f"Failed to run benchmark '{b_type}': {exc}")
+        return results
+
+    def validate_performance(self, rules: Optional[List[Dict[str, Any]]] = None) -> List[Dict[str, Any]]:
+        """Validate collected metrics against configured rules.
+
+        The ``rules`` argument is accepted for compatibility but ignored; rules
+        should be configured directly on the validation manager. A
+        ``DeprecationWarning`` is emitted to guide migration.
+        """
+        warnings.warn(
+            "validate_performance() is deprecated; use validation_manager.validate_metrics() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        metrics = self.performance_core.monitoring_manager.collect_metrics()
+        return self.performance_core.validation_manager.validate_metrics(metrics)
+
+    def generate_report(self, report_type: str = "comprehensive") -> SystemPerformanceReport:
+        """Generate a performance report.
+
+        ``report_type`` is retained for backward compatibility and has no
+        effect. A ``DeprecationWarning`` advises use of the reporting manager
+        directly.
+        """
+        warnings.warn(
+            "generate_report() is deprecated; use reporting_manager.generate_performance_report() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        metrics = self.performance_core.monitoring_manager.collect_metrics()
+        validation_results = self.performance_core.validation_manager.validate_metrics(metrics)
+        benchmark_results = self.run_benchmarks()
+        return self.performance_core.reporting_manager.generate_performance_report(
+            metrics, validation_results, benchmark_results
+        )
+
+    def start(self) -> bool:
+        """Deprecated alias for :meth:`start_system`."""
+        warnings.warn("start() is deprecated; use start_system()", DeprecationWarning, stacklevel=2)
+        return self.start_system()
+
+    def stop(self) -> bool:
+        """Deprecated alias for :meth:`stop_system`."""
+        warnings.warn("stop() is deprecated; use stop_system()", DeprecationWarning, stacklevel=2)
+        return self.stop_system()
+
+    def benchmark(self, types: Optional[List[str]] = None) -> List[BenchmarkResult]:
+        """Deprecated alias for :meth:`run_benchmarks`."""
+        warnings.warn("benchmark() is deprecated; use run_performance_benchmark()", DeprecationWarning, stacklevel=2)
+        return self.run_benchmarks(types)
+
+    def summary(self) -> Dict[str, Any]:
+        """Deprecated alias for :meth:`get_performance_summary`."""
+        warnings.warn("summary() is deprecated; use get_performance_summary()", DeprecationWarning, stacklevel=2)
+        return self.get_performance_summary()
+
+    def validate(self, rules: Optional[List[Dict[str, Any]]] = None) -> List[Dict[str, Any]]:
+        """Deprecated alias for :meth:`validate_performance`."""
+        warnings.warn("validate() is deprecated; use validate_performance()", DeprecationWarning, stacklevel=2)
+        return self.validate_performance(rules)
+
+    def report(self, report_type: str = "comprehensive") -> SystemPerformanceReport:
+        """Deprecated alias for :meth:`generate_report`."""
+        warnings.warn("report() is deprecated; use generate_report()", DeprecationWarning, stacklevel=2)
+        return self.generate_report(report_type)
+
+    def status(self) -> Dict[str, Any]:
+        """Deprecated alias for :meth:`get_system_status`."""
+        warnings.warn("status() is deprecated; use get_system_status()", DeprecationWarning, stacklevel=2)
+        return self.get_system_status()

--- a/src/core/performance/unified_performance_orchestrator.py
+++ b/src/core/performance/unified_performance_orchestrator.py
@@ -345,13 +345,13 @@ class UnifiedPerformanceSystem(UnifiedPerformanceOrchestrator):
     :class:`UnifiedPerformanceOrchestrator` directly instead.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any):
+    def __init__(self, **kwargs: Any):
         warnings.warn(
             "UnifiedPerformanceSystem is deprecated; use UnifiedPerformanceOrchestrator",
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
 
 def main():

--- a/src/core/performance/unified_performance_orchestrator.py
+++ b/src/core/performance/unified_performance_orchestrator.py
@@ -37,15 +37,15 @@ class UnifiedPerformanceOrchestrator(OrchestratorCompatibilityMixin):
         """
         self.logger = logging.getLogger(f"{__name__}.UnifiedPerformanceOrchestrator")
 
-        core_defaults = {
+        core_config = {
             "manager_id": "unified_performance_orchestrator",
             "name": "Unified Performance Orchestrator",
             "description": "Coordinates all performance system components",
         }
-        core_defaults.update(core_kwargs)
+        core_config.update(core_kwargs)
 
         # Initialize performance core with forwarded parameters
-        self.performance_core = PerformanceCore(**core_defaults)
+        self.performance_core = PerformanceCore(**core_config)
 
         # Combined statistics
         self.orchestrator_stats = {

--- a/src/core/performance/unified_performance_orchestrator.py
+++ b/src/core/performance/unified_performance_orchestrator.py
@@ -4,35 +4,49 @@ Unified Performance Orchestrator - Performance System Coordination
 ===============================================================
 
 Orchestrates all performance components using extracted modules.
-Follows V2 standards: ≤400 LOC, SRP, OOP principles.
+Legacy methods are supplied via ``OrchestratorCompatibilityMixin`` to keep the
+core orchestrator focused and within V2 standards (≤400 LOC, SRP, OOP).
 
 Author: Agent-1 (Phase 3 Modularization)
 License: MIT
 """
 
 import logging
-from typing import Dict, List, Optional, Any
+import warnings
+from typing import Any, Dict, List, Optional
 
+from .orchestrator_compat import OrchestratorCompatibilityMixin
 from .performance_core import PerformanceCore
 from .performance_models import (
-    PerformanceMetric, BenchmarkResult, SystemPerformanceReport,
-    PerformanceLevel, ValidationRule, ValidationThreshold
+    BenchmarkResult,
+    SystemPerformanceReport,
+    ValidationRule,
+    ValidationThreshold,
 )
 
 
-class UnifiedPerformanceOrchestrator:
-    """Orchestrates performance system using extracted modules"""
-    
-    def __init__(self):
+class UnifiedPerformanceOrchestrator(OrchestratorCompatibilityMixin):
+    """Orchestrates performance system using extracted modules."""
+
+    def __init__(self, **core_kwargs: Any):
+        """Initialize the orchestrator and forward parameters to ``PerformanceCore``.
+
+        Any keyword arguments supplied are passed through to the underlying
+        :class:`PerformanceCore`, allowing callers to customise the core while
+        keeping this interface stable.
+        """
         self.logger = logging.getLogger(f"{__name__}.UnifiedPerformanceOrchestrator")
-        
-        # Initialize performance core
-        self.performance_core = PerformanceCore(
-            manager_id="unified_performance_orchestrator",
-            name="Unified Performance Orchestrator",
-            description="Coordinates all performance system components"
-        )
-        
+
+        core_defaults = {
+            "manager_id": "unified_performance_orchestrator",
+            "name": "Unified Performance Orchestrator",
+            "description": "Coordinates all performance system components",
+        }
+        core_defaults.update(core_kwargs)
+
+        # Initialize performance core with forwarded parameters
+        self.performance_core = PerformanceCore(**core_defaults)
+
         # Combined statistics
         self.orchestrator_stats = {
             "core_stats": {},
@@ -41,7 +55,7 @@ class UnifiedPerformanceOrchestrator:
             "benchmarking_stats": {},
             "reporting_stats": {}
         }
-        
+
         self.logger.info("Unified Performance Orchestrator initialized")
     
     def start_system(self) -> bool:
@@ -145,7 +159,7 @@ class UnifiedPerformanceOrchestrator:
         except Exception as e:
             self.logger.error(f"Failed to get performance summary: {e}")
             return {"error": str(e)}
-    
+
     def add_custom_metric(
         self,
         name: str,
@@ -325,8 +339,19 @@ class UnifiedPerformanceOrchestrator:
 
 # Backward compatibility - maintain existing interface
 class UnifiedPerformanceSystem(UnifiedPerformanceOrchestrator):
-    """Backward compatibility alias for existing code"""
-    pass
+    """Backward compatibility alias for existing code.
+
+    This class will be removed in a future release. Use
+    :class:`UnifiedPerformanceOrchestrator` directly instead.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        warnings.warn(
+            "UnifiedPerformanceSystem is deprecated; use UnifiedPerformanceOrchestrator",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
 
 def main():

--- a/src/core/unified_performance_system.py
+++ b/src/core/unified_performance_system.py
@@ -12,7 +12,8 @@ License: MIT
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional, Union
+import warnings
+from typing import Any, Dict, List, Optional
 from pathlib import Path
 
 # Import modular components
@@ -34,9 +35,16 @@ class UnifiedPerformanceSystem:
     while maintaining backward compatibility.
     """
     
-    def __init__(self, config_path: Optional[Path] = None):
-        """Initialize the unified performance system."""
-        self.orchestrator = UnifiedPerformanceOrchestrator(config_path)
+    def __init__(self, config_path: Optional[Path] = None, **orchestrator_kwargs: Any):
+        """Initialize the unified performance system.
+
+        Any additional keyword arguments are forwarded to
+        :class:`UnifiedPerformanceOrchestrator` for configurability.
+        """
+        if config_path is not None:
+            orchestrator_kwargs.setdefault("config_path", config_path)
+
+        self.orchestrator = UnifiedPerformanceOrchestrator(**orchestrator_kwargs)
         self.core = PerformanceCore()
         self.monitoring = PerformanceMonitoring()
         self.validation = PerformanceValidation()
@@ -104,37 +112,44 @@ class UnifiedPerformanceSystem:
     # Backward compatibility methods
     def start(self) -> bool:
         """Backward compatibility: start system."""
+        warnings.warn("start() is deprecated; use start_system()", DeprecationWarning, stacklevel=2)
         return self.start_system()
     
     def stop(self) -> bool:
         """Backward compatibility: stop system."""
+        warnings.warn("stop() is deprecated; use stop_system()", DeprecationWarning, stacklevel=2)
         return self.stop_system()
     
     def benchmark(self, types: Optional[List[str]] = None) -> Dict[str, Any]:
         """Backward compatibility: run benchmarks."""
+        warnings.warn("benchmark() is deprecated; use run_benchmarks()", DeprecationWarning, stacklevel=2)
         return self.run_benchmarks(types)
     
     def summary(self) -> Dict[str, Any]:
         """Backward compatibility: get summary."""
+        warnings.warn("summary() is deprecated; use get_performance_summary()", DeprecationWarning, stacklevel=2)
         return self.get_performance_summary()
     
     def validate(self, rules: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
         """Backward compatibility: validate performance."""
+        warnings.warn("validate() is deprecated; use validate_performance()", DeprecationWarning, stacklevel=2)
         return self.validate_performance(rules)
     
     def report(self, report_type: str = "comprehensive") -> Dict[str, Any]:
         """Backward compatibility: generate report."""
+        warnings.warn("report() is deprecated; use generate_report()", DeprecationWarning, stacklevel=2)
         return self.generate_report(report_type)
     
     def status(self) -> Dict[str, Any]:
         """Backward compatibility: get status."""
+        warnings.warn("status() is deprecated; use get_system_status()", DeprecationWarning, stacklevel=2)
         return self.get_system_status()
 
 
 # Factory function for easy instantiation
 def create_performance_system(config_path: Optional[Path] = None) -> UnifiedPerformanceSystem:
     """Create and return a new performance system instance."""
-    return UnifiedPerformanceSystem(config_path)
+    return UnifiedPerformanceSystem(config_path=config_path)
 
 
 # Main execution for CLI usage

--- a/src/core/unified_performance_system.py
+++ b/src/core/unified_performance_system.py
@@ -42,7 +42,7 @@ class UnifiedPerformanceSystem:
         :class:`UnifiedPerformanceOrchestrator` for configurability.
         """
         if config_path is not None:
-            orchestrator_kwargs.setdefault("config_path", config_path)
+            orchestrator_kwargs["config_path"] = config_path
 
         self.orchestrator = UnifiedPerformanceOrchestrator(**orchestrator_kwargs)
         self.core = PerformanceCore()


### PR DESCRIPTION
## Summary
- Forward initialization kwargs to `UnifiedPerformanceOrchestrator` and `UnifiedPerformanceSystem`
- Factor legacy methods into `OrchestratorCompatibilityMixin`, keeping the orchestrator under 400 LOC
- Remove unused typing import from `UnifiedPerformanceSystem` for cleaner style

## Testing
- `pytest tests/ai_ml/test_ai_development_environment.py:: -q` (fails: ModuleNotFoundError: No module named 'coverage')
- `pytest tests/smoke_frontend/test_frontend_smoke.py:: -q` (fails: ModuleNotFoundError: No module named 'coverage')

------
https://chatgpt.com/codex/tasks/task_e_68ad9acb647c8329879b9f6a01cb60d8