### PR TITLE
feat: add performance CLI wrappers and legacy aliases

### DIFF
--- a/docs/examples/CONSOLIDATED_PERFORMANCE_VALIDATION.json
+++ b/docs/examples/CONSOLIDATED_PERFORMANCE_VALIDATION.json
@@ -34,7 +34,7 @@
       "performance_alerts.py",
       "performance_dashboard.py"
     ],
-    "main_orchestrator": "PerformanceValidationOrchestrator",
+    "main_orchestrator": "PerformanceCLIOrchestrator",
     "responsibilities": "Coordinate all performance validation activities through unified interface"
   },
   "extraction_modules": [
@@ -92,7 +92,7 @@
     "4. Extract performance_metrics.py for metrics collection and analysis",
     "5. Extract performance_alerts.py for alert generation and management",
     "6. Extract performance_dashboard.py for dashboard and visualization",
-    "7. Create PerformanceValidationOrchestrator to coordinate all modules",
+    "7. Create PerformanceCLIOrchestrator to coordinate all modules",
     "8. Update imports and dependencies across the entire system",
     "9. Test all performance validation functionality",
     "10. Remove duplicate files and clean up references",
@@ -111,7 +111,7 @@
   ],
   "testing_strategy": [
     "Unit tests for each extracted module (performance_core, metrics, alerts, dashboard)",
-    "Integration tests for the unified PerformanceValidationOrchestrator",
+    "Integration tests for the unified PerformanceCLIOrchestrator",
     "Performance benchmarks to ensure no degradation in validation speed",
     "Regression tests for all existing performance validation functionality",
     "Stress tests for high-volume performance validation scenarios"
@@ -140,7 +140,7 @@
     "performance_metrics.py (180 lines)",
     "performance_alerts.py (160 lines)",
     "performance_dashboard.py (150 lines)",
-    "PerformanceValidationOrchestrator main class",
+    "PerformanceCLIOrchestrator main class",
     "Updated import statements across project",
     "Comprehensive test suite for unified system",
     "Updated documentation and architecture diagrams",
@@ -151,6 +151,6 @@
   "status": "PLANNED",
   "phase": "PHASE_1",
   "completion_date": "TBD",
-  "notes": "This consolidation will eliminate 90% of duplication in performance validation systems and create a unified, maintainable architecture. The PerformanceValidationOrchestrator will serve as the single entry point for all performance validation activities."
+  "notes": "This consolidation will eliminate 90% of duplication in performance validation systems and create a unified, maintainable architecture. The PerformanceCLIOrchestrator will serve as the single entry point for all performance validation activities."
 }
 

--- a/docs/guides/SWARM_DEDUPLICATION_DEPLOYMENT_GUIDE.md
+++ b/docs/guides/SWARM_DEDUPLICATION_DEPLOYMENT_GUIDE.md
@@ -99,13 +99,13 @@ This guide provides a **complete execution strategy** for deploying the swarm to
 - [ ] Create `performance_metrics.py` (180 lines)
 - [ ] Create `performance_alerts.py` (160 lines)
 - [ ] Create `performance_dashboard.py` (150 lines)
-- [ ] Create `PerformanceValidationOrchestrator`
+- [ ] Create `PerformanceCLIOrchestrator`
 - [ ] Remove 8 duplicate performance files
 - [ ] Update all import statements
 
 **Deliverables:**
 - 4 new performance modules
-- PerformanceValidationOrchestrator
+- PerformanceCLIOrchestrator
 - All duplicate files removed
 - Import statements updated
 

--- a/src/core/performance/cli/interface.py
+++ b/src/core/performance/cli/interface.py
@@ -60,7 +60,10 @@ Examples:
         subparsers = parser.add_subparsers(dest="command", help="Available commands")
         
         # Test command
-        test_parser = subparsers.add_parser("test", help="Run performance validation tests")
+        # "validate" kept for backward compatibility with V1 command name
+        test_parser = subparsers.add_parser(
+            "test", aliases=["validate"], help="Run performance validation tests"
+        )
         test_parser.add_argument(
             "--smoke",
             action="store_true",

--- a/src/core/performance/performance_cli.py
+++ b/src/core/performance/performance_cli.py
@@ -86,6 +86,42 @@ class PerformanceValidationCLI(PerformanceCLIOrchestrator):
     pass
 
 
+# Backward compatibility wrapper functions (V1 command names)
+def run_performance_cli(args: Optional[list] = None) -> int:
+    """Run the performance CLI using legacy function name."""
+    return PerformanceCLIOrchestrator().run(args)
+
+
+def run_performance_validation_cli(args: Optional[list] = None) -> int:
+    """Legacy entry point retained for V1 compatibility."""
+    return run_performance_cli(args)
+
+
+def execute_performance_cli_command(command: str, **kwargs) -> int:
+    """Execute a CLI command using legacy function name."""
+    return PerformanceCLIOrchestrator().execute_command(command, **kwargs)
+
+
+def get_performance_cli_help() -> str:
+    """Get CLI help text using legacy function name."""
+    return PerformanceCLIOrchestrator().get_help()
+
+
+def validate_performance_cli_args(args: list) -> bool:
+    """Validate CLI arguments using legacy function name."""
+    return PerformanceCLIOrchestrator().validate_args(args)
+
+
+def get_performance_cli_available_commands() -> list:
+    """Get available commands using legacy function name."""
+    return PerformanceCLIOrchestrator().get_available_commands()
+
+
+def get_performance_cli_command_help(command: str) -> str:
+    """Get command help using legacy function name."""
+    return PerformanceCLIOrchestrator().get_command_help(command)
+
+
 def main():
     """Main entry point for the CLI."""
     cli = PerformanceCLIOrchestrator()


### PR DESCRIPTION
## Summary
- expose backward-compatible wrapper functions delegating to `PerformanceCLIOrchestrator`
- support legacy `validate` command name in performance CLI interface
- update docs to reference `PerformanceCLIOrchestrator` as new entry point

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ad9acc32f883298fac8b0634e9499d