### PR TITLE
Add rebalancing engine with asset weight tracking

### DIFF
--- a/src/services/financial/portfolio/__init__.py
+++ b/src/services/financial/portfolio/__init__.py
@@ -10,24 +10,26 @@ from .rebalancing_core import (
     RebalancingPlan,
     RebalancingSignal,
     RebalancingFrequency,
-    RebalancingTrigger
+    RebalancingTrigger,
 )
 from .portfolio_analysis import PortfolioAnalyzer
 from .rebalancing_executor import RebalancingExecutor
 from .rebalancing import PortfolioRebalancing
+from .rebalancing_engine import RebalancingEngine, WeightSnapshot
 
 __all__ = [
-    'RebalancingCore',
-    'RebalancingPlan', 
-    'RebalancingSignal',
-    'RebalancingFrequency',
-    'RebalancingTrigger',
-    'PortfolioAnalyzer',
-    'RebalancingExecutor',
-    'PortfolioRebalancing'
+    "RebalancingCore",
+    "RebalancingPlan",
+    "RebalancingSignal",
+    "RebalancingFrequency",
+    "RebalancingTrigger",
+    "PortfolioAnalyzer",
+    "RebalancingExecutor",
+    "PortfolioRebalancing",
+    "RebalancingEngine",
+    "WeightSnapshot",
 ]
 
 __version__ = "2.0.0"
 __author__ = "Agent Cellphone V2 Team"
 __description__ = "Modular portfolio rebalancing system following SRP principles"
-

--- a/src/services/financial/portfolio/rebalancing_engine.py
+++ b/src/services/financial/portfolio/rebalancing_engine.py
@@ -51,11 +51,11 @@ class RebalancingEngine:
         return logger
 
     # ------------------------------------------------------------------
-    def update_weights(self, weights: Dict[str, float]) -> None:
+    def update_weights(self, weights: Dict[str, float], timestamp: Optional[datetime] = None) -> None:
         """Update current asset weights and record a snapshot."""
         self.current_weights = weights.copy()
         snapshot = WeightSnapshot(
-            timestamp=datetime.now(), weights=self.current_weights.copy()
+            timestamp=timestamp or datetime.now(), weights=self.current_weights.copy()
         )
         self.weight_history.append(snapshot)
         if len(self.weight_history) > self.max_history:

--- a/src/services/financial/portfolio/rebalancing_engine.py
+++ b/src/services/financial/portfolio/rebalancing_engine.py
@@ -1,0 +1,84 @@
+"""Rebalancing engine for managing asset weights and history.
+
+Single Responsibility: Track portfolio weights and coordinate with rebalancing modules.
+Follows V2 coding standards: Clean OOP design, SRP compliance, focused functionality.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from .rebalancing import PortfolioRebalancing
+from .rebalancing_core import RebalancingPlan
+
+
+@dataclass
+class WeightSnapshot:
+    """Snapshot of asset weights at a specific time."""
+
+    timestamp: datetime
+    weights: Dict[str, float]
+
+
+class RebalancingEngine:
+    """High level engine coordinating weight tracking and rebalancing operations."""
+
+    def __init__(self, threshold: float = 0.05, max_history: int = 100) -> None:
+        self.logger = self._setup_logging()
+        self.threshold = threshold
+        self.max_history = max_history
+        self.current_weights: Dict[str, float] = {}
+        self.weight_history: List[WeightSnapshot] = []
+        self.rebalancer = PortfolioRebalancing()
+        self.logger.info(
+            "RebalancingEngine initialized with threshold %.2f", self.threshold
+        )
+
+    def _setup_logging(self) -> logging.Logger:
+        """Configure logging for the engine."""
+        logger = logging.getLogger("RebalancingEngine")
+        if not logger.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter(
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            )
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+        return logger
+
+    # ------------------------------------------------------------------
+    def update_weights(self, weights: Dict[str, float]) -> None:
+        """Update current asset weights and record a snapshot."""
+        self.current_weights = weights.copy()
+        snapshot = WeightSnapshot(
+            timestamp=datetime.now(), weights=self.current_weights.copy()
+        )
+        self.weight_history.append(snapshot)
+        if len(self.weight_history) > self.max_history:
+            self.weight_history = self.weight_history[-self.max_history :]
+        self.logger.debug("Updated weights: %s", self.current_weights)
+
+    def generate_plan(
+        self,
+        target_weights: Dict[str, float],
+        prices: Optional[Dict[str, float]] = None,
+    ) -> Optional[RebalancingPlan]:
+        """Generate a rebalancing plan via the orchestrator."""
+        if not self.current_weights:
+            self.logger.warning("Current weights are empty; cannot generate plan")
+            return None
+        return self.rebalancer.create_rebalancing_plan(
+            self.current_weights, target_weights, current_prices=prices
+        )
+
+    def execute_plan(self, plan: RebalancingPlan) -> bool:
+        """Execute a previously generated plan."""
+        return self.rebalancer.execute_rebalancing_plan(plan)
+
+    def get_weight_history(self, limit: int = 10) -> List[WeightSnapshot]:
+        """Return recent weight snapshots."""
+        return self.weight_history[-limit:] if limit > 0 else self.weight_history


### PR DESCRIPTION
## Summary
- introduce `RebalancingEngine` with weight history, logging, and threshold configuration
- expose new engine and `WeightSnapshot` via portfolio package

## Testing
- `PYTHONPATH=. pre-commit run --files src/services/financial/portfolio/rebalancing_engine.py src/services/financial/portfolio/__init__.py` *(fails: ModuleNotFoundError: No module named 'src'; duplication detector missing)*
- `PYTHONPATH=src/services/financial/portfolio pytest src/services/financial/portfolio/test_refactored_functionality.py -k test_rebalancing_module -q` *(fails: ImportError: cannot import name 'PortfolioOptimizationAlgorithms' from 'portfolio')*

------
https://chatgpt.com/codex/tasks/task_e_68ad9ace9b108329b0dcf8fd4008199e