### PR TITLE
Enforce BaseManager hook implementation across managers

### DIFF
--- a/src/core/base_manager.py
+++ b/src/core/base_manager.py
@@ -528,32 +528,32 @@ class BaseManager(ABC):
     @abstractmethod
     def _on_start(self) -> bool:
         """Subclass-specific startup logic"""
-        pass
+        raise NotImplementedError
     
     @abstractmethod
     def _on_stop(self):
         """Subclass-specific shutdown logic"""
-        pass
+        raise NotImplementedError
     
     @abstractmethod
     def _on_heartbeat(self):
         """Subclass-specific heartbeat logic"""
-        pass
+        raise NotImplementedError
     
     @abstractmethod
     def _on_initialize_resources(self) -> bool:
         """Subclass-specific resource initialization"""
-        pass
+        raise NotImplementedError
     
     @abstractmethod
     def _on_cleanup_resources(self):
         """Subclass-specific resource cleanup"""
-        pass
+        raise NotImplementedError
     
     @abstractmethod
     def _on_recovery_attempt(self, error: Exception, context: str) -> bool:
         """Subclass-specific recovery logic"""
-        pass
+        raise NotImplementedError
     
     # ============================================================================
     # UTILITY METHODS - Previously duplicated across all managers

--- a/src/core/decision/decision_core.py
+++ b/src/core/decision/decision_core.py
@@ -129,6 +129,36 @@ class DecisionCore(BaseManager):
             
         except Exception as e:
             self.logger.error(f"Error during Decision Core heartbeat: {e}")
+
+    def _on_initialize_resources(self) -> bool:
+        """Initialize decision core resources"""
+        try:
+            # Resources are initialized in __init__
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to initialize resources: {e}")
+            return False
+
+    def _on_cleanup_resources(self):
+        """Cleanup decision core resources"""
+        try:
+            self.active_decisions.clear()
+            self.decision_history.clear()
+            self.pending_decisions.clear()
+        except Exception as e:
+            self.logger.error(f"Failed to cleanup resources: {e}")
+
+    def _on_recovery_attempt(self, error: Exception, context: str) -> bool:
+        """Attempt to recover from an error"""
+        try:
+            self.logger.warning(f"Recovery attempt for {context}: {error}")
+            # Basic reset of tracking structures
+            self.active_decisions.clear()
+            self.pending_decisions.clear()
+            return True
+        except Exception as e:
+            self.logger.error(f"Recovery failed: {e}")
+            return False
     
     def make_decision(
         self,

--- a/src/core/decision/decision_manager.py
+++ b/src/core/decision/decision_manager.py
@@ -129,6 +129,33 @@ class DecisionManager(BaseManager):
             
         except Exception as e:
             self.logger.error(f"Error during Decision Manager heartbeat: {e}")
+
+    def _on_initialize_resources(self) -> bool:
+        """Initialize decision manager resources"""
+        try:
+            self.integration_status["last_health_check"] = datetime.now().isoformat()
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to initialize resources: {e}")
+            return False
+
+    def _on_cleanup_resources(self):
+        """Cleanup decision manager resources"""
+        try:
+            self.decision_core.stop()
+            self.integration_status["integration_active"] = False
+        except Exception as e:
+            self.logger.error(f"Failed to cleanup resources: {e}")
+
+    def _on_recovery_attempt(self, error: Exception, context: str) -> bool:
+        """Attempt to recover from an error"""
+        try:
+            self.logger.warning(f"Recovery attempt for {context}: {error}")
+            self.integration_status["last_error"] = str(error)
+            return True
+        except Exception as e:
+            self.logger.error(f"Recovery failed: {e}")
+            return False
     
     def make_decision(
         self,


### PR DESCRIPTION
## Summary
- Ensure `BaseManager` lifecycle hooks raise `NotImplementedError` instead of silently passing
- Add resource init, cleanup, and recovery hook implementations to `DecisionCore`
- Implement missing lifecycle hooks in `DecisionManager` to satisfy `BaseManager`

## Testing
- `python -m py_compile src/core/base_manager.py src/core/decision/decision_core.py src/core/decision/decision_manager.py`
- `pytest tests/core/test_tdd_integration_suite.py::TestTDDSystemIntegration::test_message_queue_decision_integration_tdd -q` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9ad29c6883299e7f760087faf3b8