### PR TITLE
Add persistence backend to V2MessageStorage and enforce interface contracts

### DIFF
--- a/src/services/messaging/interfaces.py
+++ b/src/services/messaging/interfaces.py
@@ -19,6 +19,7 @@ from enum import Enum
 @dataclass
 class CoordinateData:
     """Data structure for agent coordinates"""
+
     agent_id: str
     mode: str
     input_box: Tuple[int, int]
@@ -27,37 +28,39 @@ class CoordinateData:
 
 class MessagingMode(Enum):
     """Available messaging modes"""
-    PYAUTOGUI = "pyautogui"      # Default: Coordinate-based messaging
-    CDP = "cdp"                  # Chrome DevTools Protocol (headless)
-    HTTP = "http"                # HTTP/HTTPS communication
-    WEBSOCKET = "websocket"      # WebSocket communication
-    TCP = "tcp"                  # TCP communication
-    FSM = "fsm"                  # FSM-driven coordination
-    ONBOARDING = "onboarding"    # Agent onboarding workflows
-    CAMPAIGN = "campaign"        # Election/broadcast campaigns
-    YOLO = "yolo"               # Automatic mode with FSM activation
+
+    PYAUTOGUI = "pyautogui"  # Default: Coordinate-based messaging
+    CDP = "cdp"  # Chrome DevTools Protocol (headless)
+    HTTP = "http"  # HTTP/HTTPS communication
+    WEBSOCKET = "websocket"  # WebSocket communication
+    TCP = "tcp"  # TCP communication
+    FSM = "fsm"  # FSM-driven coordination
+    ONBOARDING = "onboarding"  # Agent onboarding workflows
+    CAMPAIGN = "campaign"  # Election/broadcast campaigns
+    YOLO = "yolo"  # Automatic mode with FSM activation
 
 
 class MessageType(Enum):
     """Message types for different modes"""
+
     # General messaging
     TEXT = "text"
     COMMAND = "command"
     BROADCAST = "broadcast"
-    
+
     # High priority messaging
-    HIGH_PRIORITY = "high_priority"      # Urgent messages with Ctrl+Enter 2x
-    
+    HIGH_PRIORITY = "high_priority"  # Urgent messages with Ctrl+Enter 2x
+
     # FSM coordination
     TASK_ASSIGNMENT = "task_assignment"
     STATUS_UPDATE = "status_update"
     COORDINATION = "coordination"
-    
+
     # Onboarding
     ONBOARDING_START = "onboarding_start"
     TRAINING_MODULE = "training_module"
     ROLE_ASSIGNMENT = "role_assignment"
-    
+
     # Campaign
     ELECTION_BROADCAST = "election_broadcast"
     CAMPAIGN_UPDATE = "campaign_update"
@@ -66,112 +69,127 @@ class MessageType(Enum):
 
 class IMessageSender(ABC):
     """Interface for message sending capabilities"""
-    
+
     @abstractmethod
     def send_message(self, recipient: str, message_content: str) -> bool:
         """Send a message to a recipient"""
-        pass
+        raise NotImplementedError("send_message must be implemented")
 
 
 class ICoordinateManager(ABC):
     """Interface for coordinate management"""
-    
+
     @abstractmethod
     def get_agent_coordinates(self, agent_id: str, mode: str) -> Optional[Any]:
         """Get coordinates for a specific agent"""
-        pass
-    
+        raise NotImplementedError("get_agent_coordinates must be implemented")
+
     @abstractmethod
     def validate_coordinates(self) -> Dict[str, Any]:
         """Validate all loaded coordinates"""
-        pass
-    
+        raise NotImplementedError("validate_coordinates must be implemented")
+
     @abstractmethod
     def get_available_modes(self) -> List[str]:
         """Get available coordinate modes"""
-        pass
-    
+        raise NotImplementedError("get_available_modes must be implemented")
+
     @abstractmethod
     def get_agents_in_mode(self, mode: str) -> List[str]:
         """Get agents in a specific mode"""
-        pass
-    
+        raise NotImplementedError("get_agents_in_mode must be implemented")
+
     @abstractmethod
     def map_coordinates(self, mode: str = "8-agent") -> Dict[str, Any]:
         """Map and display coordinate information for debugging"""
-        pass
-    
+        raise NotImplementedError("map_coordinates must be implemented")
+
     @abstractmethod
-    def calibrate_coordinates(self, agent_id: str, input_coords: Tuple[int, int], starter_coords: Tuple[int, int], mode: str = "8-agent") -> bool:
+    def calibrate_coordinates(
+        self,
+        agent_id: str,
+        input_coords: Tuple[int, int],
+        starter_coords: Tuple[int, int],
+        mode: str = "8-agent",
+    ) -> bool:
         """Calibrate/update coordinates for a specific agent"""
-        pass
-    
+        raise NotImplementedError("calibrate_coordinates must be implemented")
+
     @abstractmethod
     def consolidate_coordinate_files(self) -> Dict[str, Any]:
         """Consolidate multiple coordinate files"""
-        pass
+        raise NotImplementedError("consolidate_coordinate_files must be implemented")
 
 
 class IBulkMessaging(ABC):
     """Interface for bulk messaging operations"""
-    
+
     @abstractmethod
-    def send_bulk_messages(self, messages: Dict[str, str], mode: str) -> Dict[str, bool]:
+    def send_bulk_messages(
+        self, messages: Dict[str, str], mode: str
+    ) -> Dict[str, bool]:
         """Send messages to multiple agents"""
-        pass
+        raise NotImplementedError("send_bulk_messages must be implemented")
 
 
 class ICampaignMessaging(ABC):
     """Interface for campaign messaging operations"""
-    
+
     @abstractmethod
-    def send_campaign_message(self, message_content: str, campaign_type: str) -> Dict[str, bool]:
+    def send_campaign_message(
+        self, message_content: str, campaign_type: str
+    ) -> Dict[str, bool]:
         """Send campaign message to all agents"""
-        pass
+        raise NotImplementedError("send_campaign_message must be implemented")
 
 
 class IYOLOMessaging(ABC):
     """Interface for YOLO automatic activation messaging"""
-    
+
     @abstractmethod
     def activate_yolo_mode(self, message_content: str) -> Dict[str, bool]:
         """Activate YOLO mode with automatic agent activation"""
-        pass
+        raise NotImplementedError("activate_yolo_mode must be implemented")
 
 
 class ICrossSystemMessaging(ABC):
     """Interface for cross-system communication"""
-    
+
     @abstractmethod
-    async def send_cross_system_message(self, target_system: str, message_content: str, 
-                                      protocol: str) -> bool:
+    async def send_cross_system_message(
+        self, target_system: str, message_content: str, protocol: str
+    ) -> bool:
         """Send message using cross-system communication protocols"""
-        pass
+        raise NotImplementedError("send_cross_system_message must be implemented")
 
 
 class IFSMMessaging(ABC):
     """Interface for FSM-driven coordination messaging"""
-    
+
     @abstractmethod
-    def send_fsm_message(self, agent_id: str, message_type: MessageType, 
-                        payload: Dict[str, Any]) -> bool:
+    def send_fsm_message(
+        self, agent_id: str, message_type: MessageType, payload: Dict[str, Any]
+    ) -> bool:
         """Send FSM-driven coordination message"""
-        pass
+        raise NotImplementedError("send_fsm_message must be implemented")
 
 
 class IOnboardingMessaging(ABC):
     """Interface for agent onboarding messaging"""
-    
+
     @abstractmethod
-    def send_onboarding_message(self, agent_id: str, onboarding_type: MessageType, 
-                              content: str) -> bool:
+    def send_onboarding_message(
+        self, agent_id: str, onboarding_type: MessageType, content: str
+    ) -> bool:
         """Send onboarding message"""
-        pass
+        raise NotImplementedError("send_onboarding_message must be implemented")
 
 
 class CoordinateCaptureInterface(Protocol):
     """Interface for coordinate capture operations"""
-    
-    def capture_agent_coordinates(self, agent_name: str, mode: str = "8-agent") -> Optional[CoordinateData]:
+
+    def capture_agent_coordinates(
+        self, agent_name: str, mode: str = "8-agent"
+    ) -> Optional[CoordinateData]:
         """Capture coordinates for a specific agent"""
         ...

--- a/src/services/messaging/storage/storage.py
+++ b/src/services/messaging/storage/storage.py
@@ -11,7 +11,9 @@ Original file: src/core/v2_comprehensive_messaging_system.py
 Extraction date: 2024-12-19
 """
 
+import json
 import logging
+import sqlite3
 import threading
 import time
 import uuid
@@ -32,30 +34,38 @@ from ..models.v2_message import V2Message
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+
 @dataclass
 class V2AgentInfo:
     """Agent information for storage"""
+
     agent_id: str
     status: str
 
+
 class IMessageStorage(ABC):
     """Interface for message storage"""
-    
+
     @abstractmethod
     def store_message(self, message: V2Message) -> bool:
         """Store a message"""
-        pass
-    
+        raise NotImplementedError("store_message must be implemented")
+
     @abstractmethod
     def get_message(self, message_id: str) -> Optional[V2Message]:
         """Get a message by ID"""
-        pass
+        raise NotImplementedError("get_message must be implemented")
 
 
 class V2MessageStorage(IMessageStorage):
-    """Message storage implementation - SRP: Store and retrieve messages"""
-    
-    def __init__(self):
+    """Message storage implementation - SRP: Store and retrieve messages."""
+
+    def __init__(self, db_path: Optional[str] = None):
+        """Initialize storage.
+
+        Args:
+            db_path: Optional path to SQLite database for persistence.
+        """
         self.messages: Dict[str, V2Message] = {}
         self.agent_messages: Dict[str, List[str]] = defaultdict(list)
         self.type_messages: Dict[V2MessageType, List[str]] = defaultdict(list)
@@ -66,124 +76,175 @@ class V2MessageStorage(IMessageStorage):
             "total_messages": 0,
             "messages_by_type": defaultdict(int),
             "messages_by_status": defaultdict(int),
-            "messages_by_agent": defaultdict(int)
+            "messages_by_agent": defaultdict(int),
         }
-        
+        self.db_path = db_path
+        self.conn: Optional[sqlite3.Connection] = None
+        if db_path:
+            self._init_db()
+
+    def _init_db(self):
+        """Initialize SQLite backend and load existing messages."""
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS messages (message_id TEXT PRIMARY KEY, message_data TEXT)"
+        )
+        self.conn.commit()
+        cursor = self.conn.execute("SELECT message_data FROM messages")
+        for (message_data,) in cursor:
+            data = json.loads(message_data)
+            message = V2Message.from_dict(data)
+            self.messages[message.message_id] = message
+            self._update_indexes(message, "add")
+            self.storage_stats["total_messages"] += 1
+            self.storage_stats["messages_by_type"][message.message_type] += 1
+            self.storage_stats["messages_by_status"][message.status] += 1
+            if message.recipient_id and message.recipient_id != "broadcast":
+                self.storage_stats["messages_by_agent"][message.recipient_id] += 1
+
     def store_message(self, message: V2Message) -> bool:
         """Store a message with indexing"""
         try:
             with self.lock:
                 # Store the message
                 self.messages[message.message_id] = message
-                
+
                 # Update indexes
                 self._update_indexes(message, "add")
-                
+
                 # Update statistics
                 self.storage_stats["total_messages"] += 1
                 self.storage_stats["messages_by_type"][message.message_type] += 1
                 self.storage_stats["messages_by_status"][message.status] += 1
-                
+
                 if message.recipient_id and message.recipient_id != "broadcast":
                     self.storage_stats["messages_by_agent"][message.recipient_id] += 1
-                
+
+                # Persist to database if configured
+                if self.conn:
+                    self.conn.execute(
+                        "INSERT OR REPLACE INTO messages (message_id, message_data) VALUES (?, ?)",
+                        (message.message_id, json.dumps(message.to_dict())),
+                    )
+                    self.conn.commit()
+
                 logger.debug(f"Stored message {message.message_id}")
                 return True
-                
+
         except Exception as e:
             logger.error(f"Failed to store message: {e}")
             return False
-    
+
     def get_message(self, message_id: str) -> Optional[V2Message]:
         """Retrieve a message by ID"""
         try:
             with self.lock:
-                return self.messages.get(message_id)
+                message = self.messages.get(message_id)
+                if message:
+                    return message
+                if self.conn:
+                    cursor = self.conn.execute(
+                        "SELECT message_data FROM messages WHERE message_id=?",
+                        (message_id,),
+                    )
+                    row = cursor.fetchone()
+                    if row:
+                        data = json.loads(row[0])
+                        message = V2Message.from_dict(data)
+                        self.messages[message_id] = message
+                        self._update_indexes(message, "add")
+                        return message
+                return None
         except Exception as e:
             logger.error(f"Failed to get message {message_id}: {e}")
             return None
-    
-    def get_messages_for_agent(self, agent_id: str, 
-                              message_type: Optional[V2MessageType] = None,
-                              status: Optional[V2MessageStatus] = None,
-                              limit: Optional[int] = None) -> List[V2Message]:
+
+    def get_messages_for_agent(
+        self,
+        agent_id: str,
+        message_type: Optional[V2MessageType] = None,
+        status: Optional[V2MessageStatus] = None,
+        limit: Optional[int] = None,
+    ) -> List[V2Message]:
         """Get messages for an agent with optional filtering"""
         try:
             messages = []
             with self.lock:
                 # Get message IDs for this agent
                 agent_message_ids = self.agent_messages.get(agent_id, [])
-                
+
                 for message_id in agent_message_ids:
                     if message_id in self.messages:
                         message = self.messages[message_id]
-                        
+
                         # Apply filters
                         if message_type and message.message_type != message_type:
                             continue
                         if status and message.status != status:
                             continue
-                        
+
                         messages.append(message)
-                        
+
                         # Apply limit if specified
                         if limit and len(messages) >= limit:
                             break
-            
+
             # Sort by priority (highest first) then by timestamp (oldest first)
             messages.sort(key=lambda m: (m.priority.value, m.timestamp), reverse=True)
             return messages
-            
+
         except Exception as e:
             logger.error(f"Failed to get messages for agent {agent_id}: {e}")
             return []
-    
-    def get_messages_by_type(self, message_type: V2MessageType, 
-                            limit: Optional[int] = None) -> List[V2Message]:
+
+    def get_messages_by_type(
+        self, message_type: V2MessageType, limit: Optional[int] = None
+    ) -> List[V2Message]:
         """Get messages by type"""
         try:
             messages = []
             with self.lock:
                 type_message_ids = self.type_messages.get(message_type, [])
-                
+
                 for message_id in type_message_ids:
                     if message_id in self.messages:
                         messages.append(self.messages[message_id])
-                        
+
                         if limit and len(messages) >= limit:
                             break
-            
+
             # Sort by timestamp (newest first)
             messages.sort(key=lambda m: m.timestamp, reverse=True)
             return messages
-            
+
         except Exception as e:
             logger.error(f"Failed to get messages by type {message_type}: {e}")
             return []
-    
-    def get_messages_by_status(self, status: V2MessageStatus, 
-                              limit: Optional[int] = None) -> List[V2Message]:
+
+    def get_messages_by_status(
+        self, status: V2MessageStatus, limit: Optional[int] = None
+    ) -> List[V2Message]:
         """Get messages by status"""
         try:
             messages = []
             with self.lock:
                 status_message_ids = self.status_messages.get(status, [])
-                
+
                 for message_id in status_message_ids:
                     if message_id in self.messages:
                         messages.append(self.messages[message_id])
-                        
+
                         if limit and len(messages) >= limit:
                             break
-            
+
             # Sort by timestamp (newest first)
             messages.sort(key=lambda m: m.timestamp, reverse=True)
             return messages
-            
+
         except Exception as e:
             logger.error(f"Failed to get messages by status {status}: {e}")
             return []
-    
+
     def update_message_status(self, message_id: str, status: V2MessageStatus) -> bool:
         """Update message status"""
         try:
@@ -191,57 +252,77 @@ class V2MessageStorage(IMessageStorage):
                 if message_id in self.messages:
                     old_status = self.messages[message_id].status
                     self.messages[message_id].status = status
-                    
+
                     # Update status index
                     if old_status != status:
                         # Remove from old status index
                         if message_id in self.status_messages[old_status]:
                             self.status_messages[old_status].remove(message_id)
-                        
+
                         # Add to new status index
                         self.status_messages[status].append(message_id)
-                        
+
                         # Update statistics
                         self.storage_stats["messages_by_status"][old_status] -= 1
                         self.storage_stats["messages_by_status"][status] += 1
-                    
+
+                    # Persist update if using database
+                    if self.conn:
+                        self.conn.execute(
+                            "UPDATE messages SET message_data=? WHERE message_id=?",
+                            (
+                                json.dumps(self.messages[message_id].to_dict()),
+                                message_id,
+                            ),
+                        )
+                        self.conn.commit()
+
                     logger.debug(f"Updated message {message_id} status to {status}")
                     return True
                 return False
-                
+
         except Exception as e:
             logger.error(f"Failed to update message status: {e}")
             return False
-    
+
     def delete_message(self, message_id: str) -> bool:
         """Delete a message"""
         try:
             with self.lock:
                 if message_id in self.messages:
                     message = self.messages[message_id]
-                    
+
                     # Remove from indexes
                     self._update_indexes(message, "remove")
-                    
+
                     # Update statistics
                     self.storage_stats["total_messages"] -= 1
                     self.storage_stats["messages_by_type"][message.message_type] -= 1
                     self.storage_stats["messages_by_status"][message.status] -= 1
-                    
+
                     if message.recipient_id and message.recipient_id != "broadcast":
-                        self.storage_stats["messages_by_agent"][message.recipient_id] -= 1
-                    
+                        self.storage_stats["messages_by_agent"][
+                            message.recipient_id
+                        ] -= 1
+
                     # Remove from main storage
                     del self.messages[message_id]
-                    
+
+                    if self.conn:
+                        self.conn.execute(
+                            "DELETE FROM messages WHERE message_id=?",
+                            (message_id,),
+                        )
+                        self.conn.commit()
+
                     logger.debug(f"Deleted message {message_id}")
                     return True
                 return False
-                
+
         except Exception as e:
             logger.error(f"Failed to delete message: {e}")
             return False
-    
+
     def _update_indexes(self, message: V2Message, operation: str):
         """Update all indexes for a message"""
         try:
@@ -249,79 +330,92 @@ class V2MessageStorage(IMessageStorage):
                 # Add to agent index
                 if message.recipient_id and message.recipient_id != "broadcast":
                     self.agent_messages[message.recipient_id].append(message.message_id)
-                
+
                 # Add to type index
                 self.type_messages[message.message_type].append(message.message_id)
-                
+
                 # Add to status index
                 self.status_messages[message.status].append(message.message_id)
-                
+
                 # Add to timestamp index
                 self.timestamp_index.append((message.timestamp, message.message_id))
                 self.timestamp_index.sort(key=lambda x: x[0])  # Sort by timestamp
-                
+
             elif operation == "remove":
                 # Remove from agent index
                 if message.recipient_id and message.recipient_id != "broadcast":
                     if message.message_id in self.agent_messages[message.recipient_id]:
-                        self.agent_messages[message.recipient_id].remove(message.message_id)
-                
+                        self.agent_messages[message.recipient_id].remove(
+                            message.message_id
+                        )
+
                 # Remove from type index
                 if message.message_id in self.type_messages[message.message_type]:
                     self.type_messages[message.message_type].remove(message.message_id)
-                
+
                 # Remove from status index
                 if message.message_id in self.status_messages[message.status]:
                     self.status_messages[message.status].remove(message.message_id)
-                
+
                 # Remove from timestamp index
-                self.timestamp_index = [(t, mid) for t, mid in self.timestamp_index if mid != message.message_id]
-                
+                self.timestamp_index = [
+                    (t, mid)
+                    for t, mid in self.timestamp_index
+                    if mid != message.message_id
+                ]
+
         except Exception as e:
             logger.error(f"Failed to update indexes: {e}")
-    
+
     def cleanup_expired_messages(self, max_age_hours: int = 24) -> int:
         """Clean up expired messages"""
         try:
             cutoff_time = datetime.now() - timedelta(hours=max_age_hours)
             expired_messages = []
-            
+
             with self.lock:
                 for message_id, message in list(self.messages.items()):
                     if message.timestamp < cutoff_time:
                         expired_messages.append(message_id)
-                
+
                 # Delete expired messages
                 for message_id in expired_messages:
                     self.delete_message(message_id)
-            
+
             logger.info(f"Cleaned up {len(expired_messages)} expired messages")
             return len(expired_messages)
-            
+
         except Exception as e:
             logger.error(f"Failed to cleanup expired messages: {e}")
             return 0
-    
+
     def get_storage_stats(self) -> Dict[str, Any]:
         """Get storage statistics"""
         with self.lock:
             return self.storage_stats.copy()
-    
+
     def get_storage_health(self) -> Dict[str, Any]:
         """Get storage health metrics"""
         with self.lock:
             return {
                 "total_messages": len(self.messages),
                 "index_sizes": {
-                    "agent_messages": sum(len(ids) for ids in self.agent_messages.values()),
-                    "type_messages": sum(len(ids) for ids in self.type_messages.values()),
-                    "status_messages": sum(len(ids) for ids in self.status_messages.values()),
-                    "timestamp_index": len(self.timestamp_index)
+                    "agent_messages": sum(
+                        len(ids) for ids in self.agent_messages.values()
+                    ),
+                    "type_messages": sum(
+                        len(ids) for ids in self.type_messages.values()
+                    ),
+                    "status_messages": sum(
+                        len(ids) for ids in self.status_messages.values()
+                    ),
+                    "timestamp_index": len(self.timestamp_index),
                 },
-                "memory_usage_estimate": len(self.messages) * 1024,  # Rough estimate in bytes
-                "index_consistency": self._check_index_consistency()
+                "memory_usage_estimate": len(self.messages)
+                * 1024,  # Rough estimate in bytes
+                "index_consistency": self._check_index_consistency(),
             }
-    
+
     def _check_index_consistency(self) -> bool:
         """Check if indexes are consistent with main storage"""
         try:
@@ -330,11 +424,11 @@ class V2MessageStorage(IMessageStorage):
             all_indexed_ids.update(self.agent_messages.keys())
             all_indexed_ids.update(self.type_messages.keys())
             all_indexed_ids.update(self.status_messages.keys())
-            
+
             for message_id in all_indexed_ids:
                 if message_id not in self.messages:
                     return False
-            
+
             return True
         except Exception:
             return False

--- a/src/services/messaging/storage/storage.py
+++ b/src/services/messaging/storage/storage.py
@@ -131,6 +131,9 @@ class V2MessageStorage(IMessageStorage):
                 logger.debug(f"Stored message {message.message_id}")
                 return True
 
+        except sqlite3.Error as e:
+            logger.error(f"Failed to store message in database: {e}")
+            return False
         except Exception as e:
             logger.error(f"Failed to store message: {e}")
             return False


### PR DESCRIPTION
## Summary
- replace `pass` with `NotImplementedError` in messaging interfaces to enforce implementation
- add optional SQLite-backed persistence and retrieval to `V2MessageStorage`
- support storing, fetching, updating, and deleting messages via database

## Testing
- `PYTHONPATH=. pre-commit run --files src/services/messaging/storage/storage.py src/services/messaging/interfaces.py` *(fails: No module named 'yaml'; missing duplication detector script)*
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'flask', 78 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9ad038288329bbed1e13a5336f8e