### PR TITLE
Include psutil in testing requirements

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -27,6 +27,7 @@ factory-boy>=3.2.0
 faker>=18.0.0
 responses>=0.23.0
 freezegun>=1.2.0
+psutil>=5.9.0
 
 # Performance Testing
 pytest-benchmark>=4.0.0


### PR DESCRIPTION
## Summary
- add psutil dependency to testing requirements for system metrics tests

## Testing
- `pre-commit run --files requirements/testing.txt`
- `PYTHONPATH=. python tests/v2_standards_checker_simple.py --all`

------
https://chatgpt.com/codex/tasks/task_e_68ad9b068c688329bc9b4070f34dd0ed