### PR TITLE
chore: migrate pre-commit stage names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         language: python
         types: [python]
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]
         # Balanced LOC restrictions for maintainability:
         # - Standard files: max 400 LOC (was 200, balanced at 400)
         # - GUI files: max 600 LOC (was 300, generous for UI while maintaining structure)
@@ -19,7 +19,7 @@ repos:
         language: python
         types: [python]
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0


### PR DESCRIPTION
## Summary
- replace deprecated `commit` stage with `pre-commit`
- run pre-commit checks to ensure config validity

## Testing
- `SKIP=v2-standards-check,duplication-detector,trailing-whitespace,black,end-of-file-fixer PYTHONPATH=. pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68ad9b07219883299fc9103ea28a5366