### PR TITLE
refactor(auth): modularize session management

### DIFF
--- a/config/services/portal.yaml
+++ b/config/services/portal.yaml
@@ -10,6 +10,8 @@ portal:
   enable_agent_integration: true
   max_agents: 8
   session_timeout: 3600
+  session_backend: "memory"  # Options: memory, sqlite
+  session_database: "auth_sessions.db"  # Used when session_backend=sqlite
   debug_mode: false
 
 flask:

--- a/src/services_v2/auth/README.md
+++ b/src/services_v2/auth/README.md
@@ -10,6 +10,9 @@ The V2 Authentication Module provides enterprise-grade authentication and author
 services_v2/auth/
 ├── __init__.py                         # Module initialization and exports
 ├── auth_service.py                     # Core V2 authentication service
+├── session_manager.py               # Session creation and management
+├── session_store.py                 # Backend-agnostic session storage
+├── session_backend.py               # Session storage backends
 ├── auth_integration_tester.py          # Orchestrator for integration tests
 ├── auth_integration_tester_core.py     # Core test routines
 ├── auth_integration_tester_validation.py # Environment validation helpers
@@ -32,6 +35,7 @@ The core V2 authentication service that provides:
 
 - **Enhanced Authentication**: V2 authentication with comprehensive security checks
 - **Session Management**: Advanced session handling with V2 features
+- **Configurable Session Backends**: In-memory or SQLite storage via SessionManager
 - **Permission System**: Role-based access control with multiple permission levels
 - **Security Context**: Context-aware authentication with threat detection
 - **Fallback Support**: Graceful degradation when core components unavailable
@@ -165,7 +169,9 @@ config = {
     "enable_mfa": True,                # Enable multi-factor auth
     "enable_audit_logging": True,      # Enable compliance logging
     "enable_performance_monitoring": True,  # Enable performance tracking
-    "security_level": "enterprise"     # Security level
+    "security_level": "enterprise",    # Security level
+    "session_backend": "memory",       # or 'sqlite'
+    "session_db_path": "auth_sessions.db"  # Path when using sqlite backend
 }
 
 auth_service = AuthService(config)

--- a/src/services_v2/auth/session_backend.py
+++ b/src/services_v2/auth/session_backend.py
@@ -1,0 +1,95 @@
+"""Session backend implementations for AuthService.
+
+Defines lightweight backends for session persistence to keep
+`SessionStore` focused on backend selection.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Dict, Protocol
+
+
+class SessionBackend(Protocol):
+    """Protocol for session backend implementations."""
+
+    def store(self, session_data: Dict[str, object]) -> None:
+        """Persist session information."""
+
+    def flush(self) -> None:
+        """Flush cached sessions and release resources."""
+
+
+class MemorySessionBackend:
+    """In-memory session storage backend."""
+
+    def __init__(self) -> None:
+        self.sessions: Dict[str, Dict[str, object]] = {}
+
+    def store(self, session_data: Dict[str, object]) -> None:
+        self.sessions[session_data["session_id"]] = session_data
+
+    def flush(self) -> None:
+        self.sessions.clear()
+
+
+class SQLiteSessionBackend:
+    """SQLite-backed session storage backend."""
+
+    def __init__(self, db_path: str, logger: logging.Logger) -> None:
+        path = Path(db_path)
+        self.logger = logger
+        try:
+            self.db = sqlite3.connect(path)
+            self.db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    session_id TEXT PRIMARY KEY,
+                    user_id TEXT,
+                    source_ip TEXT,
+                    user_agent TEXT,
+                    created_at REAL,
+                    expires_at TEXT,
+                    metadata TEXT
+                )
+                """
+            )
+            self.db.commit()
+        except Exception as exc:  # pragma: no cover - protective logging
+            self.logger.error("Failed to initialize session database: %s", exc)
+            self.db = None
+
+    def store(self, session_data: Dict[str, object]) -> None:
+        if not self.db:
+            return
+        try:
+            with self.db:
+                self.db.execute(
+                    """
+                    INSERT OR REPLACE INTO sessions (
+                        session_id, user_id, source_ip, user_agent, created_at, expires_at, metadata
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        session_data["session_id"],
+                        session_data["user_id"],
+                        session_data["source_ip"],
+                        session_data["user_agent"],
+                        session_data["created_at"],
+                        session_data["expires_at"].isoformat(),
+                        json.dumps(session_data.get("metadata", {})),
+                    ),
+                )
+        except Exception as exc:  # pragma: no cover - protective logging
+            self.logger.error("Failed to store session: %s", exc)
+
+    def flush(self) -> None:
+        if not self.db:
+            return
+        try:
+            self.db.commit()
+            self.db.close()
+        except Exception as exc:  # pragma: no cover - protective logging
+            self.logger.error("Failed to close session database: %s", exc)

--- a/src/services_v2/auth/session_manager.py
+++ b/src/services_v2/auth/session_manager.py
@@ -1,0 +1,49 @@
+"""Session creation and management utilities."""
+from __future__ import annotations
+
+import secrets
+import time
+from datetime import datetime
+from typing import Any, Dict
+
+from services_v2.auth.session_store import SessionStore
+
+
+class SessionManager:
+    """Create and persist session data through a SessionStore."""
+
+    def __init__(
+        self, store: SessionStore, session_timeout: int, security_level: str
+    ) -> None:
+        self.store = store
+        self.session_timeout = session_timeout
+        self.security_level = security_level
+
+    def create_session(
+        self, username: str, source_ip: str, user_agent: str
+    ) -> Dict[str, Any]:
+        """Generate and persist a new session."""
+        session_id = secrets.token_urlsafe(32)
+        current_time = time.time()
+        expires_at = datetime.fromtimestamp(current_time + self.session_timeout)
+
+        session_data = {
+            "session_id": session_id,
+            "user_id": username,
+            "source_ip": source_ip,
+            "user_agent": user_agent,
+            "created_at": current_time,
+            "expires_at": expires_at,
+            "metadata": {
+                "v2_features": True,
+                "security_level": self.security_level,
+                "session_type": "enhanced",
+            },
+        }
+
+        self.store.store(session_data)
+        return session_data
+
+    def flush(self) -> None:
+        """Flush sessions via the underlying store."""
+        self.store.flush()

--- a/src/services_v2/auth/session_store.py
+++ b/src/services_v2/auth/session_store.py
@@ -1,0 +1,38 @@
+"""Session storage selector for the auth service.
+
+Delegates persistence to a configured backend implementation.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+from .session_backend import (
+    SessionBackend,
+    MemorySessionBackend,
+    SQLiteSessionBackend,
+)
+
+
+class SessionStore:
+    """Store session data using a selectable backend."""
+
+    def __init__(
+        self,
+        backend: str = "memory",
+        db_path: str = "auth_sessions.db",
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
+        if backend == "sqlite":
+            self.backend: SessionBackend = SQLiteSessionBackend(db_path, self.logger)
+        else:
+            self.backend = MemorySessionBackend()
+
+    def store(self, session_data: Dict[str, object]) -> None:
+        """Persist the provided session data."""
+        self.backend.store(session_data)
+
+    def flush(self) -> None:
+        """Flush sessions and close resources."""
+        self.backend.flush()


### PR DESCRIPTION
## Summary
- isolate session persistence backends and delegate through a lightweight `SessionStore`
- centralize session creation in a new `SessionManager` used by `AuthService`
- document session modules and pluggable backends in auth README

## Testing
- `PYTHONPATH=. pre-commit run --files src/services_v2/auth/auth_service.py src/services_v2/auth/session_store.py src/services_v2/auth/session_backend.py src/services_v2/auth/session_manager.py src/services_v2/auth/README.md` *(fails: v2-standards-check missing yaml, duplication-detector missing)*
- `pytest -k auth_service -q` *(fails: ModuleNotFoundError: No module named 'coverage')*


------
https://chatgpt.com/codex/tasks/task_e_68ad9ac919308329b10ce515d0364438