### PR TITLE
Add system metric collection and documentation

### DIFF
--- a/docs/metrics_collectors.md
+++ b/docs/metrics_collectors.md
@@ -15,7 +15,7 @@ This document describes the built-in metric collectors and the units they produc
   * `event_loop_tasks` – count
 
 ## NetworkMetricsCollector
-* **Requirements:** `psutil`
+* **Requirements:** [`psutil`](https://pypi.org/project/psutil/)
 * **Metrics:**
   * `network_bytes_sent` – bytes
   * `network_bytes_recv` – bytes

--- a/docs/metrics_collectors.md
+++ b/docs/metrics_collectors.md
@@ -1,0 +1,25 @@
+# Metrics Collector Requirements
+
+This document describes the built-in metric collectors and the units they produce.
+
+## SystemMetricsCollector
+* **Requirements:** [`psutil`](https://pypi.org/project/psutil/)
+* **Metrics:**
+  * `cpu_usage_percent` – percent
+  * `memory_usage_percent` – percent
+  * `disk_usage_percent` – percent
+
+## ApplicationMetricsCollector
+* **Metrics:**
+  * `app_uptime_seconds` – seconds
+  * `event_loop_tasks` – count
+
+## NetworkMetricsCollector
+* **Requirements:** `psutil`
+* **Metrics:**
+  * `network_bytes_sent` – bytes
+  * `network_bytes_recv` – bytes
+
+## CustomMetricsCollector
+* Collects user-defined metrics via callables.
+* Units are determined by the provided functions.


### PR DESCRIPTION
## Summary
- Collect CPU, memory, and disk usage in `SystemMetricsCollector`
- Document metric units and requirements for all collectors
- Add reference guide for available metrics and units

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.performance_monitor'; ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ad9abe0e64832998a7f1e68ea2321a