### PR TITLE
Add OSRS behavior tree module and tests

### DIFF
--- a/gaming_systems/osrs/__init__.py
+++ b/gaming_systems/osrs/__init__.py
@@ -28,7 +28,15 @@ from .trading import (
 )
 
 from .ai import (
-    OSRSDecisionEngine
+    OSRSDecisionEngine,
+    OSRSBehaviorTree,
+    OSRSBehaviorNode,
+    OSRSBehaviorNodeType,
+    OSRSActionNode,
+    OSRSConditionNode,
+    OSRSSequenceNode,
+    OSRSSelectorNode,
+    OSRSDecoratorNode,
 )
 
 # Factory function for backward compatibility
@@ -74,6 +82,14 @@ __all__ = [
     
     # AI systems
     'OSRSDecisionEngine',
+    'OSRSBehaviorTree',
+    'OSRSBehaviorNode',
+    'OSRSBehaviorNodeType',
+    'OSRSActionNode',
+    'OSRSConditionNode',
+    'OSRSSequenceNode',
+    'OSRSSelectorNode',
+    'OSRSDecoratorNode',
     
     # Factory function for backward compatibility
     'create_osrs_ai_agent'

--- a/gaming_systems/osrs/ai/__init__.py
+++ b/gaming_systems/osrs/ai/__init__.py
@@ -11,7 +11,25 @@ License: MIT
 """
 
 from .decision_engine import OSRSDecisionEngine
+from .behavior_tree import (
+    OSRSBehaviorTree,
+    OSRSBehaviorNode,
+    OSRSBehaviorNodeType,
+    OSRSActionNode,
+    OSRSConditionNode,
+    OSRSSequenceNode,
+    OSRSSelectorNode,
+    OSRSDecoratorNode,
+)
 
 __all__ = [
-    'OSRSDecisionEngine'
+    'OSRSDecisionEngine',
+    'OSRSBehaviorTree',
+    'OSRSBehaviorNode',
+    'OSRSBehaviorNodeType',
+    'OSRSActionNode',
+    'OSRSConditionNode',
+    'OSRSSequenceNode',
+    'OSRSSelectorNode',
+    'OSRSDecoratorNode',
 ]

--- a/gaming_systems/osrs/ai/behavior_tree.py
+++ b/gaming_systems/osrs/ai/behavior_tree.py
@@ -1,0 +1,127 @@
+"""Behavior tree implementation for OSRS AI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, List, Optional
+
+
+class OSRSBehaviorNodeType(Enum):
+    """Types of nodes used in the behavior tree."""
+
+    ACTION = "action"
+    CONDITION = "condition"
+    SEQUENCE = "sequence"
+    SELECTOR = "selector"
+    DECORATOR = "decorator"
+
+
+@dataclass
+class OSRSBehaviorNode:
+    """Base class for all behavior tree nodes."""
+
+    name: str
+    node_type: OSRSBehaviorNodeType
+    children: List["OSRSBehaviorNode"] = field(default_factory=list)
+
+    def add_child(self, child: "OSRSBehaviorNode") -> None:
+        """Attach a child node."""
+        self.children.append(child)
+
+    def execute(self, player: Any, game_state: Any) -> bool:  # pragma: no cover - abstract
+        """Execute the node's behavior.
+
+        Subclasses override this method to provide actual logic.
+        """
+        raise NotImplementedError
+
+
+class OSRSActionNode(OSRSBehaviorNode):
+    """Leaf node that performs an action."""
+
+    def __init__(self, name: str, action_func: Optional[Callable[[Any, Any], bool]] = None) -> None:
+        super().__init__(name, OSRSBehaviorNodeType.ACTION)
+        self.action_func = action_func
+
+    def execute(self, player: Any, game_state: Any) -> bool:
+        if not self.action_func:
+            return True
+        try:
+            return bool(self.action_func(player, game_state))
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+
+class OSRSConditionNode(OSRSBehaviorNode):
+    """Leaf node that checks a condition."""
+
+    def __init__(self, name: str, condition_func: Callable[[Any, Any], bool]) -> None:
+        super().__init__(name, OSRSBehaviorNodeType.CONDITION)
+        self.condition_func = condition_func
+
+    def execute(self, player: Any, game_state: Any) -> bool:
+        try:
+            return bool(self.condition_func(player, game_state))
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+
+class OSRSSequenceNode(OSRSBehaviorNode):
+    """Composite node that runs children in sequence until one fails."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name, OSRSBehaviorNodeType.SEQUENCE)
+
+    def execute(self, player: Any, game_state: Any) -> bool:
+        for child in self.children:
+            if not child.execute(player, game_state):
+                return False
+        return True
+
+
+class OSRSSelectorNode(OSRSBehaviorNode):
+    """Composite node that succeeds if any child succeeds."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name, OSRSBehaviorNodeType.SELECTOR)
+
+    def execute(self, player: Any, game_state: Any) -> bool:
+        for child in self.children:
+            if child.execute(player, game_state):
+                return True
+        return False
+
+
+class OSRSDecoratorNode(OSRSBehaviorNode):
+    """Node that modifies the result of its single child."""
+
+    def __init__(self, name: str, decorator: Callable[[bool], bool]) -> None:
+        super().__init__(name, OSRSBehaviorNodeType.DECORATOR)
+        self.decorator = decorator
+
+    def execute(self, player: Any, game_state: Any) -> bool:
+        if not self.children:
+            return True
+        result = self.children[0].execute(player, game_state)
+        try:
+            return bool(self.decorator(result))
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+
+class OSRSBehaviorTree:
+    """Behavior tree container."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.root: Optional[OSRSBehaviorNode] = None
+
+    def set_root(self, node: OSRSBehaviorNode) -> None:
+        self.root = node
+
+    def execute(self, player: Any, game_state: Any) -> bool:
+        """Execute the behavior tree starting from the root."""
+        if not self.root:
+            return False
+        return bool(self.root.execute(player, game_state))

--- a/tests/gaming/test_osrs_behavior_tree.py
+++ b/tests/gaming/test_osrs_behavior_tree.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from gaming_systems.osrs.ai.behavior_tree import (
+    OSRSBehaviorNodeType,
+    OSRSActionNode,
+    OSRSConditionNode,
+    OSRSSequenceNode,
+    OSRSSelectorNode,
+    OSRSBehaviorTree,
+)
+
+
+def test_node_types_enum():
+    assert OSRSBehaviorNodeType.ACTION.value == "action"
+    assert OSRSBehaviorNodeType.SELECTOR.value == "selector"
+
+
+def test_action_and_condition_execution():
+    action = OSRSActionNode("a", action_func=lambda p, s: True)
+    condition = OSRSConditionNode("c", condition_func=lambda p, s: True)
+    assert action.execute(None, {})
+    assert condition.execute(None, {})
+
+
+def test_sequence_and_selector():
+    seq = OSRSSequenceNode("seq")
+    seq.add_child(OSRSActionNode("a1", lambda p, s: True))
+    seq.add_child(OSRSActionNode("a2", lambda p, s: False))
+    assert not seq.execute(None, {})
+
+    sel = OSRSSelectorNode("sel")
+    sel.add_child(OSRSActionNode("b1", lambda p, s: False))
+    sel.add_child(OSRSActionNode("b2", lambda p, s: True))
+    assert sel.execute(None, {})
+
+
+def test_behavior_tree_execute():
+    tree = OSRSBehaviorTree("t")
+    action = OSRSActionNode("a", action_func=lambda p, s: True)
+    tree.set_root(action)
+    assert tree.execute(None, {})


### PR DESCRIPTION
## Summary
- Implement OSRS-specific behavior tree with action, condition, sequence, selector and decorator nodes
- Expose behavior tree utilities through OSRS AI package exports
- Add tests validating node execution and tree behavior

## Testing
- `pytest tests/behavior_trees/test_behavior_tree_basic.py tests/gaming/test_ai_agent_framework_setup.py tests/gaming/test_ai_agent_framework_execution.py tests/gaming/test_osrs_behavior_tree.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9ac10a248329adf5e5b8f06f8700