### PR TITLE
Add concrete FSM handlers with transition tests

### DIFF
--- a/src/core/fsm/handlers.py
+++ b/src/core/fsm/handlers.py
@@ -53,4 +53,4 @@ class ConditionalTransitionHandler(TransitionHandler):
         allowed = self.evaluate(context)
         if allowed:
             context["current_state"] = self._target_state
-        return {"allowed": allowed, "current_state": context.get("current_state")}
+        return {"allowed": allowed, "state": context.get("current_state")}

--- a/src/core/fsm/handlers.py
+++ b/src/core/fsm/handlers.py
@@ -17,12 +17,14 @@ class ConcreteStateHandler(StateHandler):
 
     def execute(self, context: Dict[str, Any]) -> StateExecutionResult:
         """Execute the configured action then validate state."""
+        start_time = time.monotonic()
         self._action(context)
         success = self._check(context)
+        execution_time = time.monotonic() - start_time
         status = StateStatus.COMPLETED if success else StateStatus.FAILED
         return StateExecutionResult(
             state_name=context.get("current_state", "unknown"),
-            execution_time=0.0,
+            execution_time=execution_time,
             status=status,
             output=context.copy(),
             error_message=None if success else "state check failed",

--- a/src/core/fsm/handlers.py
+++ b/src/core/fsm/handlers.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Concrete FSM handlers executing state actions and transition checks."""
+
+from datetime import datetime
+from typing import Any, Callable, Dict
+
+from .models import StateExecutionResult, StateHandler, StateStatus, TransitionHandler
+
+
+class ConcreteStateHandler(StateHandler):
+    """State handler that runs an action and validates context."""
+
+    def __init__(self, action: Callable[[Dict[str, Any]], None], check: Callable[[Dict[str, Any]], bool]):
+        self._action = action
+        self._check = check
+
+    def execute(self, context: Dict[str, Any]) -> StateExecutionResult:
+        """Execute the configured action then validate state."""
+        self._action(context)
+        success = self._check(context)
+        status = StateStatus.COMPLETED if success else StateStatus.FAILED
+        return StateExecutionResult(
+            state_name=context.get("current_state", "unknown"),
+            execution_time=0.0,
+            status=status,
+            output=context.copy(),
+            error_message=None if success else "state check failed",
+            metadata={},
+            timestamp=datetime.now(),
+        )
+
+    def can_transition(self, context: Dict[str, Any]) -> bool:
+        """Check if context satisfies requirements for transition."""
+        return self._check(context)
+
+
+class ConditionalTransitionHandler(TransitionHandler):
+    """Transition handler evaluating a condition and applying a state change."""
+
+    def __init__(self, condition: Callable[[Dict[str, Any]], bool], target_state: str):
+        self._condition = condition
+        self._target_state = target_state
+
+    def evaluate(self, context: Dict[str, Any]) -> bool:
+        """Return True if transition is allowed."""
+        return self._condition(context)
+
+    def execute(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Apply state change when condition is met."""
+        allowed = self.evaluate(context)
+        if allowed:
+            context["current_state"] = self._target_state
+        return {"allowed": allowed, "current_state": context.get("current_state")}

--- a/src/core/fsm/handlers.py
+++ b/src/core/fsm/handlers.py
@@ -2,6 +2,7 @@
 """Concrete FSM handlers executing state actions and transition checks."""
 
 from datetime import datetime
+import time
 from typing import Any, Callable, Dict
 
 from .models import StateExecutionResult, StateHandler, StateStatus, TransitionHandler

--- a/tests/test_fsm_handlers.py
+++ b/tests/test_fsm_handlers.py
@@ -1,0 +1,37 @@
+import pytest
+
+from src.core.fsm.handlers import ConcreteStateHandler, ConditionalTransitionHandler
+from src.core.fsm.models import StateStatus
+
+
+def test_allowed_transition():
+    context = {"current_state": "start", "value": 10, "actions": []}
+    state_handler = ConcreteStateHandler(
+        action=lambda ctx: ctx["actions"].append("processed"),
+        check=lambda ctx: ctx["value"] >= 0,
+    )
+    result = state_handler.execute(context)
+    assert result.status == StateStatus.COMPLETED
+    assert state_handler.can_transition(context) is True
+    assert context["actions"] == ["processed"]
+
+    transition = ConditionalTransitionHandler(lambda ctx: ctx["value"] > 5, "end")
+    outcome = transition.execute(context)
+    assert outcome["allowed"] is True
+    assert context["current_state"] == "end"
+
+
+def test_disallowed_transition():
+    context = {"current_state": "start", "value": 1, "actions": []}
+    state_handler = ConcreteStateHandler(
+        action=lambda ctx: ctx["actions"].append("processed"),
+        check=lambda ctx: ctx["value"] >= 0,
+    )
+    result = state_handler.execute(context)
+    assert result.status == StateStatus.COMPLETED
+    assert state_handler.can_transition(context) is True
+
+    transition = ConditionalTransitionHandler(lambda ctx: ctx["value"] > 5, "end")
+    outcome = transition.execute(context)
+    assert outcome["allowed"] is False
+    assert context["current_state"] == "start"


### PR DESCRIPTION
## Summary
- implement `ConcreteStateHandler` executing actions and validation
- add `ConditionalTransitionHandler` for predicate-based state changes
- test allowed and disallowed transitions using new handlers

## Testing
- `pytest tests/test_fsm_handlers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad9ac0c584832982179d1c1b4b148d