### PR TITLE
refactor: externalize validator rules

### DIFF
--- a/src/core/validation/code_validator.py
+++ b/src/core/validation/code_validator.py
@@ -10,7 +10,6 @@ import re
 from typing import Dict, List, Any, Optional
 from .base_validator import (
     BaseValidator,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
     ValidationResult,
@@ -67,42 +66,6 @@ class CodeValidator(BaseValidator):
             "with",
             "yield",
         ]
-
-    def _setup_default_rules(self) -> None:
-        """Setup default code validation rules"""
-        default_rules = [
-            ValidationRule(
-                rule_id="code_structure",
-                rule_name="Code Structure",
-                rule_type="code",
-                description="Validate code structure and syntax",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="code_quality_validation",
-                rule_name="Code Quality Validation",
-                rule_type="code",
-                description="Validate code quality and standards",
-                severity=ValidationSeverity.WARNING,
-            ),
-            ValidationRule(
-                rule_id="naming_convention_validation",
-                rule_name="Naming Convention Validation",
-                rule_type="code",
-                description="Validate naming conventions and standards",
-                severity=ValidationSeverity.WARNING,
-            ),
-            ValidationRule(
-                rule_id="complexity_validation",
-                rule_name="Complexity Validation",
-                rule_type="code",
-                description="Validate code complexity and maintainability",
-                severity=ValidationSeverity.WARNING,
-            ),
-        ]
-
-        for rule in default_rules:
-            self.add_validation_rule(rule)
 
     def validate(self, code_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
         """Validate code data and return validation results.

--- a/src/core/validation/config_validator.py
+++ b/src/core/validation/config_validator.py
@@ -22,43 +22,6 @@ class ConfigValidator(BaseValidator):
         """Initialize config validator with optional custom validators"""
         super().__init__("ConfigValidator")
         self.custom_validators = validators or {}
-        self._setup_default_rules()
-
-    def _setup_default_rules(self) -> None:
-        """Setup default configuration validation rules"""
-        default_rules = [
-            ValidationRule(
-                rule_id="config_structure",
-                rule_name="Configuration Structure",
-                rule_type="config",
-                description="Validate configuration structure and format",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="required_sections",
-                rule_name="Required Sections",
-                rule_type="config",
-                description="Ensure all required configuration sections are present",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="section_validators",
-                rule_name="Section Validators",
-                rule_type="config",
-                description="Run section-specific validation functions",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="config_consistency",
-                rule_name="Configuration Consistency",
-                rule_type="config",
-                description="Check for configuration consistency across sections",
-                severity=ValidationSeverity.WARNING,
-            ),
-        ]
-
-        for rule in default_rules:
-            self.add_validation_rule(rule)
 
     def validate(
         self, configs: Dict[str, Dict[str, Any]], **kwargs

--- a/src/core/validation/contract_validator.py
+++ b/src/core/validation/contract_validator.py
@@ -8,7 +8,6 @@ and following the unified validation framework patterns.
 from typing import Dict, List, Any
 from .base_validator import (
     BaseValidator,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
     ValidationResult,
@@ -21,42 +20,6 @@ class ContractValidator(BaseValidator):
     def __init__(self):
         """Initialize contract validator"""
         super().__init__("ContractValidator")
-
-    def _setup_default_rules(self) -> None:
-        """Setup default contract validation rules"""
-        default_rules = [
-            ValidationRule(
-                rule_id="required_fields",
-                rule_name="Required Fields Check",
-                rule_type="contract",
-                description="Ensure all required contract fields are present",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="priority_validation",
-                rule_name="Priority Validation",
-                rule_type="contract",
-                description="Validate contract priority values",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="capabilities_validation",
-                rule_name="Capabilities Validation",
-                rule_type="contract",
-                description="Validate required capabilities format",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="deadline_validation",
-                rule_name="Deadline Validation",
-                rule_type="contract",
-                description="Validate contract deadline format and logic",
-                severity=ValidationSeverity.WARNING,
-            ),
-        ]
-
-        for rule in default_rules:
-            self.add_validation_rule(rule)
 
     def validate(
         self, contract_data: Dict[str, Any], **kwargs

--- a/src/core/validation/message_validator.py
+++ b/src/core/validation/message_validator.py
@@ -32,50 +32,6 @@ class MessageValidator(BaseValidator):
     def __init__(self):
         """Initialize message validator"""
         super().__init__("MessageValidator")
-        self._setup_default_rules()
-
-    def _setup_default_rules(self) -> None:
-        """Setup default message validation rules"""
-        default_rules = [
-            ValidationRule(
-                rule_id="unified_message_structure",
-                rule_name="Unified Message Structure",
-                rule_type="message",
-                description="Validate UnifiedMessage structure and format",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="required_fields",
-                rule_name="Required Fields",
-                rule_type="message",
-                description="Ensure all required UnifiedMessage fields are present",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="message_format",
-                rule_name="Message Format",
-                rule_type="message",
-                description="Validate UnifiedMessage format and encoding",
-                severity=ValidationSeverity.WARNING,
-            ),
-            ValidationRule(
-                rule_id="content_validation",
-                rule_name="Content Validation",
-                rule_type="message",
-                description="Validate UnifiedMessage content and structure",
-                severity=ValidationSeverity.WARNING,
-            ),
-            ValidationRule(
-                rule_id="enum_validation",
-                rule_name="Enum Validation",
-                rule_type="message",
-                description="Validate UnifiedMessage enum values",
-                severity=ValidationSeverity.ERROR,
-            ),
-        ]
-
-        for rule in default_rules:
-            self.add_validation_rule(rule)
 
     def validate(
         self, message_data: Dict[str, Any], **kwargs

--- a/src/core/validation/onboarding_validator.py
+++ b/src/core/validation/onboarding_validator.py
@@ -8,7 +8,6 @@ and following the unified validation framework patterns.
 from typing import Dict, List, Any, Optional
 from .base_validator import (
     BaseValidator,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
     ValidationResult,
@@ -38,42 +37,6 @@ class OnboardingValidator(BaseValidator):
             "social",
             "manual",
         ]
-
-    def _setup_default_rules(self) -> None:
-        """Setup default onboarding validation rules"""
-        default_rules = [
-            ValidationRule(
-                rule_id="onboarding_structure",
-                rule_name="Onboarding Structure",
-                rule_type="onboarding",
-                description="Validate onboarding data structure and format",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="onboarding_flow_validation",
-                rule_name="Onboarding Flow Validation",
-                rule_type="onboarding",
-                description="Validate onboarding flow and progression",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="verification_validation",
-                rule_name="Verification Validation",
-                rule_type="onboarding",
-                description="Validate verification methods and status",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="compliance_check",
-                rule_name="Compliance Check",
-                rule_type="onboarding",
-                description="Check onboarding compliance requirements",
-                severity=ValidationSeverity.WARNING,
-            ),
-        ]
-
-        for rule in default_rules:
-            self.add_validation_rule(rule)
 
     def validate(
         self, onboarding_data: Dict[str, Any], **kwargs

--- a/src/core/validation/quality_validator.py
+++ b/src/core/validation/quality_validator.py
@@ -8,7 +8,6 @@ and following the unified validation framework patterns.
 from typing import Dict, List, Any, Optional
 from .base_validator import (
     BaseValidator,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
     ValidationResult,
@@ -32,42 +31,6 @@ class QualityValidator(BaseValidator):
             "max_class_length": 500,
             "max_file_length": 400,
         }
-
-    def _setup_default_rules(self) -> None:
-        """Setup default quality validation rules"""
-        default_rules = [
-            ValidationRule(
-                rule_id="quality_metrics",
-                rule_name="Quality Metrics",
-                rule_type="quality",
-                description="Validate code quality metrics against thresholds",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="complexity_analysis",
-                rule_name="Complexity Analysis",
-                rule_type="quality",
-                description="Check cyclomatic complexity and maintainability",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="duplication_check",
-                rule_name="Duplication Check",
-                rule_type="quality",
-                description="Identify code duplication patterns",
-                severity=ValidationSeverity.WARNING,
-            ),
-            ValidationRule(
-                rule_id="test_coverage_validation",
-                rule_name="Test Coverage Validation",
-                rule_type="quality",
-                description="Validate test coverage requirements",
-                severity=ValidationSeverity.WARNING,
-            ),
-        ]
-
-        for rule in default_rules:
-            self.add_validation_rule(rule)
 
     def validate(
         self, quality_data: Dict[str, Any], **kwargs

--- a/src/core/validation/rules/code.yaml
+++ b/src/core/validation/rules/code.yaml
@@ -1,0 +1,21 @@
+rules:
+  - rule_id: code_structure
+    rule_name: Code Structure
+    rule_type: code
+    description: Validate code structure and syntax
+    severity: ERROR
+  - rule_id: code_quality_validation
+    rule_name: Code Quality Validation
+    rule_type: code
+    description: Validate code quality and standards
+    severity: WARNING
+  - rule_id: naming_convention_validation
+    rule_name: Naming Convention Validation
+    rule_type: code
+    description: Validate naming conventions and standards
+    severity: WARNING
+  - rule_id: complexity_validation
+    rule_name: Complexity Validation
+    rule_type: code
+    description: Validate code complexity and maintainability
+    severity: WARNING

--- a/src/core/validation/rules/config.yaml
+++ b/src/core/validation/rules/config.yaml
@@ -1,0 +1,21 @@
+rules:
+  - rule_id: config_structure
+    rule_name: Configuration Structure
+    rule_type: config
+    description: Validate configuration structure and format
+    severity: ERROR
+  - rule_id: required_sections
+    rule_name: Required Sections
+    rule_type: config
+    description: Ensure all required configuration sections are present
+    severity: ERROR
+  - rule_id: section_validators
+    rule_name: Section Validators
+    rule_type: config
+    description: Run section-specific validation functions
+    severity: ERROR
+  - rule_id: config_consistency
+    rule_name: Configuration Consistency
+    rule_type: config
+    description: Check for configuration consistency across sections
+    severity: WARNING

--- a/src/core/validation/rules/contract.yaml
+++ b/src/core/validation/rules/contract.yaml
@@ -1,0 +1,21 @@
+rules:
+  - rule_id: required_fields
+    rule_name: Required Fields Check
+    rule_type: contract
+    description: Ensure all required contract fields are present
+    severity: ERROR
+  - rule_id: priority_validation
+    rule_name: Priority Validation
+    rule_type: contract
+    description: Validate contract priority values
+    severity: ERROR
+  - rule_id: capabilities_validation
+    rule_name: Capabilities Validation
+    rule_type: contract
+    description: Validate required capabilities format
+    severity: ERROR
+  - rule_id: deadline_validation
+    rule_name: Deadline Validation
+    rule_type: contract
+    description: Validate contract deadline format and logic
+    severity: WARNING

--- a/src/core/validation/rules/message.yaml
+++ b/src/core/validation/rules/message.yaml
@@ -1,0 +1,26 @@
+rules:
+  - rule_id: unified_message_structure
+    rule_name: Unified Message Structure
+    rule_type: message
+    description: Validate UnifiedMessage structure and format
+    severity: ERROR
+  - rule_id: required_fields
+    rule_name: Required Fields
+    rule_type: message
+    description: Ensure all required UnifiedMessage fields are present
+    severity: ERROR
+  - rule_id: message_format
+    rule_name: Message Format
+    rule_type: message
+    description: Validate UnifiedMessage format and encoding
+    severity: WARNING
+  - rule_id: content_validation
+    rule_name: Content Validation
+    rule_type: message
+    description: Validate UnifiedMessage content and structure
+    severity: WARNING
+  - rule_id: enum_validation
+    rule_name: Enum Validation
+    rule_type: message
+    description: Validate UnifiedMessage enum values
+    severity: ERROR

--- a/src/core/validation/rules/onboarding.yaml
+++ b/src/core/validation/rules/onboarding.yaml
@@ -1,0 +1,21 @@
+rules:
+  - rule_id: onboarding_structure
+    rule_name: Onboarding Structure
+    rule_type: onboarding
+    description: Validate onboarding data structure and format
+    severity: ERROR
+  - rule_id: onboarding_flow_validation
+    rule_name: Onboarding Flow Validation
+    rule_type: onboarding
+    description: Validate onboarding flow and progression
+    severity: ERROR
+  - rule_id: verification_validation
+    rule_name: Verification Validation
+    rule_type: onboarding
+    description: Validate verification methods and status
+    severity: ERROR
+  - rule_id: compliance_check
+    rule_name: Compliance Check
+    rule_type: onboarding
+    description: Check onboarding compliance requirements
+    severity: WARNING

--- a/src/core/validation/rules/quality.yaml
+++ b/src/core/validation/rules/quality.yaml
@@ -1,0 +1,21 @@
+rules:
+  - rule_id: quality_metrics
+    rule_name: Quality Metrics
+    rule_type: quality
+    description: Validate code quality metrics against thresholds
+    severity: ERROR
+  - rule_id: complexity_analysis
+    rule_name: Complexity Analysis
+    rule_type: quality
+    description: Check cyclomatic complexity and maintainability
+    severity: ERROR
+  - rule_id: duplication_check
+    rule_name: Duplication Check
+    rule_type: quality
+    description: Identify code duplication patterns
+    severity: WARNING
+  - rule_id: test_coverage_validation
+    rule_name: Test Coverage Validation
+    rule_type: quality
+    description: Validate test coverage requirements
+    severity: WARNING

--- a/src/core/validation/rules/security.yaml
+++ b/src/core/validation/rules/security.yaml
@@ -1,0 +1,27 @@
+rules:
+  - rule_id: security_structure
+    rule_name: Security Structure
+    rule_type: security
+    description: Validate security data structure and format
+    severity: ERROR
+  - rule_id: authentication_validation
+    rule_name: Authentication Validation
+    rule_type: security
+    description: Validate authentication mechanisms and credentials
+    severity: ERROR
+  - rule_id: authorization_check
+    rule_name: Authorization Check
+    rule_type: security
+    description: Validate authorization rules and permissions
+    severity: ERROR
+  - rule_id: data_encryption_validation
+    rule_name: Data Encryption Validation
+    rule_type: security
+    description: Validate encryption methods and key management
+    severity: WARNING
+patterns:
+  api_key: "^[a-zA-Z0-9]{32,64}$"
+  jwt_token: "^[A-Za-z0-9-_]+\\.[A-Za-z0-9-_]+\\.[A-Za-z0-9-_]*$"
+  uuid: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+  email: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+  ip_address: "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"

--- a/src/core/validation/rules/storage.yaml
+++ b/src/core/validation/rules/storage.yaml
@@ -1,0 +1,21 @@
+rules:
+  - rule_id: storage_structure
+    rule_name: Storage Structure
+    rule_type: storage
+    description: Validate storage configuration structure
+    severity: ERROR
+  - rule_id: storage_type_validation
+    rule_name: Storage Type Validation
+    rule_type: storage
+    description: Validate storage type and configuration
+    severity: ERROR
+  - rule_id: connection_validation
+    rule_name: Connection Validation
+    rule_type: storage
+    description: Validate storage connection parameters
+    severity: ERROR
+  - rule_id: performance_validation
+    rule_name: Performance Validation
+    rule_type: storage
+    description: Validate storage performance settings
+    severity: WARNING

--- a/src/core/validation/rules/task.yaml
+++ b/src/core/validation/rules/task.yaml
@@ -1,0 +1,21 @@
+rules:
+  - rule_id: task_structure
+    rule_name: Task Structure
+    rule_type: task
+    description: Validate task data structure and format
+    severity: ERROR
+  - rule_id: task_assignment_validation
+    rule_name: Task Assignment Validation
+    rule_type: task
+    description: Validate task assignment and ownership
+    severity: ERROR
+  - rule_id: task_dependencies_validation
+    rule_name: Task Dependencies Validation
+    rule_type: task
+    description: Validate task dependencies and relationships
+    severity: WARNING
+  - rule_id: task_progress_validation
+    rule_name: Task Progress Validation
+    rule_type: task
+    description: Validate task progress and timeline
+    severity: WARNING

--- a/src/core/validation/rules/workflow_execution.yaml
+++ b/src/core/validation/rules/workflow_execution.yaml
@@ -1,0 +1,6 @@
+rules:
+  - rule_id: workflow_execution
+    rule_name: Workflow Execution Validation
+    rule_type: workflow
+    description: Validate workflow execution state and transitions
+    severity: ERROR

--- a/src/core/validation/rules/workflow_performance.yaml
+++ b/src/core/validation/rules/workflow_performance.yaml
@@ -1,0 +1,6 @@
+rules:
+  - rule_id: performance_metrics
+    rule_name: Performance Metrics Validation
+    rule_type: workflow
+    description: Validate workflow performance and optimization
+    severity: WARNING

--- a/src/core/validation/rules/workflow_structure.yaml
+++ b/src/core/validation/rules/workflow_structure.yaml
@@ -1,0 +1,11 @@
+rules:
+  - rule_id: workflow_structure
+    rule_name: Workflow Structure Validation
+    rule_type: workflow
+    description: Validate workflow definition structure and integrity
+    severity: ERROR
+  - rule_id: step_dependencies
+    rule_name: Step Dependencies Validation
+    rule_type: workflow
+    description: Validate workflow step dependencies and cycles
+    severity: ERROR

--- a/src/core/validation/security_validator.py
+++ b/src/core/validation/security_validator.py
@@ -9,7 +9,6 @@ import re
 from typing import Dict, List, Any, Optional
 from .base_validator import (
     BaseValidator,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
     ValidationResult,
@@ -22,14 +21,7 @@ class SecurityValidator(BaseValidator):
     def __init__(self):
         """Initialize security validator"""
         super().__init__("SecurityValidator")
-        self.security_patterns = {
-            "api_key": r"^[a-zA-Z0-9]{32,64}$",
-            "jwt_token": r"^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$",
-            "uuid": r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-            "email": r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$",
-            "ip_address": r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
-        }
-
+        self.security_patterns = self._config.get("patterns", {})
         self.sensitive_fields = [
             "password",
             "secret",
@@ -42,42 +34,6 @@ class SecurityValidator(BaseValidator):
             "confidential",
             "secure",
         ]
-
-    def _setup_default_rules(self) -> None:
-        """Setup default security validation rules"""
-        default_rules = [
-            ValidationRule(
-                rule_id="security_structure",
-                rule_name="Security Structure",
-                rule_type="security",
-                description="Validate security data structure and format",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="authentication_validation",
-                rule_name="Authentication Validation",
-                rule_type="security",
-                description="Validate authentication mechanisms and credentials",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="authorization_check",
-                rule_name="Authorization Check",
-                rule_type="security",
-                description="Validate authorization rules and permissions",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="data_encryption_validation",
-                rule_name="Data Encryption Validation",
-                rule_type="security",
-                description="Validate encryption methods and key management",
-                severity=ValidationSeverity.WARNING,
-            ),
-        ]
-
-        for rule in default_rules:
-            self.add_validation_rule(rule)
 
     def validate(
         self, security_data: Dict[str, Any], **kwargs

--- a/src/core/validation/storage_validator.py
+++ b/src/core/validation/storage_validator.py
@@ -8,7 +8,6 @@ and following the unified validation framework patterns.
 from typing import Dict, List, Any, Optional
 from .base_validator import (
     BaseValidator,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
     ValidationResult,
@@ -39,42 +38,6 @@ class StorageValidator(BaseValidator):
             "elasticsearch",
             "dynamodb",
         ]
-
-    def _setup_default_rules(self) -> None:
-        """Setup default storage validation rules"""
-        default_rules = [
-            ValidationRule(
-                rule_id="storage_structure",
-                rule_name="Storage Structure",
-                rule_type="storage",
-                description="Validate storage configuration structure",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="storage_type_validation",
-                rule_name="Storage Type Validation",
-                rule_type="storage",
-                description="Validate storage type and configuration",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="connection_validation",
-                rule_name="Connection Validation",
-                rule_type="storage",
-                description="Validate storage connection parameters",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="performance_validation",
-                rule_name="Performance Validation",
-                rule_type="storage",
-                description="Validate storage performance settings",
-                severity=ValidationSeverity.WARNING,
-            ),
-        ]
-
-        for rule in default_rules:
-            self.add_validation_rule(rule)
 
     def validate(
         self, storage_data: Dict[str, Any], **kwargs

--- a/src/core/validation/task_validator.py
+++ b/src/core/validation/task_validator.py
@@ -8,7 +8,6 @@ and following the unified validation framework patterns.
 from typing import Dict, List, Any, Optional
 from .base_validator import (
     BaseValidator,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
     ValidationResult,
@@ -43,42 +42,6 @@ class TaskValidator(BaseValidator):
             "refactoring",
             "review",
         ]
-
-    def _setup_default_rules(self) -> None:
-        """Setup default task validation rules"""
-        default_rules = [
-            ValidationRule(
-                rule_id="task_structure",
-                rule_name="Task Structure",
-                rule_type="task",
-                description="Validate task data structure and format",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="task_assignment_validation",
-                rule_name="Task Assignment Validation",
-                rule_type="task",
-                description="Validate task assignment and ownership",
-                severity=ValidationSeverity.ERROR,
-            ),
-            ValidationRule(
-                rule_id="task_dependencies_validation",
-                rule_name="Task Dependencies Validation",
-                rule_type="task",
-                description="Validate task dependencies and relationships",
-                severity=ValidationSeverity.WARNING,
-            ),
-            ValidationRule(
-                rule_id="task_progress_validation",
-                rule_name="Task Progress Validation",
-                rule_type="task",
-                description="Validate task progress and timeline",
-                severity=ValidationSeverity.WARNING,
-            ),
-        ]
-
-        for rule in default_rules:
-            self.add_validation_rule(rule)
 
     def validate(self, task_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
         """Validate task data and return validation results.

--- a/src/core/workflow/validation/execution_validator.py
+++ b/src/core/workflow/validation/execution_validator.py
@@ -5,7 +5,6 @@ from typing import List
 from src.core.validation import (
     BaseValidator,
     ValidationResult,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
 )
@@ -18,17 +17,6 @@ class WorkflowExecutionValidator(BaseValidator):
 
     def __init__(self) -> None:
         super().__init__("WorkflowExecutionValidator")
-
-    def _setup_default_rules(self) -> None:  # pragma: no cover - simple rule setup
-        self.add_validation_rule(
-            ValidationRule(
-                rule_id="workflow_execution",
-                rule_name="Workflow Execution Validation",
-                rule_type="workflow",
-                description="Validate workflow execution state and transitions",
-                severity=ValidationSeverity.ERROR,
-            )
-        )
 
     def validate(self, execution: WorkflowExecution, **_) -> List[ValidationResult]:
         results: List[ValidationResult] = []
@@ -83,7 +71,9 @@ class WorkflowExecutionValidator(BaseValidator):
 
         return results
 
-    def _validate_step_execution_states(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
+    def _validate_step_execution_states(
+        self, steps: List[WorkflowStep]
+    ) -> List[ValidationResult]:
         results: List[ValidationResult] = []
 
         for i, step in enumerate(steps):
@@ -122,7 +112,9 @@ class WorkflowExecutionValidator(BaseValidator):
 
         return results
 
-    def _validate_execution_timing(self, execution: WorkflowExecution) -> List[ValidationResult]:
+    def _validate_execution_timing(
+        self, execution: WorkflowExecution
+    ) -> List[ValidationResult]:
         results: List[ValidationResult] = []
 
         if execution.start_time > execution.end_time:

--- a/src/core/workflow/validation/performance_validator.py
+++ b/src/core/workflow/validation/performance_validator.py
@@ -5,7 +5,6 @@ from typing import List
 from src.core.validation import (
     BaseValidator,
     ValidationResult,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
 )
@@ -18,24 +17,15 @@ class WorkflowPerformanceValidator(BaseValidator):
     def __init__(self) -> None:
         super().__init__("WorkflowPerformanceValidator")
 
-    def _setup_default_rules(self) -> None:  # pragma: no cover - simple rule setup
-        self.add_validation_rule(
-            ValidationRule(
-                rule_id="performance_metrics",
-                rule_name="Performance Metrics Validation",
-                rule_type="workflow",
-                description="Validate workflow performance and optimization",
-                severity=ValidationSeverity.WARNING,
-            )
-        )
-
     def validate(
         self, workflow_def: WorkflowDefinition, execution: WorkflowExecution, **_
     ) -> List[ValidationResult]:
         results: List[ValidationResult] = []
 
         try:
-            total_estimated = sum(step.estimated_duration for step in workflow_def.steps)
+            total_estimated = sum(
+                step.estimated_duration for step in workflow_def.steps
+            )
 
             if execution.start_time and execution.end_time:
                 actual_duration = (
@@ -60,9 +50,7 @@ class WorkflowPerformanceValidator(BaseValidator):
                     )
 
             long_steps = [
-                step
-                for step in workflow_def.steps
-                if step.estimated_duration > 300
+                step for step in workflow_def.steps if step.estimated_duration > 300
             ]
             if long_steps:
                 results.append(

--- a/src/core/workflow/validation/structure_validator.py
+++ b/src/core/workflow/validation/structure_validator.py
@@ -5,7 +5,6 @@ from typing import List
 from src.core.validation import (
     BaseValidator,
     ValidationResult,
-    ValidationRule,
     ValidationSeverity,
     ValidationStatus,
 )
@@ -18,26 +17,6 @@ class WorkflowStructureValidator(BaseValidator):
 
     def __init__(self) -> None:
         super().__init__("WorkflowStructureValidator")
-
-    def _setup_default_rules(self) -> None:  # pragma: no cover - simple rule setup
-        self.add_validation_rule(
-            ValidationRule(
-                rule_id="workflow_structure",
-                rule_name="Workflow Structure Validation",
-                rule_type="workflow",
-                description="Validate workflow definition structure and integrity",
-                severity=ValidationSeverity.ERROR,
-            )
-        )
-        self.add_validation_rule(
-            ValidationRule(
-                rule_id="step_dependencies",
-                rule_name="Step Dependencies Validation",
-                rule_type="workflow",
-                description="Validate workflow step dependencies and cycles",
-                severity=ValidationSeverity.ERROR,
-            )
-        )
 
     def validate(self, workflow_def: WorkflowDefinition, **_) -> List[ValidationResult]:
         results: List[ValidationResult] = []
@@ -116,7 +95,9 @@ class WorkflowStructureValidator(BaseValidator):
 
         return results
 
-    def _validate_workflow_steps(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
+    def _validate_workflow_steps(
+        self, steps: List[WorkflowStep]
+    ) -> List[ValidationResult]:
         results: List[ValidationResult] = []
 
         for i, step in enumerate(steps):
@@ -173,7 +154,9 @@ class WorkflowStructureValidator(BaseValidator):
 
         return results
 
-    def _validate_step_dependencies(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
+    def _validate_step_dependencies(
+        self, steps: List[WorkflowStep]
+    ) -> List[ValidationResult]:
         results: List[ValidationResult] = []
         step_ids = {step.step_id for step in steps}
 
@@ -210,7 +193,9 @@ class WorkflowStructureValidator(BaseValidator):
         results.extend(self._detect_dependency_cycles(steps))
         return results
 
-    def _detect_dependency_cycles(self, steps: List[WorkflowStep]) -> List[ValidationResult]:
+    def _detect_dependency_cycles(
+        self, steps: List[WorkflowStep]
+    ) -> List[ValidationResult]:
         results: List[ValidationResult] = []
 
         for i, step in enumerate(steps):
@@ -242,7 +227,9 @@ class WorkflowStructureValidator(BaseValidator):
 
         for dep_id in step.dependencies:
             dep_step = next((s for s in all_steps if s.step_id == dep_id), None)
-            if dep_step and self._has_cycle_recursive(dep_step, all_steps, visited, path):
+            if dep_step and self._has_cycle_recursive(
+                dep_step, all_steps, visited, path
+            ):
                 return True
 
         path.remove(step.step_id)

--- a/src/core/workflow/validation/workflow_validator.py
+++ b/src/core/workflow/validation/workflow_validator.py
@@ -18,8 +18,6 @@ class WorkflowValidator(BaseValidator):
         self.execution_validator = WorkflowExecutionValidator()
         self.performance_validator = WorkflowPerformanceValidator()
         super().__init__("WorkflowValidator")
-
-    def _setup_default_rules(self) -> None:  # pragma: no cover - simple delegation
         for validator in (
             self.structure_validator,
             self.execution_validator,


### PR DESCRIPTION
## Summary
- load validator rules from YAML files at runtime
- remove inline rule and pattern definitions

## Testing
- `pre-commit run --files src/core/validation/base_validator.py src/core/validation/config_validator.py src/core/validation/message_validator.py src/core/validation/security_validator.py src/core/validation/contract_validator.py src/core/validation/storage_validator.py src/core/validation/onboarding_validator.py src/core/validation/quality_validator.py src/core/validation/task_validator.py src/core/validation/code_validator.py src/core/workflow/validation/structure_validator.py src/core/workflow/validation/execution_validator.py src/core/workflow/validation/performance_validator.py src/core/workflow/validation/workflow_validator.py src/core/validation/rules/code.yaml src/core/validation/rules/config.yaml src/core/validation/rules/contract.yaml src/core/validation/rules/message.yaml src/core/validation/rules/onboarding.yaml src/core/validation/rules/quality.yaml src/core/validation/rules/security.yaml src/core/validation/rules/storage.yaml src/core/validation/rules/task.yaml src/core/validation/rules/workflow_structure.yaml src/core/validation/rules/workflow_execution.yaml src/core/validation/rules/workflow_performance.yaml` *(failed: ModuleNotFoundError: No module named 'src'; duplication-detector script missing)*
- `pytest src/core/validation/test_simple.py` *(failed: ModuleNotFoundError: No module named 'src.core.validation.workflow_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68addf5eceb8832981ba4dfc01814fa4