### PR TITLE
refactor: modularize communication channels and adapters

### DIFF
--- a/src/core/communication/__init__.py
+++ b/src/core/communication/__init__.py
@@ -1,0 +1,14 @@
+"""Core communication package."""
+
+from .channels import Channel, ChannelType
+from .adapters import HTTPAdapter, HTTPSAdapter, WebSocketAdapter
+from .communication_manager import CommunicationManager
+
+__all__ = [
+    "Channel",
+    "ChannelType",
+    "HTTPAdapter",
+    "HTTPSAdapter",
+    "WebSocketAdapter",
+    "CommunicationManager",
+]

--- a/src/core/communication/adapters.py
+++ b/src/core/communication/adapters.py
@@ -1,0 +1,82 @@
+"""Network and protocol adapters for communication channels."""
+from typing import Any, Dict, Optional
+
+import json
+
+import aiohttp
+import ssl
+import certifi
+import websockets
+from aiohttp import ClientSession
+
+from .channels import Channel
+from ...services.messaging.models.v2_message import V2Message
+
+
+class HTTPAdapter:
+    """Adapter for sending HTTP messages."""
+
+    def __init__(self) -> None:
+        self.session: Optional[ClientSession] = None
+
+    async def send(self, channel: Channel, message: V2Message) -> bool:
+        try:
+            if self.session is None:
+                self.session = aiohttp.ClientSession()
+            async with self.session.post(
+                f"{channel.url}/message",
+                json=message.content,
+                headers=message.headers,
+                timeout=aiohttp.ClientTimeout(total=message.timeout),
+            ) as response:
+                return response.status == 200
+        except Exception:
+            return False
+
+    async def close(self) -> None:
+        if self.session and not self.session.closed:
+            await self.session.close()
+
+
+class HTTPSAdapter(HTTPAdapter):
+    """Adapter for sending HTTPS messages with SSL."""
+
+    async def send(self, channel: Channel, message: V2Message) -> bool:
+        if self.session is None:
+            ssl_context = ssl.create_default_context(cafile=certifi.where())
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            self.session = aiohttp.ClientSession(connector=connector)
+        return await super().send(channel, message)
+
+
+class WebSocketAdapter:
+    """Adapter for WebSocket connections."""
+
+    def __init__(self) -> None:
+        self.connections: Dict[str, Any] = {}
+
+    async def connect(self, channel: Channel) -> None:
+        websocket = await websockets.connect(
+            channel.url,
+            extra_headers=channel.config.get("headers", {}),
+            ping_interval=channel.config.get("ping_interval", 30),
+            ping_timeout=channel.config.get("ping_timeout", 10),
+        )
+        self.connections[channel.id] = websocket
+
+    async def send(self, channel_id: str, data: Any) -> bool:
+        websocket = self.connections.get(channel_id)
+        if not websocket:
+            return False
+        try:
+            if isinstance(data, (dict, list)):
+                data = json.dumps(data)
+            await websocket.send(data)
+            return True
+        except Exception:
+            return False
+
+    async def close(self, channel_id: str) -> None:
+        websocket = self.connections.pop(channel_id, None)
+        if websocket:
+            await websocket.close()

--- a/src/core/communication/channels.py
+++ b/src/core/communication/channels.py
@@ -1,0 +1,31 @@
+"""Channel definitions and enums for communication system."""
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict
+
+
+class ChannelType(Enum):
+    """Supported communication channel types."""
+    HTTP = "http"
+    HTTPS = "https"
+    WEBSOCKET = "websocket"
+    TCP = "tcp"
+    UDP = "udp"
+    SERIAL = "serial"
+    MQTT = "mqtt"
+    REDIS = "redis"
+
+
+@dataclass
+class Channel:
+    """Represents a configured communication channel."""
+    id: str
+    name: str
+    type: ChannelType
+    url: str
+    config: Dict[str, Any]
+    status: str
+    created_at: str
+    last_used: str
+    message_count: int
+    error_count: int

--- a/src/core/communication/communication_manager.py
+++ b/src/core/communication/communication_manager.py
@@ -1,0 +1,114 @@
+"""Streamlined communication manager coordinating channels and routing."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from ...services.messaging.models.v2_message import V2Message
+from ...services.messaging.types.v2_message_enums import (
+    V2MessageStatus,
+    V2MessageType,
+)
+
+from .channels import Channel, ChannelType
+from .adapters import HTTPAdapter, HTTPSAdapter, WebSocketAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class CommunicationManager:
+    """Coordinate channels and route messages using adapters."""
+
+    def __init__(self) -> None:
+        self.channels: Dict[str, Channel] = {}
+        self.http_adapter = HTTPAdapter()
+        self.https_adapter = HTTPSAdapter()
+        self.websocket_adapter = WebSocketAdapter()
+
+    async def create_channel(
+        self,
+        name: str,
+        channel_type: ChannelType,
+        url: str,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Register a new channel and initialise protocol adapters as needed."""
+        channel_id = f"{channel_type.value}_{len(self.channels)}"
+        channel = Channel(
+            id=channel_id,
+            name=name,
+            type=channel_type,
+            url=url,
+            config=config or {},
+            status="active",
+            created_at=datetime.now().isoformat(),
+            last_used=datetime.now().isoformat(),
+            message_count=0,
+            error_count=0,
+        )
+        self.channels[channel_id] = channel
+
+        if channel.type == ChannelType.WEBSOCKET:
+            await self.websocket_adapter.connect(channel)
+
+        logger.info("Created channel %s (%s)", channel_id, channel.type.value)
+        return channel_id
+
+    async def send_message(
+        self,
+        channel_id: str,
+        content: Any,
+        message_type: V2MessageType = V2MessageType.TASK,
+        recipient: str = "all",
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[float] = None,
+    ) -> str:
+        """Send message through a channel using the appropriate adapter."""
+        channel = self.channels.get(channel_id)
+        if not channel:
+            logger.warning("Channel not found: %s", channel_id)
+            return ""
+
+        message_id = f"outgoing_{channel_id}_{int(datetime.now().timestamp())}"
+        message = V2Message(
+            message_id=message_id,
+            message_type=message_type,
+            sender_id="system",
+            recipient_id=recipient,
+            content=content,
+            payload={},
+            timestamp=datetime.now(),
+            status=V2MessageStatus.PENDING,
+            retry_count=0,
+            max_retries=channel.config.get("retry_count", 3),
+            headers=headers or {},
+            timeout=timeout or 30.0,
+        )
+
+        success = False
+        if channel.type == ChannelType.HTTP:
+            success = await self.http_adapter.send(channel, message)
+        elif channel.type == ChannelType.HTTPS:
+            success = await self.https_adapter.send(channel, message)
+        elif channel.type == ChannelType.WEBSOCKET:
+            success = await self.websocket_adapter.send(channel_id, message.content)
+        else:
+            logger.warning("Unsupported channel type: %s", channel.type)
+
+        if success:
+            message.status = V2MessageStatus.SENT
+            channel.message_count += 1
+        else:
+            message.status = V2MessageStatus.FAILED
+            channel.error_count += 1
+
+        channel.last_used = datetime.now().isoformat()
+        return message_id
+
+    async def close(self) -> None:
+        """Close any open network resources."""
+        await self.http_adapter.close()
+        await self.https_adapter.close()
+        for cid in list(self.websocket_adapter.connections.keys()):
+            await self.websocket_adapter.close(cid)

--- a/src/core/managers/communication/models.py
+++ b/src/core/managers/communication/models.py
@@ -12,35 +12,9 @@ License: MIT
 """
 
 from dataclasses import dataclass
-from enum import Enum
 from typing import Dict, Any, Optional
 
-
-class ChannelType(Enum):
-    """Communication channel types"""
-    HTTP = "http"
-    HTTPS = "https"
-    WEBSOCKET = "websocket"
-    TCP = "tcp"
-    UDP = "udp"
-    SERIAL = "serial"
-    MQTT = "mqtt"
-    REDIS = "redis"
-
-
-@dataclass
-class Channel:
-    """Communication channel definition"""
-    id: str
-    name: str
-    type: ChannelType
-    url: str
-    config: Dict[str, Any]
-    status: str
-    created_at: str
-    last_used: str
-    message_count: int
-    error_count: int
+from ...communication.channels import Channel, ChannelType
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add dedicated `channels.py` with `ChannelType` enum and `Channel` dataclass
- introduce HTTP, HTTPS and WebSocket adapters
- implement streamlined `communication_manager` orchestrating channels via adapters
- update communication models to reuse shared channel definitions

## Testing
- `pytest tests/smoke/test_service_components.py -q` *(fails: ModuleNotFoundError: No module named 'core.performance_monitor')*


------
https://chatgpt.com/codex/tasks/task_e_68addf6359cc8329a94260bc13ba54d5