### PR TITLE
Centralize package init template

### DIFF
--- a/src/package_template/__init__.py
+++ b/src/package_template/__init__.py
@@ -1,0 +1,7 @@
+"""Canonical package initializer.
+
+This module centralizes minimal package setup so that packages can
+reuse it instead of maintaining duplicate empty ``__init__.py`` files.
+"""
+
+__all__: list[str] = []

--- a/src/task_distribution/__init__.py
+++ b/src/task_distribution/__init__.py
@@ -1,0 +1,3 @@
+"""Task distribution package initializer using canonical template."""
+
+from src.package_template import *  # noqa: F401,F403

--- a/src/task_distribution/agents/__init__.py
+++ b/src/task_distribution/agents/__init__.py
@@ -1,0 +1,3 @@
+"""Task distribution agents package initializer using canonical template."""
+
+from src.package_template import *  # noqa: F401,F403

--- a/src/web/frontend/testing/__init__.py
+++ b/src/web/frontend/testing/__init__.py
@@ -1,0 +1,3 @@
+"""Web frontend testing package initializer using canonical template."""
+
+from src.package_template import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add canonical package initializer
- reuse template in task distribution and web testing packages

## Testing
- `PYTHONPATH=. pre-commit run --files src/package_template/__init__.py src/task_distribution/__init__.py src/task_distribution/agents/__init__.py src/web/frontend/testing/__init__.py` *(failed: No module named 'yaml'; duplication module missing)*
- `PYTHONPATH=. pytest -q` *(failed: ModuleNotFoundError: No module named 'psutil' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aef60e16c88329a4d93b32e53def96