### PR TITLE
refactor: extract integration test helpers

### DIFF
--- a/src/core/workflow/integration_test_plan.py
+++ b/src/core/workflow/integration_test_plan.py
@@ -11,12 +11,11 @@ License: MIT
 """
 
 import logging
-import json
-import os
 import sys
-from typing import Dict, List, Any, Optional
+from typing import Any, Dict
 from pathlib import Path
 from datetime import datetime
+from dataclasses import asdict
 
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -25,703 +24,90 @@ from .base_workflow_engine import BaseWorkflowEngine
 from .specialized.business_process_workflow import BusinessProcessWorkflow
 from .consolidation_migration import WorkflowConsolidationMigrator
 from .learning_integration import LearningWorkflowIntegration
+from .testing.integration_test_plan_structures import (
+    ContractIntegrationResult,
+    LearningIntegrationResult,
+    BusinessProcessIntegrationResult,
+    PerformanceTestResult,
+    DataModelCompatibilityResult,
+)
+from .testing.helpers import (
+    load_contract_data,
+    test_contract_workflow_integration,
+    test_learning_workflow_integration,
+    test_business_process_workflow_integration,
+    test_performance_and_scalability,
+    test_data_model_compatibility,
+)
 
 
 class WorkflowIntegrationTestPlan:
-    """
-    Comprehensive integration testing for unified workflow system.
-    
-    Single responsibility: Test and validate workflow system integration
-    with existing contracts, learning systems, and external systems.
-    Follows established architecture patterns - NO duplicate implementations.
-    """
-    
-    def __init__(self):
-        """Initialize integration test plan."""
+    """Comprehensive integration testing for unified workflow system."""
+
+    def __init__(self) -> None:
         self.logger = logging.getLogger(f"{__name__}.WorkflowIntegrationTestPlan")
-        
-        # Initialize workflow components using existing unified systems
         self.base_engine = BaseWorkflowEngine()
         self.business_process_workflow = BusinessProcessWorkflow()
         self.consolidation_migrator = WorkflowConsolidationMigrator()
         self.learning_integration = LearningWorkflowIntegration()
-        
-        # Test results tracking
-        self.test_results: Dict[str, Dict[str, Any]] = {}
-        self.integration_status: Dict[str, str] = {}
-        self.performance_metrics: Dict[str, float] = {}
-        
-        # Contract integration data
         self.contract_data: Dict[str, Any] = {}
         self.contract_workflows: Dict[str, str] = {}
-        
-        self.logger.info("🚀 Workflow Integration Test Plan initialized using existing unified systems")
-    
-    def load_contract_data(self) -> Dict[str, Any]:
-        """
-        Load existing contract data for integration testing.
-        
-        Returns:
-            Loaded contract data
-        """
-        self.logger.info("📋 Loading contract data for integration testing...")
-        
-        try:
-            # Load master contract index
-            contract_index_path = "contracts/MASTER_CONTRACT_INDEX.json"
-            if os.path.exists(contract_index_path):
-                with open(contract_index_path, 'r') as f:
-                    self.contract_data["master_index"] = json.load(f)
-                self.logger.info("✅ Master contract index loaded")
-            
-            # Load consolidated contract template
-            template_path = "contracts/CONSOLIDATED_CONTRACT_TEMPLATE.json"
-            if os.path.exists(template_path):
-                with open(template_path, 'r') as f:
-                    self.contract_data["template"] = json.load(f)
-                self.logger.info("✅ Contract template loaded")
-            
-            # Load phase contracts for testing
-            phase_contracts = [
-                "contracts/phase3a_core_system_contracts.json",
-                "contracts/phase3b_moderate_contracts.json",
-                "contracts/phase3c_standard_moderate_contracts.json"
-            ]
-            
-            for contract_file in phase_contracts:
-                if os.path.exists(contract_file):
-                    with open(contract_file, 'r') as f:
-                        phase_name = os.path.basename(contract_file).replace('.json', '')
-                        self.contract_data[phase_name] = json.load(f)
-                        self.logger.info(f"✅ {phase_name} contracts loaded")
-            
-            return self.contract_data
-            
-        except Exception as e:
-            self.logger.error(f"❌ Failed to load contract data: {e}")
-            return {}
-    
-    def test_contract_workflow_integration(self) -> Dict[str, Any]:
-        """
-        Test workflow system integration with existing contracts.
-        
-        Returns:
-            Integration test results
-        """
-        self.logger.info("🔄 Testing contract workflow integration...")
-        
-        test_results = {
-            "contracts_processed": 0,
-            "workflows_created": 0,
-            "integration_success": 0,
-            "integration_failures": 0,
-            "details": []
-        }
-        
-        try:
-            # Test with master contract index
-            if "master_index" in self.contract_data:
-                master_contract = self.contract_data["master_index"]
-                
-                # Create workflow for contract management
-                workflow_definition = {
-                    "name": "Contract Management Workflow",
-                    "description": "Automated contract management and tracking",
-                    "steps": [
-                        {
-                            "step_id": "contract_analysis",
-                            "name": "Contract Analysis",
-                            "step_type": "analysis"
-                        },
-                        {
-                            "step_id": "workflow_generation",
-                            "name": "Workflow Generation",
-                            "step_type": "generation"
-                        },
-                        {
-                            "step_id": "execution_tracking",
-                            "step_type": "tracking"
-                        }
-                    ],
-                    "metadata": {
-                        "contract_type": "master_index",
-                        "total_phases": master_contract.get("total_phases", 0),
-                        "total_contracts": master_contract.get("total_contracts", 0)
-                    }
-                }
-                
-                # Create workflow using unified engine
-                workflow_id = self.base_engine.create_workflow(
-                    "sequential", 
-                    workflow_definition
-                )
-                
-                if workflow_id:
-                    test_results["workflows_created"] += 1
-                    test_results["integration_success"] += 1
-                    self.contract_workflows["master_index"] = workflow_id
-                    
-                    test_results["details"].append({
-                        "contract_type": "master_index",
-                        "workflow_id": workflow_id,
-                        "status": "success",
-                        "message": "Master contract workflow created successfully"
-                    })
-                    
-                    self.logger.info(f"✅ Created workflow for master contract: {workflow_id}")
-                else:
-                    test_results["integration_failures"] += 1
-                    test_results["details"].append({
-                        "contract_type": "master_index",
-                        "status": "failed",
-                        "message": "Failed to create workflow"
-                    })
-            
-            # Test with phase contracts
-            for phase_name, phase_data in self.contract_data.items():
-                if phase_name in ["master_index", "template"]:
-                    continue
-                
-                test_results["contracts_processed"] += 1
-                
-                try:
-                    # Create workflow for phase contracts
-                    phase_workflow_definition = {
-                        "name": f"{phase_name.replace('_', ' ').title()} Workflow",
-                        "description": f"Automated workflow for {phase_name} contracts",
-                        "steps": [
-                            {
-                                "step_id": "phase_analysis",
-                                "name": "Phase Analysis",
-                                "step_type": "analysis"
-                            },
-                            {
-                                "step_id": "contract_processing",
-                                "name": "Contract Processing",
-                                "step_type": "processing"
-                            },
-                            {
-                                "step_id": "validation",
-                                "name": "Validation",
-                                "step_type": "validation"
-                            }
-                        ],
-                        "metadata": {
-                            "contract_type": phase_name,
-                            "contract_count": len(phase_data.get("contracts", [])),
-                            "priority": phase_data.get("priority", "unknown")
-                        }
-                    }
-                    
-                    # Create workflow
-                    phase_workflow_id = self.base_engine.create_workflow(
-                        "sequential",
-                        phase_workflow_definition
-                    )
-                    
-                    if phase_workflow_id:
-                        test_results["workflows_created"] += 1
-                        test_results["integration_success"] += 1
-                        self.contract_workflows[phase_name] = phase_workflow_id
-                        
-                        test_results["details"].append({
-                            "contract_type": phase_name,
-                            "workflow_id": phase_workflow_id,
-                            "status": "success",
-                            "message": f"{phase_name} workflow created successfully"
-                        })
-                        
-                        self.logger.info(f"✅ Created workflow for {phase_name}: {phase_workflow_id}")
-                    else:
-                        test_results["integration_failures"] += 1
-                        test_results["details"].append({
-                            "contract_type": phase_name,
-                            "status": "failed",
-                            "message": f"Failed to create {phase_name} workflow"
-                        })
-                        
-                except Exception as e:
-                    test_results["integration_failures"] += 1
-                    test_results["details"].append({
-                        "contract_type": phase_name,
-                        "status": "error",
-                        "message": f"Error processing {phase_name}: {str(e)}"
-                    })
-                    
-                    self.logger.error(f"❌ Error processing {phase_name}: {e}")
-            
-            self.logger.info(f"✅ Contract integration testing complete: {test_results['integration_success']} successes, {test_results['integration_failures']} failures")
-            return test_results
-            
-        except Exception as e:
-            self.logger.error(f"❌ Contract integration testing failed: {e}")
-            return {"error": str(e)}
-    
-    def test_learning_workflow_integration(self) -> Dict[str, Any]:
-        """
-        Test learning workflow integration using existing unified systems.
-        
-        Returns:
-            Learning workflow integration test results
-        """
-        self.logger.info("🧠 Testing learning workflow integration...")
-        
-        test_results = {
-            "learning_workflows_created": 0,
-            "decision_workflows_created": 0,
-            "integration_success": 0,
-            "integration_failures": 0,
-            "details": []
-        }
-        
-        try:
-            # Test learning workflow creation
-            test_goal = "Integration Testing - Learning Workflow"
-            test_agent = "test_agent_001"
-            
-            learning_workflow_id = self.learning_integration.create_learning_workflow(
-                test_goal, 
-                test_agent
-            )
-            
-            if learning_workflow_id:
-                test_results["learning_workflows_created"] += 1
-                test_results["integration_success"] += 1
-                
-                test_results["details"].append({
-                    "test_type": "learning_workflow",
-                    "workflow_id": learning_workflow_id,
-                    "status": "success",
-                    "message": "Learning workflow created successfully"
-                })
-                
-                self.logger.info(f"✅ Created learning workflow: {learning_workflow_id}")
-            else:
-                test_results["integration_failures"] += 1
-                test_results["details"].append({
-                    "test_type": "learning_workflow",
-                    "status": "failed",
-                    "message": "Failed to create learning workflow"
-                })
-            
-            # Test decision workflow creation
-            decision_workflow_id = self.learning_integration.create_decision_workflow(
-                "integration_test",
-                "high",
-                {"test_mode": True, "integration_required": True}
-            )
-            
-            if decision_workflow_id:
-                test_results["decision_workflows_created"] += 1
-                test_results["integration_success"] += 1
-                
-                test_results["details"].append({
-                    "test_type": "decision_workflow",
-                    "workflow_id": decision_workflow_id,
-                    "status": "success",
-                    "message": "Decision workflow created successfully"
-                })
-                
-                self.logger.info(f"✅ Created decision workflow: {decision_workflow_id}")
-            else:
-                test_results["integration_failures"] += 1
-                test_results["details"].append({
-                    "test_type": "decision_workflow",
-                    "status": "failed",
-                    "message": "Failed to create decision workflow"
-                })
-            
-            # Test integration status
-            integration_status = self.learning_integration.get_integration_status()
-            
-            if "error" not in integration_status:
-                test_results["details"].append({
-                    "test_type": "integration_status",
-                    "status": "success",
-                    "message": "Integration status retrieved successfully"
-                })
-            else:
-                test_results["details"].append({
-                    "test_type": "integration_status",
-                    "status": "failed",
-                    "message": "Failed to get integration status"
-                })
-            
-            self.logger.info(f"✅ Learning workflow integration testing complete: {test_results['integration_success']} successes")
-            return test_results
-            
-        except Exception as e:
-            self.logger.error(f"❌ Learning workflow integration testing failed: {e}")
-            return {"error": str(e)}
-    
-    def test_business_process_workflow_integration(self) -> Dict[str, Any]:
-        """
-        Test business process workflow integration with contracts.
-        
-        Returns:
-            Business process integration test results
-        """
-        self.logger.info("🔄 Testing business process workflow integration...")
-        
-        test_results = {
-            "business_processes_created": 0,
-            "approval_workflows": 0,
-            "compliance_tracking": 0,
-            "integration_success": 0,
-            "integration_failures": 0,
-            "details": []
-        }
-        
-        try:
-            # Test approval workflow for contract management
-            approval_data = {
-                "business_unit": "Contract Management",
-                "priority": "high",
-                "compliance_required": True,
-                "expected_duration": 48,  # hours
-                "business_rules": {
-                    "auto_approval_threshold": 100,
-                    "manager_approval_required": True,
-                    "compliance_review_required": True
-                }
-            }
-            
-            # Create approval workflow
-            approval_workflow_id = self.business_process_workflow.create_business_process(
-                "approval",
-                approval_data
-            )
-            
-            if approval_workflow_id:
-                test_results["business_processes_created"] += 1
-                test_results["approval_workflows"] += 1
-                test_results["integration_success"] += 1
-                
-                # Add approval step
-                approval_success = self.business_process_workflow.add_approval_step(
-                    approval_workflow_id,
-                    "contract_manager_001",
-                    "standard"
-                )
-                
-                if approval_success:
-                    test_results["compliance_tracking"] += 1
-                
-                test_results["details"].append({
-                    "process_type": "approval",
-                    "workflow_id": approval_workflow_id,
-                    "status": "success",
-                    "message": "Contract approval workflow created successfully"
-                })
-                
-                self.logger.info(f"✅ Created approval workflow: {approval_workflow_id}")
-            else:
-                test_results["integration_failures"] += 1
-                test_results["details"].append({
-                    "process_type": "approval",
-                    "status": "failed",
-                    "message": "Failed to create approval workflow"
-                })
-            
-            # Test review workflow for contract validation
-            review_data = {
-                "business_unit": "Quality Assurance",
-                "priority": "medium",
-                "compliance_required": True,
-                "expected_duration": 24,
-                "business_rules": {
-                    "technical_review_required": True,
-                    "business_review_required": True,
-                    "compliance_check_required": True
-                }
-            }
-            
-            review_workflow_id = self.business_process_workflow.create_business_process(
-                "review",
-                review_data
-            )
-            
-            if review_workflow_id:
-                test_results["business_processes_created"] += 1
-                test_results["integration_success"] += 1
-                
-                test_results["details"].append({
-                    "process_type": "review",
-                    "workflow_id": review_workflow_id,
-                    "status": "success",
-                    "message": "Contract review workflow created successfully"
-                })
-                
-                self.logger.info(f"✅ Created review workflow: {review_workflow_id}")
-            else:
-                test_results["integration_failures"] += 1
-                test_results["details"].append({
-                    "process_type": "review",
-                    "status": "failed",
-                    "message": "Failed to create review workflow"
-                })
-            
-            self.logger.info(f"✅ Business process integration testing complete: {test_results['integration_success']} successes")
-            return test_results
-            
-        except Exception as e:
-            self.logger.error(f"❌ Business process integration testing failed: {e}")
-            return {"error": str(e)}
-    
-    def test_performance_and_scalability(self) -> Dict[str, Any]:
-        """
-        Test workflow system performance and scalability.
-        
-        Returns:
-            Performance test results
-        """
-        self.logger.info("⚡ Testing performance and scalability...")
-        
-        test_results = {
-            "workflow_creation_time": 0.0,
-            "execution_time": 0.0,
-            "memory_usage": 0.0,
-            "concurrent_workflows": 0,
-            "performance_score": 0.0,
-            "details": []
-        }
-        
-        try:
-            import time
-            
-            # Test workflow creation performance
-            start_time = time.time()
-            
-            # Create multiple test workflows
-            test_workflows = []
-            for i in range(10):
-                workflow_def = {
-                    "name": f"Performance Test Workflow {i}",
-                    "description": f"Test workflow for performance testing {i}",
-                    "steps": [
-                        {
-                            "step_id": f"test_step_{i}",
-                            "name": f"Test Step {i}",
-                            "step_type": "test"
-                        }
-                    ]
-                }
-                
-                workflow_id = self.base_engine.create_workflow("sequential", workflow_def)
-                if workflow_id:
-                    test_workflows.append(workflow_id)
-            
-            creation_time = time.time() - start_time
-            test_results["workflow_creation_time"] = creation_time
-            test_results["concurrent_workflows"] = len(test_workflows)
-            
-            # Test execution performance
-            if test_workflows:
-                start_time = time.time()
-                
-                # Execute workflows
-                execution_ids = []
-                for workflow_id in test_workflows[:5]:  # Test with first 5
-                    try:
-                        execution_id = self.base_engine.execute_workflow(workflow_id)
-                        if execution_id:
-                            execution_ids.append(execution_id)
-                    except Exception as e:
-                        self.logger.warning(f"⚠️ Failed to execute workflow {workflow_id}: {e}")
-                
-                execution_time = time.time() - start_time
-                test_results["execution_time"] = execution_time
-                
-                # Get system health
-                system_health = self.base_engine.get_system_health()
-                test_results["details"].append({
-                    "test_type": "system_health",
-                    "result": system_health,
-                    "status": "success"
-                })
-            
-            # Calculate performance score
-            if test_results["workflow_creation_time"] > 0:
-                # Lower time is better, normalize to 0-100 scale
-                creation_score = max(0, 100 - (test_results["workflow_creation_time"] * 100))
-                execution_score = max(0, 100 - (test_results["execution_time"] * 100))
-                test_results["performance_score"] = (creation_score + execution_score) / 2
-            
-            self.logger.info(f"✅ Performance testing complete: Score {test_results['performance_score']:.1f}/100")
-            return test_results
-            
-        except Exception as e:
-            self.logger.error(f"❌ Performance testing failed: {e}")
-            return {"error": str(e)}
-    
-    def test_data_model_compatibility(self) -> Dict[str, Any]:
-        """
-        Test data model compatibility between workflow system and contracts.
-        
-        Returns:
-            Data model compatibility test results
-        """
-        self.logger.info("🔍 Testing data model compatibility...")
-        
-        test_results = {
-            "models_tested": 0,
-            "compatibility_success": 0,
-            "compatibility_failures": 0,
-            "validation_errors": [],
-            "details": []
-        }
-        
-        try:
-            # Test workflow definition compatibility
-            test_definition = {
-                "name": "Contract Integration Test",
-                "description": "Test workflow for contract integration",
-                "steps": [
-                    {
-                        "step_id": "contract_load",
-                        "name": "Load Contract",
-                        "step_type": "data_loading"
-                    },
-                    {
-                        "step_id": "workflow_generate",
-                        "name": "Generate Workflow",
-                        "step_type": "workflow_generation"
-                    },
-                    {
-                        "step_id": "validate",
-                        "name": "Validate Integration",
-                        "step_type": "validation"
-                    }
-                ],
-                "metadata": {
-                    "contract_integration": True,
-                    "test_mode": True,
-                    "validation_required": True
-                }
-            }
-            
-            # Test workflow creation
-            try:
-                workflow_id = self.base_engine.create_workflow("sequential", test_definition)
-                test_results["models_tested"] += 1
-                
-                if workflow_id:
-                    test_results["compatibility_success"] += 1
-                    test_results["details"].append({
-                        "test_type": "workflow_creation",
-                        "status": "success",
-                        "message": "Workflow definition compatible with system"
-                    })
-                else:
-                    test_results["compatibility_failures"] += 1
-                    test_results["details"].append({
-                        "test_type": "workflow_creation",
-                        "status": "failed",
-                        "message": "Workflow creation failed"
-                    })
-                    
-            except Exception as e:
-                test_results["compatibility_failures"] += 1
-                test_results["validation_errors"].append(str(e))
-                test_results["details"].append({
-                    "test_type": "workflow_creation",
-                    "status": "error",
-                    "message": f"Workflow creation error: {str(e)}"
-                })
-            
-            # Test business process data model
-            try:
-                business_data = {
-                    "business_unit": "Integration Testing",
-                    "priority": "high",
-                    "compliance_required": True,
-                    "expected_duration": 24,
-                    "business_rules": {
-                        "test_mode": True,
-                        "validation_required": True
-                    }
-                }
-                
-                business_workflow_id = self.business_process_workflow.create_business_process(
-                    "compliance",
-                    business_data
-                )
-                
-                test_results["models_tested"] += 1
-                
-                if business_workflow_id:
-                    test_results["compatibility_success"] += 1
-                    test_results["details"].append({
-                        "test_type": "business_process",
-                        "status": "success",
-                        "message": "Business process data model compatible"
-                    })
-                else:
-                    test_results["compatibility_failures"] += 1
-                    test_results["details"].append({
-                        "test_type": "business_process",
-                        "status": "failed",
-                        "message": "Business process creation failed"
-                    })
-                    
-            except Exception as e:
-                test_results["compatibility_failures"] += 1
-                test_results["validation_errors"].append(str(e))
-                test_results["details"].append({
-                    "test_type": "business_process",
-                    "status": "error",
-                    "message": f"Business process error: {str(e)}"
-                })
-            
-            self.logger.info(f"✅ Data model compatibility testing complete: {test_results['compatibility_success']} successes, {test_results['compatibility_failures']} failures")
-            return test_results
-            
-        except Exception as e:
-            self.logger.error(f"❌ Data model compatibility testing failed: {e}")
-            return {"error": str(e)}
-    
+        self.logger.info(
+            "🚀 Workflow Integration Test Plan initialized using existing unified systems"
+        )
+
     def run_comprehensive_integration_test(self) -> Dict[str, Any]:
-        """
-        Run comprehensive integration testing suite.
-        
-        Returns:
-            Complete integration test results
-        """
+        """Run comprehensive integration testing suite."""
         self.logger.info("🚀 Starting comprehensive integration testing...")
-        
         start_time = datetime.now()
-        
-        # Load contract data
-        contract_data = self.load_contract_data()
-        
-        # Run all test suites
+
+        self.contract_data = load_contract_data(self.logger)
+        contract_results = test_contract_workflow_integration(
+            self.base_engine, self.contract_data, self.logger, self.contract_workflows
+        )
+        learning_results = test_learning_workflow_integration(
+            self.learning_integration, self.logger
+        )
+        business_results = test_business_process_workflow_integration(
+            self.business_process_workflow, self.logger
+        )
+        performance_results = test_performance_and_scalability(
+            self.base_engine, self.logger
+        )
+        compatibility_results = test_data_model_compatibility(
+            self.base_engine, self.business_process_workflow, self.logger
+        )
+
         test_suites = {
-            "contract_integration": self.test_contract_workflow_integration(),
-            "learning_integration": self.test_learning_workflow_integration(),
-            "business_process_integration": self.test_business_process_workflow_integration(),
-            "performance_testing": self.test_performance_and_scalability(),
-            "data_model_compatibility": self.test_data_model_compatibility()
+            "contract_integration": asdict(contract_results),
+            "learning_integration": asdict(learning_results),
+            "business_process_integration": asdict(business_results),
+            "performance_testing": asdict(performance_results),
+            "data_model_compatibility": asdict(compatibility_results),
         }
-        
-        # Calculate overall results
-        total_tests = 0
-        total_successes = 0
-        total_failures = 0
-        
-        for suite_name, suite_results in test_suites.items():
-            if "error" not in suite_results:
-                if "integration_success" in suite_results:
-                    total_tests += suite_results.get("integration_success", 0) + suite_results.get("integration_failures", 0)
-                    total_successes += suite_results.get("integration_success", 0)
-                    total_failures += suite_results.get("integration_failures", 0)
-                elif "compatibility_success" in suite_results:
-                    total_tests += suite_results.get("compatibility_success", 0) + suite_results.get("compatibility_failures", 0)
-                    total_successes += suite_results.get("compatibility_success", 0)
-                    total_failures += suite_results.get("compatibility_failures", 0)
-        
+
+        total_tests = (
+            contract_results.integration_success + contract_results.integration_failures
+            + learning_results.integration_success + learning_results.integration_failures
+            + business_results.integration_success + business_results.integration_failures
+            + compatibility_results.compatibility_success + compatibility_results.compatibility_failures
+        )
+        total_successes = (
+            contract_results.integration_success
+            + learning_results.integration_success
+            + business_results.integration_success
+            + compatibility_results.compatibility_success
+        )
+        total_failures = (
+            contract_results.integration_failures
+            + learning_results.integration_failures
+            + business_results.integration_failures
+            + compatibility_results.compatibility_failures
+        )
+
         end_time = datetime.now()
         test_duration = (end_time - start_time).total_seconds()
-        
+
         comprehensive_results = {
             "test_execution_time": test_duration,
             "total_tests": total_tests,
@@ -729,29 +115,27 @@ class WorkflowIntegrationTestPlan:
             "total_failures": total_failures,
             "success_rate": (total_successes / total_tests * 100) if total_tests > 0 else 0,
             "test_suites": test_suites,
-            "overall_status": "PASSED" if total_failures == 0 else "PARTIAL" if total_successes > 0 else "FAILED",
-            "timestamp": datetime.now().isoformat()
+            "overall_status": "PASSED"
+            if total_failures == 0
+            else "PARTIAL" if total_successes > 0 else "FAILED",
+            "timestamp": datetime.now().isoformat(),
         }
-        
-        self.logger.info(f"🎉 Comprehensive integration testing complete!")
-        self.logger.info(f"📊 Results: {total_successes}/{total_tests} tests passed ({comprehensive_results['success_rate']:.1f}%)")
+
+        self.logger.info("🎉 Comprehensive integration testing complete!")
+        self.logger.info(
+            f"📊 Results: {total_successes}/{total_tests} tests passed ({comprehensive_results['success_rate']:.1f}%)"
+        )
         self.logger.info(f"⏱️ Duration: {test_duration:.2f} seconds")
-        self.logger.info(f"📈 Overall Status: {comprehensive_results['overall_status']}")
-        
+        self.logger.info(
+            f"📈 Overall Status: {comprehensive_results['overall_status']}"
+        )
+
         return comprehensive_results
-    
+
     def generate_integration_report(self) -> str:
-        """
-        Generate comprehensive integration test report.
-        
-        Returns:
-            Formatted integration test report
-        """
+        """Generate comprehensive integration test report."""
         try:
-            # Run comprehensive testing
             results = self.run_comprehensive_integration_test()
-            
-            # Generate report
             report = f"""
 🎯 WORKFLOW SYSTEM INTEGRATION TEST REPORT
 =========================================
@@ -798,14 +182,16 @@ Success Rate: {results['success_rate']:.1f}%
 🎯 RECOMMENDATIONS
 ------------------
 """
-            
             if results['overall_status'] == 'PASSED':
                 report += "✅ All integration tests passed successfully. Workflow system is ready for production use."
             elif results['overall_status'] == 'PARTIAL':
-                report += "⚠️ Some integration tests failed. Review failed tests and address issues before production deployment."
+                report += (
+                    "⚠️ Some integration tests failed. Review failed tests and address issues before production deployment."
+                )
             else:
-                report += "❌ Multiple integration tests failed. System requires significant fixes before production use."
-            
+                report += (
+                    "❌ Multiple integration tests failed. System requires significant fixes before production use."
+                )
             report += f"""
 
 📋 NEXT STEPS
@@ -828,26 +214,16 @@ Data Model Compatibility: {'✅ READY' if results['test_suites']['data_model_com
 Report Generated: {datetime.now().isoformat()}
 Agent: Agent-3 (Integration & Testing)
 """
-            
             return report
-            
         except Exception as e:
             self.logger.error(f"❌ Failed to generate integration report: {e}")
             return f"❌ Error generating report: {str(e)}"
 
 
 if __name__ == "__main__":
-    # Initialize test plan
     test_plan = WorkflowIntegrationTestPlan()
-    
-    # Generate comprehensive report
     report = test_plan.generate_integration_report()
-    
-    # Print report
     print(report)
-    
-    # Save report to file
     with open("workflow_integration_test_report.md", "w") as f:
         f.write(report)
-    
     print("\n📄 Report saved to: workflow_integration_test_report.md")

--- a/src/core/workflow/testing/helpers/__init__.py
+++ b/src/core/workflow/testing/helpers/__init__.py
@@ -1,0 +1,16 @@
+"""Helper functions for workflow integration testing."""
+
+from .contract import load_contract_data, test_contract_workflow_integration
+from .learning import test_learning_workflow_integration
+from .business_process import test_business_process_workflow_integration
+from .performance import test_performance_and_scalability
+from .data_model import test_data_model_compatibility
+
+__all__ = [
+    "load_contract_data",
+    "test_contract_workflow_integration",
+    "test_learning_workflow_integration",
+    "test_business_process_workflow_integration",
+    "test_performance_and_scalability",
+    "test_data_model_compatibility",
+]

--- a/src/core/workflow/testing/helpers/business_process.py
+++ b/src/core/workflow/testing/helpers/business_process.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Business process workflow helpers for integration tests."""
+
+import logging
+
+from ..integration_test_plan_structures import BusinessProcessIntegrationResult
+from ...specialized.business_process_workflow import BusinessProcessWorkflow
+
+
+def test_business_process_workflow_integration(
+    business_process_workflow: BusinessProcessWorkflow, logger: logging.Logger
+) -> BusinessProcessIntegrationResult:
+    """Test business process workflow integration."""
+    logger.info("\ud83d\udd04 Testing business process workflow integration...")
+    result = BusinessProcessIntegrationResult()
+    try:
+        approval_data = {
+            "business_unit": "Contract Management",
+            "priority": "high",
+            "compliance_required": True,
+            "expected_duration": 48,
+            "business_rules": {
+                "auto_approval_threshold": 100,
+                "manager_approval_required": True,
+                "compliance_review_required": True,
+            },
+        }
+        approval_workflow_id = business_process_workflow.create_business_process(
+            "approval", approval_data
+        )
+        if approval_workflow_id:
+            result.business_processes_created += 1
+            result.approval_workflows += 1
+            result.integration_success += 1
+            approval_success = business_process_workflow.add_approval_step(
+                approval_workflow_id, "contract_manager_001", "standard"
+            )
+            if approval_success:
+                result.compliance_tracking += 1
+            result.details.append(
+                {
+                    "process_type": "approval",
+                    "workflow_id": approval_workflow_id,
+                    "status": "success",
+                    "message": "Contract approval workflow created successfully",
+                }
+            )
+            logger.info(f"\u2705 Created approval workflow: {approval_workflow_id}")
+        else:
+            result.integration_failures += 1
+            result.details.append(
+                {
+                    "process_type": "approval",
+                    "status": "failed",
+                    "message": "Failed to create approval workflow",
+                }
+            )
+        review_data = {
+            "business_unit": "Quality Assurance",
+            "priority": "medium",
+            "compliance_required": True,
+            "expected_duration": 24,
+            "business_rules": {
+                "technical_review_required": True,
+                "business_review_required": True,
+                "compliance_check_required": True,
+            },
+        }
+        review_workflow_id = business_process_workflow.create_business_process(
+            "review", review_data
+        )
+        if review_workflow_id:
+            result.business_processes_created += 1
+            result.integration_success += 1
+            result.details.append(
+                {
+                    "process_type": "review",
+                    "workflow_id": review_workflow_id,
+                    "status": "success",
+                    "message": "Contract review workflow created successfully",
+                }
+            )
+            logger.info(f"\u2705 Created review workflow: {review_workflow_id}")
+        else:
+            result.integration_failures += 1
+            result.details.append(
+                {
+                    "process_type": "review",
+                    "status": "failed",
+                    "message": "Failed to create review workflow",
+                }
+            )
+        logger.info(
+            f"\u2705 Business process integration testing complete: {result.integration_success} successes"
+        )
+        return result
+    except Exception as e:  # pragma: no cover - logging
+        logger.error(f"\u274c Business process integration testing failed: {e}")
+        return result

--- a/src/core/workflow/testing/helpers/contract.py
+++ b/src/core/workflow/testing/helpers/contract.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Contract testing helpers for integration tests."""
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from ..integration_test_plan_structures import ContractIntegrationResult
+from ...base_workflow_engine import BaseWorkflowEngine
+
+
+def load_contract_data(logger: logging.Logger) -> Dict[str, Any]:
+    """Load contract data for integration testing."""
+    logger.info("\ud83d\udccb Loading contract data for integration testing...")
+    contract_data: Dict[str, Any] = {}
+    try:
+        contract_index_path = "contracts/MASTER_CONTRACT_INDEX.json"
+        if os.path.exists(contract_index_path):
+            with open(contract_index_path, "r") as f:
+                contract_data["master_index"] = json.load(f)
+            logger.info("\u2705 Master contract index loaded")
+
+        template_path = "contracts/CONSOLIDATED_CONTRACT_TEMPLATE.json"
+        if os.path.exists(template_path):
+            with open(template_path, "r") as f:
+                contract_data["template"] = json.load(f)
+            logger.info("\u2705 Contract template loaded")
+
+        phase_contracts = [
+            "contracts/phase3a_core_system_contracts.json",
+            "contracts/phase3b_moderate_contracts.json",
+            "contracts/phase3c_standard_moderate_contracts.json",
+        ]
+        for contract_file in phase_contracts:
+            if os.path.exists(contract_file):
+                with open(contract_file, "r") as f:
+                    phase_name = os.path.basename(contract_file).replace(".json", "")
+                    contract_data[phase_name] = json.load(f)
+                    logger.info(f"\u2705 {phase_name} contracts loaded")
+        return contract_data
+    except Exception as e:  # pragma: no cover - logging
+        logger.error(f"\u274c Failed to load contract data: {e}")
+        return {}
+
+
+def test_contract_workflow_integration(
+    base_engine: BaseWorkflowEngine,
+    contract_data: Dict[str, Any],
+    logger: logging.Logger,
+    contract_workflows: Optional[Dict[str, str]] = None,
+) -> ContractIntegrationResult:
+    """Test workflow system integration with contracts."""
+    logger.info("\ud83d\udd04 Testing contract workflow integration...")
+    result = ContractIntegrationResult()
+    if contract_workflows is None:
+        contract_workflows = {}
+    try:
+        if "master_index" in contract_data:
+            master_contract = contract_data["master_index"]
+            workflow_definition = {
+                "name": "Contract Management Workflow",
+                "description": "Automated contract management and tracking",
+                "steps": [
+                    {"step_id": "contract_analysis", "name": "Contract Analysis", "step_type": "analysis"},
+                    {"step_id": "workflow_generation", "name": "Workflow Generation", "step_type": "generation"},
+                    {"step_id": "execution_tracking", "step_type": "tracking"},
+                ],
+                "metadata": {
+                    "contract_type": "master_index",
+                    "total_phases": master_contract.get("total_phases", 0),
+                    "total_contracts": master_contract.get("total_contracts", 0),
+                },
+            }
+            workflow_id = base_engine.create_workflow("sequential", workflow_definition)
+            if workflow_id:
+                result.workflows_created += 1
+                result.integration_success += 1
+                contract_workflows["master_index"] = workflow_id
+                result.details.append(
+                    {
+                        "contract_type": "master_index",
+                        "workflow_id": workflow_id,
+                        "status": "success",
+                        "message": "Master contract workflow created successfully",
+                    }
+                )
+                logger.info(f"\u2705 Created workflow for master contract: {workflow_id}")
+            else:
+                result.integration_failures += 1
+                result.details.append(
+                    {
+                        "contract_type": "master_index",
+                        "status": "failed",
+                        "message": "Failed to create workflow",
+                    }
+                )
+        for phase_name, phase_data in contract_data.items():
+            if phase_name in ["master_index", "template"]:
+                continue
+            result.contracts_processed += 1
+            try:
+                phase_workflow_definition = {
+                    "name": f"{phase_name.replace('_', ' ').title()} Workflow",
+                    "description": f"Automated workflow for {phase_name} contracts",
+                    "steps": [
+                        {"step_id": "phase_analysis", "name": "Phase Analysis", "step_type": "analysis"},
+                        {"step_id": "contract_processing", "name": "Contract Processing", "step_type": "processing"},
+                        {"step_id": "validation", "name": "Validation", "step_type": "validation"},
+                    ],
+                    "metadata": {
+                        "contract_type": phase_name,
+                        "contract_count": len(phase_data.get("contracts", [])),
+                        "priority": phase_data.get("priority", "unknown"),
+                    },
+                }
+                phase_workflow_id = base_engine.create_workflow("sequential", phase_workflow_definition)
+                if phase_workflow_id:
+                    result.workflows_created += 1
+                    result.integration_success += 1
+                    contract_workflows[phase_name] = phase_workflow_id
+                    result.details.append(
+                        {
+                            "contract_type": phase_name,
+                            "workflow_id": phase_workflow_id,
+                            "status": "success",
+                            "message": f"{phase_name} workflow created successfully",
+                        }
+                    )
+                    logger.info(f"\u2705 Created workflow for {phase_name}: {phase_workflow_id}")
+                else:
+                    result.integration_failures += 1
+                    result.details.append(
+                        {
+                            "contract_type": phase_name,
+                            "status": "failed",
+                            "message": f"Failed to create {phase_name} workflow",
+                        }
+                    )
+            except Exception as e:  # pragma: no cover - logging
+                result.integration_failures += 1
+                result.details.append(
+                    {
+                        "contract_type": phase_name,
+                        "status": "error",
+                        "message": f"Error processing {phase_name}: {str(e)}",
+                    }
+                )
+                logger.error(f"\u274c Error processing {phase_name}: {e}")
+        logger.info(
+            f"\u2705 Contract integration testing complete: {result.integration_success} successes, {result.integration_failures} failures"
+        )
+        result.workflows = contract_workflows
+        return result
+    except Exception as e:  # pragma: no cover - logging
+        logger.error(f"\u274c Contract integration testing failed: {e}")
+        return result

--- a/src/core/workflow/testing/helpers/data_model.py
+++ b/src/core/workflow/testing/helpers/data_model.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Data model compatibility helpers for integration tests."""
+
+import logging
+
+from ..integration_test_plan_structures import DataModelCompatibilityResult
+from ...base_workflow_engine import BaseWorkflowEngine
+from ...specialized.business_process_workflow import BusinessProcessWorkflow
+
+
+def test_data_model_compatibility(
+    base_engine: BaseWorkflowEngine,
+    business_process_workflow: BusinessProcessWorkflow,
+    logger: logging.Logger,
+) -> DataModelCompatibilityResult:
+    """Test data model compatibility between workflow system and contracts."""
+    logger.info("\ud83d\udd0d Testing data model compatibility...")
+    result = DataModelCompatibilityResult()
+    try:
+        test_definition = {
+            "name": "Contract Integration Test",
+            "description": "Test workflow for contract integration",
+            "steps": [
+                {"step_id": "contract_load", "name": "Load Contract", "step_type": "data_loading"},
+                {"step_id": "workflow_generate", "name": "Generate Workflow", "step_type": "workflow_generation"},
+                {"step_id": "validate", "name": "Validate Integration", "step_type": "validation"},
+            ],
+            "metadata": {
+                "contract_integration": True,
+                "test_mode": True,
+                "validation_required": True,
+            },
+        }
+        try:
+            workflow_id = base_engine.create_workflow("sequential", test_definition)
+            result.models_tested += 1
+            if workflow_id:
+                result.compatibility_success += 1
+                result.details.append(
+                    {
+                        "test_type": "workflow_creation",
+                        "status": "success",
+                        "message": "Workflow definition compatible with system",
+                    }
+                )
+            else:
+                result.compatibility_failures += 1
+                result.details.append(
+                    {
+                        "test_type": "workflow_creation",
+                        "status": "failed",
+                        "message": "Workflow creation failed",
+                    }
+                )
+        except Exception as e:  # pragma: no cover - logging
+            result.compatibility_failures += 1
+            result.validation_errors.append(str(e))
+            result.details.append(
+                {
+                    "test_type": "workflow_creation",
+                    "status": "error",
+                    "message": f"Workflow creation error: {str(e)}",
+                }
+            )
+        try:
+            business_data = {
+                "business_unit": "Integration Testing",
+                "priority": "high",
+                "compliance_required": True,
+                "expected_duration": 24,
+                "business_rules": {"test_mode": True, "validation_required": True},
+            }
+            business_workflow_id = business_process_workflow.create_business_process(
+                "compliance", business_data
+            )
+            result.models_tested += 1
+            if business_workflow_id:
+                result.compatibility_success += 1
+                result.details.append(
+                    {
+                        "test_type": "business_process",
+                        "status": "success",
+                        "message": "Business process data model compatible",
+                    }
+                )
+            else:
+                result.compatibility_failures += 1
+                result.details.append(
+                    {
+                        "test_type": "business_process",
+                        "status": "failed",
+                        "message": "Business process creation failed",
+                    }
+                )
+        except Exception as e:  # pragma: no cover - logging
+            result.compatibility_failures += 1
+            result.validation_errors.append(str(e))
+            result.details.append(
+                {
+                    "test_type": "business_process",
+                    "status": "error",
+                    "message": f"Business process error: {str(e)}",
+                }
+            )
+        logger.info(
+            f"\u2705 Data model compatibility testing complete: {result.compatibility_success} successes, {result.compatibility_failures} failures"
+        )
+        return result
+    except Exception as e:  # pragma: no cover - logging
+        logger.error(f"\u274c Data model compatibility testing failed: {e}")
+        return result

--- a/src/core/workflow/testing/helpers/learning.py
+++ b/src/core/workflow/testing/helpers/learning.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Learning workflow helpers for integration tests."""
+
+import logging
+
+from ..integration_test_plan_structures import LearningIntegrationResult
+from ...learning_integration import LearningWorkflowIntegration
+
+
+def test_learning_workflow_integration(
+    learning_integration: LearningWorkflowIntegration, logger: logging.Logger
+) -> LearningIntegrationResult:
+    """Test learning workflow integration."""
+    logger.info("\ud83e\uddd0 Testing learning workflow integration...")
+    result = LearningIntegrationResult()
+    try:
+        learning_workflow_id = learning_integration.create_learning_workflow(
+            "Integration Testing - Learning Workflow", "test_agent_001"
+        )
+        if learning_workflow_id:
+            result.learning_workflows_created += 1
+            result.integration_success += 1
+            result.details.append(
+                {
+                    "test_type": "learning_workflow",
+                    "workflow_id": learning_workflow_id,
+                    "status": "success",
+                    "message": "Learning workflow created successfully",
+                }
+            )
+            logger.info(f"\u2705 Created learning workflow: {learning_workflow_id}")
+        else:
+            result.integration_failures += 1
+            result.details.append(
+                {
+                    "test_type": "learning_workflow",
+                    "status": "failed",
+                    "message": "Failed to create learning workflow",
+                }
+            )
+        decision_workflow_id = learning_integration.create_decision_workflow(
+            "integration_test", "high", {"test_mode": True, "integration_required": True}
+        )
+        if decision_workflow_id:
+            result.decision_workflows_created += 1
+            result.integration_success += 1
+            result.details.append(
+                {
+                    "test_type": "decision_workflow",
+                    "workflow_id": decision_workflow_id,
+                    "status": "success",
+                    "message": "Decision workflow created successfully",
+                }
+            )
+            logger.info(f"\u2705 Created decision workflow: {decision_workflow_id}")
+        else:
+            result.integration_failures += 1
+            result.details.append(
+                {
+                    "test_type": "decision_workflow",
+                    "status": "failed",
+                    "message": "Failed to create decision workflow",
+                }
+            )
+        integration_status = learning_integration.get_integration_status()
+        status = "success" if "error" not in integration_status else "failed"
+        result.details.append(
+            {
+                "test_type": "integration_status",
+                "status": status,
+                "message": "Integration status retrieved successfully"
+                if status == "success"
+                else "Failed to get integration status",
+            }
+        )
+        logger.info(
+            f"\u2705 Learning workflow integration testing complete: {result.integration_success} successes"
+        )
+        return result
+    except Exception as e:  # pragma: no cover - logging
+        logger.error(f"\u274c Learning workflow integration testing failed: {e}")
+        return result

--- a/src/core/workflow/testing/helpers/performance.py
+++ b/src/core/workflow/testing/helpers/performance.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Performance and scalability helpers for integration tests."""
+
+import logging
+import time
+
+from ..integration_test_plan_structures import PerformanceTestResult
+from ...base_workflow_engine import BaseWorkflowEngine
+
+
+def test_performance_and_scalability(
+    base_engine: BaseWorkflowEngine, logger: logging.Logger
+) -> PerformanceTestResult:
+    """Test workflow system performance and scalability."""
+    logger.info("\u26a1 Testing performance and scalability...")
+    result = PerformanceTestResult()
+    try:
+        start_time = time.time()
+        test_workflows = []
+        for i in range(10):
+            workflow_def = {
+                "name": f"Performance Test Workflow {i}",
+                "description": f"Test workflow for performance testing {i}",
+                "steps": [{"step_id": f"test_step_{i}", "name": f"Test Step {i}", "step_type": "test"}],
+            }
+            workflow_id = base_engine.create_workflow("sequential", workflow_def)
+            if workflow_id:
+                test_workflows.append(workflow_id)
+        result.workflow_creation_time = time.time() - start_time
+        result.concurrent_workflows = len(test_workflows)
+        if test_workflows:
+            start_time = time.time()
+            for workflow_id in test_workflows[:5]:
+                try:
+                    base_engine.execute_workflow(workflow_id)
+                except Exception as exc:  # pragma: no cover - logging
+                    logger.warning(f"\u26a0\ufe0f Failed to execute workflow {workflow_id}: {exc}")
+            result.execution_time = time.time() - start_time
+            system_health = base_engine.get_system_health()
+            result.details.append(
+                {
+                    "test_type": "system_health",
+                    "result": system_health,
+                    "status": "success",
+                }
+            )
+        if result.workflow_creation_time > 0:
+            creation_score = max(0, 100 - (result.workflow_creation_time * 100))
+            execution_score = max(0, 100 - (result.execution_time * 100))
+            result.performance_score = (creation_score + execution_score) / 2
+        logger.info(
+            f"\u2705 Performance testing complete: Score {result.performance_score:.1f}/100"
+        )
+        return result
+    except Exception as e:  # pragma: no cover - logging
+        logger.error(f"\u274c Performance testing failed: {e}")
+        return result

--- a/src/core/workflow/testing/integration_test_plan_structures.py
+++ b/src/core/workflow/testing/integration_test_plan_structures.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Integration Test Plan Structures
+===============================
+
+Dataclasses defining result structures for the workflow integration test plan.
+Follows V2 standards: <=200 LOC, single responsibility.
+
+Author: Agent-3 (Integration & Testing)
+License: MIT
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class ContractIntegrationResult:
+    """Results for contract workflow integration tests."""
+    contracts_processed: int = 0
+    workflows_created: int = 0
+    integration_success: int = 0
+    integration_failures: int = 0
+    workflows: Dict[str, str] = field(default_factory=dict)
+    details: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class LearningIntegrationResult:
+    """Results for learning workflow integration tests."""
+    learning_workflows_created: int = 0
+    decision_workflows_created: int = 0
+    integration_success: int = 0
+    integration_failures: int = 0
+    details: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class BusinessProcessIntegrationResult:
+    """Results for business process workflow integration tests."""
+    business_processes_created: int = 0
+    approval_workflows: int = 0
+    compliance_tracking: int = 0
+    integration_success: int = 0
+    integration_failures: int = 0
+    details: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class PerformanceTestResult:
+    """Results for performance and scalability tests."""
+    workflow_creation_time: float = 0.0
+    execution_time: float = 0.0
+    memory_usage: float = 0.0
+    concurrent_workflows: int = 0
+    performance_score: float = 0.0
+    details: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class DataModelCompatibilityResult:
+    """Results for data model compatibility tests."""
+    models_tested: int = 0
+    compatibility_success: int = 0
+    compatibility_failures: int = 0
+    validation_errors: List[str] = field(default_factory=list)
+    details: List[Dict[str, Any]] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- modularize integration test helpers into dedicated modules for contract, learning, business process, performance, and data-model checks
- re-export helper functions via `testing.helpers` package and update integration test plan imports

## Testing
- `python -m pytest tests/simple_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68aef63fd0f883299dedd836b4efbe4a