### PR TITLE
Centralize DecisionMetrics

### DIFF
--- a/src/core/decision/__init__.py
+++ b/src/core/decision/__init__.py
@@ -25,8 +25,8 @@ from .decision_manager import DecisionManager, DecisionManagerConfig
 from .decision_types import (
     DecisionRequest, DecisionResult, DecisionContext, DecisionType,
     DecisionPriority, DecisionStatus, DecisionConfidence, IntelligenceLevel,
-    DecisionMetrics  # SSOT: Unified decision metrics
 )
+from .decision_metrics import DecisionMetrics  # SSOT: Unified decision metrics
 
 # Factory functions for easy component creation
 def create_decision_core(manager_id: str, name: str = "Decision Core", description: str = "") -> DecisionCore:

--- a/src/core/decision/decision_cleanup.py
+++ b/src/core/decision/decision_cleanup.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Any, Optional, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 
-from .decision_models import DecisionStatus
+from .decision_types import DecisionStatus
 
 
 @dataclass

--- a/src/core/decision/decision_core.py
+++ b/src/core/decision/decision_core.py
@@ -22,6 +22,7 @@ from .decision_types import (
     DecisionPriority, DecisionStatus, DecisionConfidence, IntelligenceLevel,
     DecisionAlgorithm
 )
+from .decision_metrics import DecisionMetrics
 from .decision_algorithms import DecisionAlgorithmExecutor
 from .decision_workflows import DecisionWorkflowExecutor
 from .decision_rules import DecisionRuleEngine

--- a/src/core/decision/decision_types.py
+++ b/src/core/decision/decision_types.py
@@ -14,7 +14,7 @@ CONSOLIDATION STATUS:
 - ❌ REMOVED: LearningMode (unified with src/core/learning/)
 - ❌ REMOVED: DataIntegrityLevel (not decision-specific)
 - ✅ Clean decision type definitions
-- ✅ SSOT: Unified DecisionMetrics class
+- ✅ Decision metrics centralized in decision_metrics module
 """
 
 from enum import Enum
@@ -168,104 +168,6 @@ class DecisionWorkflow:
     steps: List[str]
     decision_types: List[DecisionType]
     is_active: bool
-
-
-@dataclass
-class DecisionMetrics:
-    """
-    SSOT: Unified Decision Performance Metrics
-    
-    This class consolidates all decision metrics functionality into a single
-    source of truth, eliminating duplication across the codebase.
-    """
-    metrics_id: str
-    decision_type: DecisionType
-    total_decisions: int = 0
-    successful_decisions: int = 0
-    failed_decisions: int = 0
-    average_confidence: float = 0.0
-    average_execution_time: float = 0.0
-    last_updated: datetime = field(default_factory=datetime.now)
-    
-    # Performance tracking
-    total_execution_time: float = 0.0
-    confidence_history: List[float] = field(default_factory=list)
-    execution_time_history: List[float] = field(default_factory=list)
-    
-    # Alert thresholds
-    success_rate_threshold: float = 0.8
-    execution_time_threshold: float = 5.0
-    confidence_threshold: float = 0.7
-    
-    def update_metrics(self, success: bool, execution_time: float, confidence: float):
-        """Update metrics with new decision result"""
-        self.total_decisions += 1
-        if success:
-            self.successful_decisions += 1
-        else:
-            self.failed_decisions += 1
-            
-        self.total_execution_time += execution_time
-        self.execution_time_history.append(execution_time)
-        self.confidence_history.append(confidence)
-        
-        # Update averages
-        self.average_execution_time = self.total_execution_time / self.total_decisions
-        self.average_confidence = sum(self.confidence_history) / len(self.confidence_history)
-        
-        # Keep history manageable
-        if len(self.execution_time_history) > 1000:
-            self.execution_time_history = self.execution_time_history[-1000:]
-        if len(self.confidence_history) > 1000:
-            self.confidence_history = self.confidence_history[-1000:]
-            
-        self.last_updated = datetime.now()
-    
-    def get_success_rate(self) -> float:
-        """Get current success rate"""
-        if self.total_decisions == 0:
-            return 0.0
-        return self.successful_decisions / self.total_decisions
-    
-    def get_performance_score(self) -> float:
-        """Calculate overall performance score"""
-        success_rate = self.get_success_rate()
-        time_score = max(0.0, 1.0 - (self.average_execution_time / 10.0))
-        confidence_score = self.average_confidence
-        
-        # Weighted combination
-        return (success_rate * 0.4) + (time_score * 0.3) + (confidence_score * 0.3)
-    
-    def check_alerts(self) -> List[str]:
-        """Check for performance alerts"""
-        alerts = []
-        
-        if self.get_success_rate() < self.success_rate_threshold:
-            alerts.append(f"Success rate {self.get_success_rate():.2%} below threshold {self.success_rate_threshold:.2%}")
-            
-        if self.average_execution_time > self.execution_time_threshold:
-            alerts.append(f"Average execution time {self.average_execution_time:.2f}s above threshold {self.execution_time_threshold:.2f}s")
-            
-        if self.average_confidence < self.confidence_threshold:
-            alerts.append(f"Average confidence {self.average_confidence:.2f} below threshold {self.confidence_threshold:.2f}")
-            
-        return alerts
-    
-    def get_summary(self) -> Dict[str, Any]:
-        """Get comprehensive metrics summary"""
-        return {
-            "metrics_id": self.metrics_id,
-            "decision_type": self.decision_type.value,
-            "total_decisions": self.total_decisions,
-            "successful_decisions": self.successful_decisions,
-            "failed_decisions": self.failed_decisions,
-            "success_rate": self.get_success_rate(),
-            "average_execution_time": self.average_execution_time,
-            "average_confidence": self.average_confidence,
-            "performance_score": self.get_performance_score(),
-            "alerts": self.check_alerts(),
-            "last_updated": self.last_updated.isoformat()
-        }
 
 
 @dataclass

--- a/src/core/decision/test_modular_decision_system.py
+++ b/src/core/decision/test_modular_decision_system.py
@@ -24,11 +24,12 @@ from .decision_rules import DecisionRuleEngine, RuleEvaluationResult, RulePerfor
 from .decision_manager import DecisionManager, DecisionManagerConfig
 
 # Import decision models
-from .decision_models import (
+from .decision_types import (
     DecisionRequest, DecisionResult, DecisionContext, DecisionType,
     DecisionPriority, DecisionStatus, DecisionConfidence, DecisionAlgorithm,
-    DecisionRule, DecisionMetrics, DecisionWorkflow
+    DecisionRule, DecisionWorkflow
 )
+from .decision_metrics import DecisionMetrics
 
 
 class TestDecisionCore(unittest.TestCase):

--- a/src/core/learning/decision_models.py
+++ b/src/core/learning/decision_models.py
@@ -150,49 +150,6 @@ class DecisionRule:
         if not self.rule_id:
             self.rule_id = str(uuid.uuid4())
 
-
-@dataclass
-class DecisionMetrics:
-    """Unified decision performance metrics"""
-    metrics_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    decision_type: DecisionType = DecisionType.TASK_ASSIGNMENT
-    total_decisions: int = 0
-    successful_decisions: int = 0
-    failed_decisions: int = 0
-    average_processing_time: float = 0.0
-    confidence_distribution: Dict[str, int] = field(default_factory=dict)
-    last_updated: datetime = field(default_factory=datetime.now)
-    
-    def __post_init__(self):
-        if not self.metrics_id:
-            self.metrics_id = str(uuid.uuid4())
-    
-    def update_metrics(self, success: bool, processing_time: float, confidence: DecisionConfidence):
-        """Update decision metrics"""
-        self.total_decisions += 1
-        if success:
-            self.successful_decisions += 1
-        else:
-            self.failed_decisions += 1
-        
-        # Update average processing time
-        if self.total_decisions > 0:
-            total_time = self.average_processing_time * (self.total_decisions - 1)
-            self.average_processing_time = (total_time + processing_time) / self.total_decisions
-        
-        # Update confidence distribution
-        confidence_key = confidence.value
-        self.confidence_distribution[confidence_key] = self.confidence_distribution.get(confidence_key, 0) + 1
-        
-        self.last_updated = datetime.now()
-    
-    def get_success_rate(self) -> float:
-        """Calculate decision success rate"""
-        if self.total_decisions == 0:
-            return 0.0
-        return (self.successful_decisions / self.total_decisions) * 100.0
-
-
 @dataclass
 class DecisionWorkflow:
     """Unified decision workflow definition"""

--- a/src/core/learning/unified_learning_engine.py
+++ b/src/core/learning/unified_learning_engine.py
@@ -24,8 +24,9 @@ from .models import (
 from .decision_models import (
     DecisionRequest, DecisionResult, DecisionContext, DecisionType,
     DecisionPriority, DecisionStatus, DecisionConfidence, DecisionAlgorithm,
-    DecisionRule, DecisionMetrics, DecisionWorkflow, DecisionCollaboration
+    DecisionRule, DecisionWorkflow, DecisionCollaboration
 )
+from ..decision import DecisionMetrics
 
 
 class UnifiedLearningEngine:


### PR DESCRIPTION
## Summary
- consolidate `DecisionMetrics` dataclass into `decision_metrics.py`
- remove redundant metric definitions in decision_types and learning decision_models
- update modules and tests to import centralized `DecisionMetrics`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68aef64e56608329888becdcdc9d010a