### PR TITLE
refactor: modularize metrics collector

### DIFF
--- a/src/core/performance/__init__.py
+++ b/src/core/performance/__init__.py
@@ -21,6 +21,7 @@ from .monitoring.performance_monitor import (
     MonitorSnapshot,
     PerformanceLevel
 )
+from .metrics.collector import MetricsCollector
 
 from .performance_core import (
     PerformanceLevel as CorePerformanceLevel,
@@ -90,7 +91,8 @@ def get_performance_monitor(*args, **kwargs):
 def get_metrics_collector(*args, **kwargs):
     """SSOT: Get unified metrics collector"""
     _deprecation_warning(
-        "src.services.performance_monitor.MetricsCollector", 
-        "src.core.performance.monitoring.performance_monitor.PerformanceMonitor"
+        "src.services.performance_monitor.MetricsCollector",
+        "src.core.performance.metrics.collector.MetricsCollector"
     )
-    return PerformanceMonitor(*args, **kwargs)
+    return MetricsCollector(*args, **kwargs)
+

--- a/src/core/performance/metrics/__init__.py
+++ b/src/core/performance/metrics/__init__.py
@@ -7,5 +7,14 @@ Handles performance metrics collection and processing.
 """
 
 from .collector import MetricsCollector
+from .types import MetricData, MetricType
+from .benchmarks import BenchmarkType, PerformanceBenchmark, PerformanceLevel
 
-__all__ = ["MetricsCollector"]
+__all__ = [
+    "MetricsCollector",
+    "MetricData",
+    "MetricType",
+    "BenchmarkType",
+    "PerformanceBenchmark",
+    "PerformanceLevel",
+]

--- a/src/core/performance/metrics/benchmarks.py
+++ b/src/core/performance/metrics/benchmarks.py
@@ -1,0 +1,190 @@
+"""Benchmark-related types and helpers."""
+import logging
+import statistics
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class BenchmarkType(Enum):
+    """Performance benchmark types"""
+
+    RESPONSE_TIME = "response_time"
+    THROUGHPUT = "throughput"
+    SCALABILITY = "scalability"
+    RELIABILITY = "reliability"
+    RESOURCE_UTILIZATION = "resource_utilization"
+    LATENCY = "latency"
+
+
+class PerformanceLevel(Enum):
+    """Performance level classifications"""
+
+    ENTERPRISE_READY = "enterprise_ready"
+    PRODUCTION_READY = "production_ready"
+    DEVELOPMENT_READY = "development_ready"
+    NOT_READY = "not_ready"
+
+
+@dataclass
+class PerformanceBenchmark:
+    """Performance benchmark result"""
+
+    benchmark_id: str
+    benchmark_type: BenchmarkType
+    test_name: str
+    start_time: str
+    end_time: str
+    duration: float
+    metrics: Dict[str, float]
+    target_metrics: Dict[str, float]
+    performance_level: PerformanceLevel
+    optimization_recommendations: List[str]
+
+
+class BenchmarkManager:
+    """Manage storage and analysis of benchmarks."""
+
+    def __init__(self) -> None:
+        self.benchmarks: Dict[str, PerformanceBenchmark] = {}
+        self.logger = logging.getLogger(f"{__name__}.BenchmarkManager")
+
+    # Storage operations -------------------------------------------------
+    def store(self, benchmark: PerformanceBenchmark) -> bool:
+        try:
+            self.benchmarks[benchmark.benchmark_id] = benchmark
+            self.logger.info(f"Stored benchmark: {benchmark.benchmark_id}")
+            return True
+        except Exception as exc:  # pragma: no cover - logging only
+            self.logger.error(f"Failed to store benchmark: {exc}")
+            return False
+
+    def get(self, benchmark_id: str) -> Optional[PerformanceBenchmark]:
+        return self.benchmarks.get(benchmark_id)
+
+    def all(self) -> Dict[str, PerformanceBenchmark]:
+        return self.benchmarks.copy()
+
+    def by_type(self, benchmark_type: BenchmarkType) -> List[PerformanceBenchmark]:
+        return [
+            b for b in self.benchmarks.values() if b.benchmark_type == benchmark_type
+        ]
+
+    def clear(self) -> None:
+        self.benchmarks.clear()
+        self.logger.info("Cleared all benchmarks")
+
+    # Aggregate calculations --------------------------------------------
+    def calculate_aggregate_metrics(
+        self, benchmarks: List[PerformanceBenchmark]
+    ) -> Dict[str, Any]:
+        try:
+            if not benchmarks:
+                return {}
+
+            by_type: Dict[BenchmarkType, List[PerformanceBenchmark]] = {}
+            for benchmark in benchmarks:
+                by_type.setdefault(benchmark.benchmark_type, []).append(benchmark)
+
+            aggregate: Dict[str, Any] = {}
+            for benchmark_type, type_benchmarks in by_type.items():
+                type_metrics: List[float] = []
+                for benchmark in type_benchmarks:
+                    type_metrics.extend(benchmark.metrics.values())
+
+                if type_metrics:
+                    aggregate[benchmark_type.value] = {
+                        "count": len(type_benchmarks),
+                        "average": statistics.mean(type_metrics),
+                        "min": min(type_metrics),
+                        "max": max(type_metrics),
+                        "std_dev": statistics.stdev(type_metrics)
+                        if len(type_metrics) > 1
+                        else 0,
+                    }
+            return aggregate
+        except Exception as exc:  # pragma: no cover - logging only
+            self.logger.error(f"Failed to calculate aggregate metrics: {exc}")
+            return {}
+
+    # Scalability helpers ------------------------------------------------
+    def calculate_scalability_score(self, scalability_results: List[Dict[str, Any]]) -> float:
+        try:
+            if len(scalability_results) < 2:
+                return 100.0  # Perfect score if only one data point
+
+            sorted_results = sorted(
+                scalability_results, key=lambda x: x.get("concurrent_agents", 0)
+            )
+            baseline_ops = sorted_results[0].get("operations_per_second", 1)
+            final_ops = sorted_results[-1].get("operations_per_second", 1)
+            if baseline_ops == 0:
+                return 0.0
+
+            baseline_agents = sorted_results[0].get("concurrent_agents", 1)
+            final_agents = sorted_results[-1].get("concurrent_agents", 1)
+            expected_ops = baseline_ops * (final_agents / baseline_agents)
+            actual_efficiency = (
+                (final_ops / expected_ops) * 100 if expected_ops > 0 else 0
+            )
+            return min(100.0, max(0.0, actual_efficiency))
+        except Exception as exc:  # pragma: no cover - logging only
+            self.logger.error(f"Failed to calculate scalability score: {exc}")
+            return 0.0
+
+    def calculate_performance_degradation(
+        self, scalability_results: List[Dict[str, Any]]
+    ) -> float:
+        try:
+            if len(scalability_results) < 2:
+                return 0.0
+
+            sorted_results = sorted(
+                scalability_results, key=lambda x: x.get("concurrent_agents", 0)
+            )
+            baseline_ops = sorted_results[0].get("operations_per_second", 1)
+            final_ops = sorted_results[-1].get("operations_per_second", 1)
+            if baseline_ops == 0:
+                return 100.0
+
+            degradation = ((baseline_ops - final_ops) / baseline_ops) * 100
+            return max(0.0, degradation)
+        except Exception as exc:  # pragma: no cover - logging only
+            self.logger.error(f"Failed to calculate performance degradation: {exc}")
+            return 0.0
+
+    # Summary ------------------------------------------------------------
+    def summary(self) -> Dict[str, Any]:
+        try:
+            total = len(self.benchmarks)
+            if total == 0:
+                return {"total_benchmarks": 0}
+
+            type_counts: Dict[str, int] = {}
+            performance_levels: Dict[str, int] = {}
+            for benchmark in self.benchmarks.values():
+                bt = benchmark.benchmark_type.value
+                type_counts[bt] = type_counts.get(bt, 0) + 1
+                level = benchmark.performance_level.value
+                performance_levels[level] = performance_levels.get(level, 0) + 1
+
+            latest = max(
+                self.benchmarks.values(), key=lambda x: x.start_time
+            ).benchmark_id
+            return {
+                "total_benchmarks": total,
+                "benchmarks_by_type": type_counts,
+                "performance_levels": performance_levels,
+                "latest_benchmark": latest,
+            }
+        except Exception as exc:  # pragma: no cover - logging only
+            self.logger.error(f"Failed to get benchmark summary: {exc}")
+            return {"error": str(exc)}
+
+
+__all__ = [
+    "BenchmarkManager",
+    "BenchmarkType",
+    "PerformanceBenchmark",
+    "PerformanceLevel",
+]

--- a/src/core/performance/metrics/types.py
+++ b/src/core/performance/metrics/types.py
@@ -1,0 +1,30 @@
+"""Metric data structures and types."""
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, Union
+
+
+class MetricType(Enum):
+    """Types of metrics that can be collected."""
+
+    GAUGE = "gauge"  # Current value (e.g., CPU usage)
+    COUNTER = "counter"  # Incrementing value (e.g., request count)
+    HISTOGRAM = "histogram"  # Distribution of values
+    TIMER = "timer"  # Timing measurements
+    SET = "set"  # Unique values count
+
+
+@dataclass
+class MetricData:
+    """Individual metric data point."""
+
+    metric_name: str
+    metric_type: MetricType
+    value: Union[float, int]
+    timestamp: float
+    tags: Dict[str, str] = field(default_factory=dict)
+    unit: str = ""
+    description: str = ""
+
+
+__all__ = ["MetricType", "MetricData"]

--- a/src/services/metrics_collector.py
+++ b/src/services/metrics_collector.py
@@ -5,7 +5,7 @@ from .metrics_collector_config import CollectorConfig
 from .metrics_collector_core import BaseCollector, SystemMetricsCollector, ApplicationMetricsCollector, NetworkMetricsCollector, CustomMetricsCollector
 from .metrics_collector_processor import MetricsProcessor
 from .metrics_collector_storage import MetricsStorage
-from .performance_monitor import MetricData, MetricType
+from src.core.performance.metrics.collector import MetricData, MetricType
 class MetricsCollectorOrchestrator:
     """Coordinate collectors, processor, and storage."""
     def __init__(self, collectors: Iterable[BaseCollector] | None=None, config: CollectorConfig | None=None) -> None:

--- a/src/services/metrics_collector_core.py
+++ b/src/services/metrics_collector_core.py
@@ -7,7 +7,11 @@ from typing import Callable, Dict, List
 
 import psutil
 
-from .performance_monitor import MetricsCollector, MetricData, MetricType
+from src.core.performance.metrics.collector import (
+    MetricsCollector,
+    MetricData,
+    MetricType,
+)
 from .metrics_collector_config import CollectorConfig
 
 

--- a/src/services/metrics_collector_processor.py
+++ b/src/services/metrics_collector_processor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Callable, Iterable, List
 
-from .performance_monitor import MetricData, MetricType
+from src.core.performance.metrics.collector import MetricData, MetricType
 
 
 class MetricsProcessor:

--- a/src/services/metrics_collector_storage.py
+++ b/src/services/metrics_collector_storage.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from .performance_monitor import MetricData
+from src.core.performance.metrics.collector import MetricData
 
 
 class MetricsStorage:

--- a/src/services/performance_monitor.py
+++ b/src/services/performance_monitor.py
@@ -9,7 +9,6 @@ import logging
 import time
 
 from src.utils.stability_improvements import stability_manager, safe_import
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union, Callable
@@ -18,19 +17,12 @@ import uuid
 from datetime import datetime, timedelta
 import threading
 
+# Consolidated metrics definitions
+from src.core.performance.metrics.collector import MetricData, MetricType
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-class MetricType(Enum):
-    """Types of metrics that can be collected."""
-
-    GAUGE = "gauge"  # Current value (e.g., CPU usage)
-    COUNTER = "counter"  # Incrementing value (e.g., request count)
-    HISTOGRAM = "histogram"  # Distribution of values
-    TIMER = "timer"  # Timing measurements
-    SET = "set"  # Unique values count
 
 
 class AlertSeverity(Enum):
@@ -51,19 +43,6 @@ class AlertCondition(Enum):
     NOT_EQUALS = "not_equals"
     GREATER_THAN_OR_EQUAL = "greater_than_or_equal"
     LESS_THAN_OR_EQUAL = "less_than_or_equal"
-
-
-@dataclass
-class MetricData:
-    """Individual metric data point."""
-
-    metric_name: str
-    metric_type: MetricType
-    value: Union[float, int]
-    timestamp: float
-    tags: Dict[str, str] = field(default_factory=dict)
-    unit: str = ""
-    description: str = ""
 
 
 @dataclass
@@ -489,39 +468,13 @@ class PerformanceMonitor:
         }
 
 
-# Base class for metrics collectors (will be used by metrics_collector.py)
-class MetricsCollector(ABC):
-    """Abstract base class for metrics collectors."""
-
-    def __init__(self, collection_interval: int = 60):
-        self.collection_interval = collection_interval
-        self.enabled = True
-        self.running = False
-        self.performance_monitor: Optional[PerformanceMonitor] = None
-
-    @abstractmethod
-    async def collect_metrics(self) -> List[MetricData]:
-        """Collect metrics and return list of MetricData objects."""
-        raise NotImplementedError
-
-    def set_enabled(self, enabled: bool):
-        """Enable or disable this collector."""
-        self.enabled = enabled
-        logger.info(
-            f"Metrics collector {self.__class__.__name__} {'enabled' if enabled else 'disabled'}"
-        )
-
-
 # Export all classes for use in other modules
 __all__ = [
-    "MetricType",
     "AlertSeverity",
     "AlertCondition",
-    "MetricData",
     "MetricSeries",
     "AlertRule",
     "PerformanceAlert",
     "MetricsStorage",
     "PerformanceMonitor",
-    "MetricsCollector",
 ]


### PR DESCRIPTION
## Summary
- modularize performance metrics by extracting metric and benchmark primitives into dedicated modules
- slim down MetricsCollector to delegate benchmark management to BenchmarkManager
- export new types through metrics package for easy consumption

## Testing
- `pytest tests/performance/test_metrics_collector_module.py tests/test_performance_setup.py tests/test_performance_execution.py tests/smoke/test_performance_monitoring_smoke.py -q` *(fails: AttributeError: type object 'ManagerPriority' has no attribute 'MEDIUM')*
- `pytest tests/performance/test_metrics_collector_module.py -q` *(fails: AttributeError: type object 'ManagerPriority' has no attribute 'MEDIUM')*

------
https://chatgpt.com/codex/tasks/task_e_68aef64f4e0883299e5ef124b265ce05