### PR TITLE
Add duplication types and reporter modules

### DIFF
--- a/tools/duplication/duplication_reporter.py
+++ b/tools/duplication/duplication_reporter.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Duplication Reporter - Agent Cellphone V2
+=======================================
+
+Report generation utilities for the duplication detection system.
+Follows V2 standards: ≤200 LOC, OOP design, SRP compliance.
+
+Author: V2 SWARM CAPTAIN
+License: MIT
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List
+
+from .duplication_types import DuplicationIssue, DuplicationSeverity
+
+
+class DuplicationReporter:
+    """Generates human readable and JSON reports."""
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(__name__)
+
+    def generate_report(
+        self, issues: List[DuplicationIssue], total_files: int
+    ) -> Dict[str, Any]:
+        """Create a structured report from detected issues."""
+        severity_counts = {s.value: 0 for s in DuplicationSeverity}
+        for issue in issues:
+            severity_counts[issue.severity.value] += 1
+
+        return {
+            "summary": {
+                "total_files": total_files,
+                "total_issues": len(issues),
+                "severity_counts": severity_counts,
+            },
+            "issues": [issue.to_dict() for issue in issues],
+        }
+
+    def print_report(self, report: Dict[str, Any]) -> None:
+        """Print a human readable report to stdout."""
+        summary = report["summary"]
+        print("=== Duplication Report ===")
+        print(f"Analyzed files: {summary['total_files']}")
+        print(f"Issues found: {summary['total_issues']}")
+        for sev, count in summary["severity_counts"].items():
+            print(f"{sev.title()}: {count}")
+
+        if not report["issues"]:
+            print("\nNo issues detected.")
+            return
+
+        print("\nDetailed Issues:")
+        for issue in report["issues"]:
+            print(f"- [{issue['severity']}] {issue['description']}")
+            for file_path, line in issue["line_numbers"]:
+                print(f"  {file_path}:{line}")
+            print()
+
+    def save_json_report(self, report: Dict[str, Any], output_path: str) -> None:
+        """Save the report to a JSON file."""
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+        self.logger.info("Report saved to %s", output_path)

--- a/tools/duplication/duplication_types.py
+++ b/tools/duplication/duplication_types.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Duplication Types - Agent Cellphone V2
+=====================================
+
+Shared data structures for the duplication detection system.
+Follows V2 standards: ≤200 LOC, OOP design, SRP compliance.
+
+Author: V2 SWARM CAPTAIN
+License: MIT
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Set, Tuple
+
+
+class BlockType(Enum):
+    """Types of code blocks that can be analyzed."""
+
+    FUNCTION = "function"
+    CLASS = "class"
+    IMPORT = "import"
+    BLOCK = "block"
+
+
+@dataclass
+class CodeBlock:
+    """Represents a block of code extracted for analysis."""
+
+    content: str
+    hash: str
+    file_path: str
+    start_line: int
+    end_line: int
+    block_type: BlockType
+    length: int
+    tokens: Set[str] = field(default_factory=set)
+
+
+class DuplicationSeverity(Enum):
+    """Severity levels for duplication issues."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+@dataclass
+class DuplicationIssue:
+    """Represents a detected duplication issue."""
+
+    issue_type: str
+    severity: DuplicationSeverity
+    description: str
+    files_involved: List[str]
+    line_numbers: List[Tuple[str, int]]
+    similarity_score: float
+    suggested_action: str
+    code_blocks: List[CodeBlock] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert issue to a serializable dictionary."""
+        return {
+            "issue_type": self.issue_type,
+            "severity": self.severity.value,
+            "description": self.description,
+            "files_involved": self.files_involved,
+            "line_numbers": self.line_numbers,
+            "similarity_score": self.similarity_score,
+            "suggested_action": self.suggested_action,
+            "code_blocks": [
+                {
+                    "file_path": block.file_path,
+                    "start_line": block.start_line,
+                    "end_line": block.end_line,
+                    "block_type": block.block_type.value,
+                    "length": block.length,
+                }
+                for block in self.code_blocks
+            ],
+        }


### PR DESCRIPTION
## Summary
- add duplication_types dataclasses for block and issue definitions
- add duplication_reporter for generating and printing reports

## Testing
- `pre-commit run --files tools/duplication/duplication_types.py tools/duplication/duplication_reporter.py` *(fails: No module named 'yaml'; duplication detector hook interrupted)*
- `echo $PYTHONPATH`
- `python tools/duplication_detector_main.py src --output duplication_report.json` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68aef60eb5848329b14aaf5ad05cb992