### PR TITLE
refactor: modularize task lifecycle services

### DIFF
--- a/src/core/managers/task_execution_service.py
+++ b/src/core/managers/task_execution_service.py
@@ -1,0 +1,190 @@
+"""Service handling task submission and execution."""
+import time
+from threading import Thread, Timer
+from typing import Callable, Dict, Any
+
+from .task_models import TaskStatus, TaskResult
+
+
+class TaskExecutionService:
+    """Handle submission and execution of tasks for the manager."""
+
+    def __init__(self, persistence, manager) -> None:
+        self._persistence = persistence
+        self._manager = manager
+        self._processor_thread: Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Processor management
+    # ------------------------------------------------------------------
+    def start_processor(self) -> None:
+        """Start the background task processor loop."""
+        self._processor_thread = Thread(target=self._task_processor_loop, daemon=True)
+        self._processor_thread.start()
+
+    def cleanup(self) -> None:
+        """Join the processor thread if running."""
+        if self._processor_thread and self._processor_thread.is_alive():
+            self._processor_thread.join(timeout=5)
+
+    # ------------------------------------------------------------------
+    # Public API used by TaskManager
+    # ------------------------------------------------------------------
+    def submit(self, task_id: str, executor_func: Callable, *args, **kwargs) -> bool:
+        """Submit a task for execution."""
+        try:
+            with self._manager.task_lock:
+                if task_id not in self._manager.tasks:
+                    return False
+
+                task = self._manager.tasks[task_id]
+                if task.status != TaskStatus.PENDING:
+                    return False
+
+                if not self._check_dependencies(task_id):
+                    return True
+
+                task.status = TaskStatus.RUNNING
+                task.started_at = self._manager._now_iso()
+
+                execution_thread = Thread(
+                    target=self._execute_task,
+                    args=(task_id, executor_func, args, kwargs),
+                    daemon=True,
+                )
+                self._manager.running_tasks[task_id] = execution_thread
+                execution_thread.start()
+
+                self._manager._emit_event(
+                    "task_started", {"task_id": task_id, "started_at": task.started_at}
+                )
+                self._persistence.persist(self._manager.tasks, self._manager.task_queue)
+                return True
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _check_dependencies(self, task_id: str) -> bool:
+        try:
+            task = self._manager.tasks[task_id]
+            for dep_id in task.dependencies:
+                if dep_id not in self._manager.tasks:
+                    return False
+                if self._manager.tasks[dep_id].status != TaskStatus.COMPLETED:
+                    return False
+            return True
+        except Exception:
+            return False
+
+    def _execute_task(self, task_id: str, executor_func: Callable, args: tuple, kwargs: Dict[str, Any]) -> None:
+        try:
+            task = self._manager.tasks[task_id]
+            start_time = time.time()
+            result = executor_func(*args, **kwargs)
+            execution_time = time.time() - start_time
+
+            task_result = TaskResult(
+                task_id=task_id,
+                success=True,
+                result=result,
+                error=None,
+                execution_time=execution_time,
+                metadata={"executor": executor_func.__name__},
+            )
+
+            with self._manager.task_lock:
+                task.status = TaskStatus.COMPLETED
+                task.completed_at = self._manager._now_iso()
+                task.duration = execution_time
+                task.result = result
+                if task_id in self._manager.running_tasks:
+                    del self._manager.running_tasks[task_id]
+                self._manager.completed_tasks[task_id] = task_result
+
+            self._manager._emit_event(
+                "task_completed",
+                {"task_id": task_id, "execution_time": execution_time, "success": True},
+            )
+            self._check_dependent_tasks(task_id)
+            self._persistence.persist(self._manager.tasks, self._manager.task_queue)
+        except Exception as e:
+            execution_time = time.time() - start_time  # type: ignore[unbound-local-variable]
+            task = self._manager.tasks.get(task_id)
+            if task and task.retry_count < task.max_retries:
+                task.retry_count += 1
+                task.status = TaskStatus.PENDING
+                task.error = f"Retry {task.retry_count}/{task.max_retries}: {e}"
+                Timer(
+                    self._manager.retry_delay, self._requeue_task, args=[task_id]
+                ).start()
+                self._persistence.persist(self._manager.tasks, self._manager.task_queue)
+            else:
+                if task:
+                    with self._manager.task_lock:
+                        task.status = TaskStatus.FAILED
+                        task.completed_at = self._manager._now_iso()
+                        task.duration = execution_time
+                        task.error = str(e)
+                        if task_id in self._manager.running_tasks:
+                            del self._manager.running_tasks[task_id]
+                    self._manager._emit_event(
+                        "task_failed",
+                        {
+                            "task_id": task_id,
+                            "error": str(e),
+                            "retry_count": task.retry_count if task else 0,
+                        },
+                    )
+                    self._persistence.persist(
+                        self._manager.tasks, self._manager.task_queue
+                    )
+
+    def _requeue_task(self, task_id: str) -> None:
+        try:
+            with self._manager.task_lock:
+                if task_id in self._manager.tasks:
+                    task = self._manager.tasks[task_id]
+                    self._manager.task_queue.put((task.priority.value, task_id))
+                    self._persistence.persist(
+                        self._manager.tasks, self._manager.task_queue
+                    )
+        except Exception:
+            pass
+
+    def _check_dependent_tasks(self, completed_task_id: str) -> None:
+        try:
+            with self._manager.task_lock:
+                for task_id, task in self._manager.tasks.items():
+                    if (
+                        task.status == TaskStatus.PENDING
+                        and completed_task_id in task.dependencies
+                        and self._check_dependencies(task_id)
+                    ):
+                        self._manager.task_queue.put((task.priority.value, task_id))
+                        self._persistence.persist(
+                            self._manager.tasks, self._manager.task_queue
+                        )
+        except Exception:
+            pass
+
+    def _task_processor_loop(self) -> None:
+        while not self._manager.shutdown_event.is_set():
+            try:
+                if (
+                    not self._manager.task_queue.empty()
+                    and len(self._manager.running_tasks)
+                    < self._manager.max_concurrent_tasks
+                ):
+                    priority, task_id = self._manager.task_queue.get_nowait()
+                    with self._manager.task_lock:
+                        if (
+                            task_id in self._manager.tasks
+                            and self._manager.tasks[task_id].status == TaskStatus.PENDING
+                            and self._check_dependencies(task_id)
+                        ):
+                            continue
+                time.sleep(0.1)
+            except Exception:
+                time.sleep(1)

--- a/src/core/managers/task_lifecycle_services/__init__.py
+++ b/src/core/managers/task_lifecycle_services/__init__.py
@@ -1,0 +1,13 @@
+"""Task lifecycle services package."""
+from .interfaces import PersistenceInterface, HealthCheckInterface
+from .task_creation_service import TaskCreationService
+from .task_cancellation_service import TaskCancellationService
+from .task_monitoring_service import TaskMonitoringService
+
+__all__ = [
+    "PersistenceInterface",
+    "HealthCheckInterface",
+    "TaskCreationService",
+    "TaskCancellationService",
+    "TaskMonitoringService",
+]

--- a/src/core/managers/task_lifecycle_services/interfaces.py
+++ b/src/core/managers/task_lifecycle_services/interfaces.py
@@ -1,0 +1,21 @@
+"""Common interfaces for task lifecycle services."""
+from queue import PriorityQueue
+from typing import Dict, Protocol
+
+from ..task_models import Task
+
+
+class PersistenceInterface(Protocol):
+    """Interface for task state persistence."""
+
+    def persist(self, tasks: Dict[str, Task], queue: PriorityQueue) -> None:
+        """Persist task state."""
+        ...
+
+
+class HealthCheckInterface(Protocol):
+    """Interface for health checking."""
+
+    def is_healthy(self) -> bool:
+        """Return True if the component is healthy."""
+        ...

--- a/src/core/managers/task_lifecycle_services/task_cancellation_service.py
+++ b/src/core/managers/task_lifecycle_services/task_cancellation_service.py
@@ -1,0 +1,27 @@
+"""Service responsible for cancelling tasks."""
+from datetime import datetime
+from queue import PriorityQueue
+from typing import Dict
+
+from ..task_models import Task, TaskStatus
+from .interfaces import PersistenceInterface, HealthCheckInterface
+
+
+class TaskCancellationService:
+    """Service responsible for cancelling tasks."""
+
+    def __init__(self, persistence: PersistenceInterface, health: HealthCheckInterface) -> None:
+        self._persistence = persistence
+        self._health = health
+
+    def _cancel(self, task_id: str, tasks: Dict[str, Task], queue: PriorityQueue) -> bool:
+        task = tasks.get(task_id)
+        if not task or task.status != TaskStatus.PENDING:
+            return False
+        task.status = TaskStatus.CANCELLED
+        task.completed_at = datetime.now().isoformat()
+        self._persistence.persist(tasks, queue)
+        return True
+
+    def check_health(self) -> bool:
+        return self._health.is_healthy()

--- a/src/core/managers/task_lifecycle_services/task_creation_service.py
+++ b/src/core/managers/task_lifecycle_services/task_creation_service.py
@@ -1,0 +1,23 @@
+"""Service responsible for creating tasks."""
+from queue import PriorityQueue
+from typing import Dict
+
+from ..task_models import Task
+from .interfaces import PersistenceInterface, HealthCheckInterface
+
+
+class TaskCreationService:
+    """Service responsible for creating tasks."""
+
+    def __init__(self, persistence: PersistenceInterface, health: HealthCheckInterface) -> None:
+        self._persistence = persistence
+        self._health = health
+
+    def _create(self, tasks: Dict[str, Task], queue: PriorityQueue, task: Task) -> str:
+        tasks[task.id] = task
+        queue.put((task.priority.value, task.id))
+        self._persistence.persist(tasks, queue)
+        return task.id
+
+    def check_health(self) -> bool:
+        return self._health.is_healthy()

--- a/src/core/managers/task_lifecycle_services/task_monitoring_service.py
+++ b/src/core/managers/task_lifecycle_services/task_monitoring_service.py
@@ -1,0 +1,20 @@
+"""Service responsible for monitoring task statuses."""
+from collections import Counter
+from typing import Dict
+
+from ..task_models import Task
+from .interfaces import HealthCheckInterface
+
+
+class TaskMonitoringService:
+    """Service responsible for monitoring task statuses."""
+
+    def __init__(self, health: HealthCheckInterface) -> None:
+        self._health = health
+
+    def _monitor(self, tasks: Dict[str, Task]) -> Dict[str, int]:
+        counts = Counter(task.status.value for task in tasks.values())
+        return dict(counts)
+
+    def check_health(self) -> bool:
+        return self._health.is_healthy()

--- a/src/core/managers/task_manager.py
+++ b/src/core/managers/task_manager.py
@@ -1,66 +1,35 @@
-#!/usr/bin/env python3
-"""
-Task Manager - V2 Core Manager Consolidation System
-==================================================
-
-Consolidates task management, scheduling, and workflow coordination.
-Replaces 4+ duplicate task manager files with single, specialized manager.
-
-Follows V2 standards: 200 LOC, OOP design, SRP.
-
-Author: V2 SWARM CAPTAIN
-License: MIT
-"""
-
-import logging
+"""Task Manager - orchestrates task lifecycle and scheduling."""
 import json
-import time
+import logging
 import uuid
+from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Callable
-from datetime import datetime, timedelta
-from threading import Lock, Thread, Event
-from queue import PriorityQueue, Queue
-import asyncio
-
-from ..base_manager import BaseManager, ManagerStatus, ManagerPriority
-from .task_models import (
-    Task,
-    TaskPriority,
-    TaskStatus,
-    TaskType,
-    Workflow,
-    TaskResult,
-)
+from threading import Event, Lock, Thread
+from queue import PriorityQueue
+from typing import Any, Callable, Dict, List, Optional
+from ..base_manager import BaseManager
+from .task_models import Task, TaskPriority, TaskStatus, TaskType, Workflow, TaskResult
 from .task_persistence import TaskStatePersister, TaskStorageInterface
-
+from .task_lifecycle_services import (
+    TaskCancellationService,
+    TaskCreationService,
+    TaskMonitoringService,
+)
+from .task_execution_service import TaskExecutionService
+from .task_query_service import TaskQueryService
+from .workflow_service import WorkflowService
 logger = logging.getLogger(__name__)
 
-
 class TaskManager(BaseManager):
-    """
-    Task Manager - Single responsibility: Task management and scheduling
-    
-    This manager consolidates functionality from:
-    - task_manager.py
-    - src/autonomous_development/tasks/manager.py
-    - src/core/task_management/task_scheduler_manager.py
-    - src/autonomous_development/workflow/manager.py
-    
-    Total consolidation: 4 files → 1 file (80% duplication eliminated)
-    """
+    """Core manager responsible for task and workflow orchestration."""
 
-    def __init__(self, config_path: str = "config/task_manager.json",
-                 storage: Optional[TaskStorageInterface] = None):
-        """Initialize task manager"""
-        super().__init__(
-            manager_name="TaskManager",
-            config_path=config_path,
-            enable_metrics=True,
-            enable_events=True,
-            enable_persistence=True
-        )
-        
+    def __init__(
+        self,
+        config_path: str = "config/task_manager.json",
+        storage: Optional[TaskStorageInterface] = None,
+    ) -> None:
+        super().__init__(manager_id="task_manager", name="TaskManager")
+        self.config_path = config_path
         self.tasks: Dict[str, Task] = {}
         self.workflows: Dict[str, Workflow] = {}
         self.task_queue: PriorityQueue = PriorityQueue()
@@ -69,48 +38,57 @@ class TaskManager(BaseManager):
         self.task_lock = Lock()
         self.workflow_lock = Lock()
         self.shutdown_event = Event()
-        self._persistence = TaskStatePersister(storage)
-        
-        # Task execution settings
-        self.max_concurrent_tasks = 10
-        self.task_timeout_default = 300  # 5 minutes
-        self.retry_delay = 5  # seconds
-        
-        # Initialize task management
-        self._load_manager_config()
-        self._start_task_processor()
 
-    def _load_manager_config(self):
-        """Load manager-specific configuration"""
+        self._persistence = TaskStatePersister(storage)
+        self._creator = TaskCreationService(self._persistence, self)
+        self._canceller = TaskCancellationService(self._persistence, self)
+        self._monitor = TaskMonitoringService(self)
+        self._executor = TaskExecutionService(self._persistence, self)
+        self._query = TaskQueryService(self)
+        self._workflow = WorkflowService(self)
+
+        self.max_concurrent_tasks = 10
+        self.task_timeout_default = 300
+        self.retry_delay = 5
+
+        self._load_manager_config()
+        self._executor.start_processor()
+
+    # Helpers
+    def _generate_id(self) -> str:
+        return str(uuid.uuid4())
+
+    def _now_iso(self) -> str:
+        return datetime.now().isoformat()
+
+    def _load_manager_config(self) -> None:
         try:
             if Path(self.config_path).exists():
-                with open(self.config_path, 'r') as f:
+                with open(self.config_path, "r") as f:
                     config = json.load(f)
-                    self.max_concurrent_tasks = config.get('max_concurrent_tasks', 10)
-                    self.task_timeout_default = config.get('task_timeout_default', 300)
-                    self.retry_delay = config.get('retry_delay', 5)
+                self.max_concurrent_tasks = config.get("max_concurrent_tasks", 10)
+                self.task_timeout_default = config.get("task_timeout_default", 300)
+                self.retry_delay = config.get("retry_delay", 5)
             else:
                 logger.warning(f"Task config file not found: {self.config_path}")
         except Exception as e:
             logger.error(f"Failed to load task config: {e}")
 
-    def _start_task_processor(self):
-        """Start the task processing thread"""
+    # Task lifecycle
+    def create_task(
+        self,
+        name: str,
+        description: str,
+        task_type: TaskType = TaskType.CUSTOM,
+        priority: TaskPriority = TaskPriority.NORMAL,
+        timeout: Optional[float] = None,
+        max_retries: int = 3,
+        dependencies: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> str:
         try:
-            processor_thread = Thread(target=self._task_processor_loop, daemon=True)
-            processor_thread.start()
-            logger.info("Task processor started")
-        except Exception as e:
-            logger.error(f"Failed to start task processor: {e}")
-
-    def create_task(self, name: str, description: str, task_type: TaskType = TaskType.CUSTOM,
-                   priority: TaskPriority = TaskPriority.NORMAL, timeout: Optional[float] = None,
-                   max_retries: int = 3, dependencies: Optional[List[str]] = None,
-                   metadata: Optional[Dict[str, Any]] = None, tags: Optional[List[str]] = None) -> str:
-        """Create a new task"""
-        try:
-            task_id = str(uuid.uuid4())
-            
+            task_id = self._generate_id()
             task = Task(
                 id=task_id,
                 name=name,
@@ -118,7 +96,7 @@ class TaskManager(BaseManager):
                 task_type=task_type,
                 priority=priority,
                 status=TaskStatus.PENDING,
-                created_at=datetime.now().isoformat(),
+                created_at=self._now_iso(),
                 started_at=None,
                 completed_at=None,
                 duration=None,
@@ -129,398 +107,94 @@ class TaskManager(BaseManager):
                 retry_count=0,
                 max_retries=max_retries,
                 timeout=timeout or self.task_timeout_default,
-                tags=tags or []
+                tags=tags or [],
             )
-            
             with self.task_lock:
-                self.tasks[task_id] = task
-                
-                # Add to priority queue
-                self.task_queue.put((priority.value, task_id))
-            
-            self._emit_event("task_created", {
-                "task_id": task_id,
-                "name": name,
-                "priority": priority.value,
-                "type": task_type.value
-            })
-
-            logger.info(f"Task created: {name} (ID: {task_id})")
-            self._persistence.persist(self.tasks, self.task_queue)
+                self._creator._create(self.tasks, self.task_queue, task)
+            self._emit_event(
+                "task_created",
+                {
+                    "task_id": task_id,
+                    "name": name,
+                    "priority": priority.value,
+                    "type": task_type.value,
+                },
+            )
             return task_id
-            
         except Exception as e:
             logger.error(f"Failed to create task: {e}")
             return ""
 
     def submit_task(self, task_id: str, executor_func: Callable, *args, **kwargs) -> bool:
-        """Submit a task for execution"""
-        try:
-            with self.task_lock:
-                if task_id not in self.tasks:
-                    logger.warning(f"Task not found: {task_id}")
-                    return False
-                
-                task = self.tasks[task_id]
-                if task.status != TaskStatus.PENDING:
-                    logger.warning(f"Task {task_id} is not pending (status: {task.status})")
-                    return False
-                
-                # Check dependencies
-                if not self._check_dependencies(task_id):
-                    logger.info(f"Task {task_id} dependencies not met, keeping in queue")
-                    return True
-                
-                # Update task status
-                task.status = TaskStatus.RUNNING
-                task.started_at = datetime.now().isoformat()
-                
-                # Create execution thread
-                execution_thread = Thread(
-                    target=self._execute_task,
-                    args=(task_id, executor_func, args, kwargs),
-                    daemon=True
-                )
-                
-                self.running_tasks[task_id] = execution_thread
-                execution_thread.start()
-                
-                self._emit_event("task_started", {
-                    "task_id": task_id,
-                    "started_at": task.started_at
-                })
-
-                logger.info(f"Task {task_id} started execution")
-                self._persistence.persist(self.tasks, self.task_queue)
-                return True
-                
-        except Exception as e:
-            logger.error(f"Failed to submit task {task_id}: {e}")
-            return False
-
-    def _check_dependencies(self, task_id: str) -> bool:
-        """Check if task dependencies are met"""
-        try:
-            task = self.tasks[task_id]
-            
-            for dep_id in task.dependencies:
-                if dep_id not in self.tasks:
-                    logger.warning(f"Dependency {dep_id} not found for task {task_id}")
-                    return False
-                
-                dep_task = self.tasks[dep_id]
-                if dep_task.status != TaskStatus.COMPLETED:
-                    return False
-            
-            return True
-            
-        except Exception as e:
-            logger.error(f"Failed to check dependencies for task {task_id}: {e}")
-            return False
-
-    def _execute_task(self, task_id: str, executor_func: Callable, args: tuple, kwargs: dict):
-        """Execute a task in a separate thread"""
-        try:
-            task = self.tasks[task_id]
-            start_time = time.time()
-            
-            # Execute the task
-            result = executor_func(*args, **kwargs)
-            execution_time = time.time() - start_time
-            
-            # Create task result
-            task_result = TaskResult(
-                task_id=task_id,
-                success=True,
-                result=result,
-                error=None,
-                execution_time=execution_time,
-                metadata={"executor": executor_func.__name__}
-            )
-            
-            # Update task
-            with self.task_lock:
-                task.status = TaskStatus.COMPLETED
-                task.completed_at = datetime.now().isoformat()
-                task.duration = execution_time
-                task.result = result
-                
-                # Remove from running tasks
-                if task_id in self.running_tasks:
-                    del self.running_tasks[task_id]
-                
-                # Add to completed tasks
-                self.completed_tasks[task_id] = task_result
-            
-            self._emit_event("task_completed", {
-                "task_id": task_id,
-                "execution_time": execution_time,
-                "success": True
-            })
-
-            logger.info(f"Task {task_id} completed successfully in {execution_time:.2f}s")
-
-            # Check for dependent tasks that can now run
-            self._check_dependent_tasks(task_id)
-            self._persistence.persist(self.tasks, self.task_queue)
-
-        except Exception as e:
-            execution_time = time.time() - start_time
-            error_msg = str(e)
-            
-            # Handle retries
-            if task.retry_count < task.max_retries:
-                task.retry_count += 1
-                task.status = TaskStatus.PENDING
-                task.error = f"Retry {task.retry_count}/{task.max_retries}: {error_msg}"
-                
-                # Re-add to queue with delay
-                Timer(self.retry_delay, self._requeue_task, args=[task_id]).start()
-
-                logger.info(f"Task {task_id} scheduled for retry {task.retry_count}/{task.max_retries}")
-                self._persistence.persist(self.tasks, self.task_queue)
-
-            else:
-                # Task failed permanently
-                with self.task_lock:
-                    task.status = TaskStatus.FAILED
-                    task.completed_at = datetime.now().isoformat()
-                    task.duration = execution_time
-                    task.error = error_msg
-                    
-                    # Remove from running tasks
-                    if task_id in self.running_tasks:
-                        del self.running_tasks[task_id]
-                
-                self._emit_event("task_failed", {
-                    "task_id": task_id,
-                    "error": error_msg,
-                    "retry_count": task.retry_count
-                })
-
-                logger.error(f"Task {task_id} failed permanently after {task.max_retries} retries")
-                self._persistence.persist(self.tasks, self.task_queue)
-
-    def _requeue_task(self, task_id: str):
-        """Re-queue a task for retry"""
-        try:
-            with self.task_lock:
-                if task_id in self.tasks:
-                    task = self.tasks[task_id]
-                    self.task_queue.put((task.priority.value, task_id))
-                    logger.debug(f"Task {task_id} re-queued for retry")
-                    self._persistence.persist(self.tasks, self.task_queue)
-        except Exception as e:
-            logger.error(f"Failed to re-queue task {task_id}: {e}")
-
-    def _check_dependent_tasks(self, completed_task_id: str):
-        """Check if any dependent tasks can now run"""
-        try:
-            with self.task_lock:
-                for task_id, task in self.tasks.items():
-                    if (task.status == TaskStatus.PENDING and 
-                        completed_task_id in task.dependencies):
-                        
-                        if self._check_dependencies(task_id):
-                            # Re-queue with current priority
-                            self.task_queue.put((task.priority.value, task_id))
-                            self._persistence.persist(self.tasks, self.task_queue)
-
-        except Exception as e:
-            logger.error(f"Failed to check dependent tasks: {e}")
-
-    def _task_processor_loop(self):
-        """Main task processing loop"""
-        while not self.shutdown_event.is_set():
-            try:
-                # Process pending tasks
-                if not self.task_queue.empty() and len(self.running_tasks) < self.max_concurrent_tasks:
-                    priority, task_id = self.task_queue.get_nowait()
-                    
-                    # Check if task is still pending and dependencies are met
-                    with self.task_lock:
-                        if (task_id in self.tasks and 
-                            self.tasks[task_id].status == TaskStatus.PENDING and
-                            self._check_dependencies(task_id)):
-                            
-                            # Task will be picked up by submit_task
-                            continue
-                
-                time.sleep(0.1)  # Small delay to prevent busy waiting
-                
-            except Exception as e:
-                logger.error(f"Task processor error: {e}")
-                time.sleep(1)
+        return self._executor.submit(task_id, executor_func, *args, **kwargs)
 
     def cancel_task(self, task_id: str) -> bool:
-        """Cancel a running or pending task"""
         try:
             with self.task_lock:
-                if task_id not in self.tasks:
-                    logger.warning(f"Task not found: {task_id}")
-                    return False
-                
-                task = self.tasks[task_id]
-                
-                if task.status == TaskStatus.RUNNING:
-                    # Stop execution thread
-                    if task_id in self.running_tasks:
-                        # Note: Thread termination is not implemented for safety
-                        # The task will complete naturally
-                        logger.info(f"Task {task_id} is running, will complete naturally")
-                        return False
-                
-                elif task.status == TaskStatus.PENDING:
-                    # Remove from queue (this is approximate since PriorityQueue doesn't support removal)
-                    task.status = TaskStatus.CANCELLED
-                    task.completed_at = datetime.now().isoformat()
-                    
-                    self._emit_event("task_cancelled", {"task_id": task_id})
-                    logger.info(f"Task {task_id} cancelled")
-                    self._persistence.persist(self.tasks, self.task_queue)
-                    return True
-                
-                else:
-                    logger.warning(f"Cannot cancel task {task_id} in status {task.status}")
-                    return False
-                
-        except Exception as e:
-            logger.error(f"Failed to cancel task {task_id}: {e}")
+                result = self._canceller._cancel(task_id, self.tasks, self.task_queue)
+            if result:
+                self._emit_event("task_cancelled", {"task_id": task_id})
+            return result
+        except Exception:
+            logger.exception("Failed to cancel task")
             return False
 
-    def get_task_status(self, task_id: str) -> Optional[TaskStatus]:
-        """Get task status"""
-        try:
-            return self.tasks.get(task_id, {}).get('status')
-        except Exception as e:
-            logger.error(f"Failed to get task status for {task_id}: {e}")
-            return None
-
-    def get_task_info(self, task_id: str) -> Optional[Task]:
-        """Get complete task information"""
-        try:
-            return self.tasks.get(task_id)
-        except Exception as e:
-            logger.error(f"Failed to get task info for {task_id}: {e}")
-            return None
-
-    def get_running_tasks(self) -> List[str]:
-        """Get list of currently running task IDs"""
-        try:
-            return list(self.running_tasks.keys())
-        except Exception as e:
-            logger.error(f"Failed to get running tasks: {e}")
-            return []
-
-    def get_pending_tasks(self) -> List[Task]:
-        """Get list of pending tasks"""
+    def monitor_tasks(self) -> Dict[str, int]:
         try:
             with self.task_lock:
-                return [
-                    task for task in self.tasks.values()
-                    if task.status == TaskStatus.PENDING
-                ]
-        except Exception as e:
-            logger.error(f"Failed to get pending tasks: {e}")
-            return []
-
-    def get_completed_tasks(self, limit: int = 100) -> List[TaskResult]:
-        """Get list of completed task results"""
-        try:
-            results = list(self.completed_tasks.values())
-            return sorted(results, key=lambda x: x.execution_time, reverse=True)[:limit]
-        except Exception as e:
-            logger.error(f"Failed to get completed tasks: {e}")
-            return []
-
-    def create_workflow(self, name: str, description: str, tasks: List[str],
-                       dependencies: Dict[str, List[str]], metadata: Optional[Dict[str, Any]] = None) -> str:
-        """Create a new workflow"""
-        try:
-            workflow_id = str(uuid.uuid4())
-            
-            workflow = Workflow(
-                id=workflow_id,
-                name=name,
-                description=description,
-                tasks=tasks,
-                dependencies=dependencies,
-                status=TaskStatus.PENDING,
-                created_at=datetime.now().isoformat(),
-                started_at=None,
-                completed_at=None,
-                metadata=metadata or {}
-            )
-            
-            with self.workflow_lock:
-                self.workflows[workflow_id] = workflow
-            
-            self._emit_event("workflow_created", {
-                "workflow_id": workflow_id,
-                "name": name,
-                "task_count": len(tasks)
-            })
-            
-            logger.info(f"Workflow created: {name} (ID: {workflow_id})")
-            return workflow_id
-            
-        except Exception as e:
-            logger.error(f"Failed to create workflow: {e}")
-            return ""
-
-    def get_workflow_info(self, workflow_id: str) -> Optional[Workflow]:
-        """Get workflow information"""
-        try:
-            return self.workflows.get(workflow_id)
-        except Exception as e:
-            logger.error(f"Failed to get workflow info for {workflow_id}: {e}")
-            return None
-
-    def get_task_statistics(self) -> Dict[str, Any]:
-        """Get task execution statistics"""
-        try:
-            total_tasks = len(self.tasks)
-            pending_tasks = len([t for t in self.tasks.values() if t.status == TaskStatus.PENDING])
-            running_tasks = len(self.running_tasks)
-            completed_tasks = len([t for t in self.tasks.values() if t.status == TaskStatus.COMPLETED])
-            failed_tasks = len([t for t in self.tasks.values() if t.status == TaskStatus.FAILED])
-            
-            return {
-                "total_tasks": total_tasks,
-                "pending_tasks": pending_tasks,
-                "running_tasks": running_tasks,
-                "completed_tasks": completed_tasks,
-                "failed_tasks": failed_tasks,
-                "success_rate": (completed_tasks / total_tasks * 100) if total_tasks > 0 else 0,
-                "active_workflows": len([w for w in self.workflows.values() if w.status == TaskStatus.RUNNING])
-            }
-            
-        except Exception as e:
-            logger.error(f"Failed to get task statistics: {e}")
+                return self._monitor._monitor(self.tasks)
+        except Exception:
+            logger.exception("Failed to monitor tasks")
             return {}
 
-    def cleanup(self):
-        """Cleanup resources"""
+    # Query helpers
+    def get_task_status(self, task_id: str) -> Optional[TaskStatus]:
+        return self._query.get_task_status(task_id)
+
+    def get_task_info(self, task_id: str) -> Optional[Task]:
+        return self._query.get_task_info(task_id)
+
+    def get_running_tasks(self) -> List[str]:
+        return self._query.get_running_tasks()
+
+    def get_pending_tasks(self) -> List[Task]:
+        return self._query.get_pending_tasks()
+
+    def get_completed_tasks(self, limit: int = 100) -> List[TaskResult]:
+        return self._query.get_completed_tasks(limit)
+
+    def get_task_statistics(self) -> Dict[str, Any]:
+        return self._query.get_task_statistics()
+
+    # Workflow management
+    def create_workflow(
+        self,
+        name: str,
+        description: str,
+        tasks: List[str],
+        dependencies: Dict[str, List[str]],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        return self._workflow.create(name, description, tasks, dependencies, metadata)
+
+    def get_workflow_info(self, workflow_id: str) -> Optional[Workflow]:
+        return self._workflow.get_info(workflow_id)
+
+    # Cleanup
+    def cleanup(self) -> None:
         try:
-            # Signal shutdown
             self.shutdown_event.set()
-            
-            # Wait for running tasks to complete
+            self._executor.cleanup()
             for thread in self.running_tasks.values():
                 if thread.is_alive():
                     thread.join(timeout=5)
-            
-            # Clear collections
             with self.task_lock:
                 self.tasks.clear()
                 self.running_tasks.clear()
                 self.completed_tasks.clear()
-            
             with self.workflow_lock:
                 self.workflows.clear()
-            
             super().cleanup()
             logger.info("TaskManager cleanup completed")
-            
         except Exception as e:
             logger.error(f"TaskManager cleanup failed: {e}")

--- a/src/core/managers/task_query_service.py
+++ b/src/core/managers/task_query_service.py
@@ -1,0 +1,62 @@
+"""Service providing task and workflow query helpers."""
+from typing import Dict, List, Optional, Any
+
+from .task_models import Task, TaskResult, TaskStatus
+
+
+class TaskQueryService:
+    """Query helper methods for TaskManager."""
+
+    def __init__(self, manager) -> None:
+        self._manager = manager
+
+    def get_task_status(self, task_id: str) -> Optional[TaskStatus]:
+        return self._manager.tasks.get(task_id, {}).get("status")
+
+    def get_task_info(self, task_id: str) -> Optional[Task]:
+        return self._manager.tasks.get(task_id)
+
+    def get_running_tasks(self) -> List[str]:
+        return list(self._manager.running_tasks.keys())
+
+    def get_pending_tasks(self) -> List[Task]:
+        with self._manager.task_lock:
+            return [
+                task
+                for task in self._manager.tasks.values()
+                if task.status == TaskStatus.PENDING
+            ]
+
+    def get_completed_tasks(self, limit: int = 100) -> List[TaskResult]:
+        results = list(self._manager.completed_tasks.values())
+        return sorted(results, key=lambda x: x.execution_time, reverse=True)[:limit]
+
+    def get_task_statistics(self) -> Dict[str, Any]:
+        total_tasks = len(self._manager.tasks)
+        pending_tasks = len(
+            [t for t in self._manager.tasks.values() if t.status == TaskStatus.PENDING]
+        )
+        running_tasks = len(self._manager.running_tasks)
+        completed_tasks = len(
+            [t for t in self._manager.tasks.values() if t.status == TaskStatus.COMPLETED]
+        )
+        failed_tasks = len(
+            [t for t in self._manager.tasks.values() if t.status == TaskStatus.FAILED]
+        )
+        return {
+            "total_tasks": total_tasks,
+            "pending_tasks": pending_tasks,
+            "running_tasks": running_tasks,
+            "completed_tasks": completed_tasks,
+            "failed_tasks": failed_tasks,
+            "success_rate": (completed_tasks / total_tasks * 100)
+            if total_tasks > 0
+            else 0,
+            "active_workflows": len(
+                [
+                    w
+                    for w in self._manager.workflows.values()
+                    if w.status == TaskStatus.RUNNING
+                ]
+            ),
+        }

--- a/src/core/managers/workflow_service.py
+++ b/src/core/managers/workflow_service.py
@@ -1,0 +1,43 @@
+"""Service for workflow management."""
+from typing import Dict, List, Optional, Any
+
+from .task_models import Workflow, TaskStatus
+
+
+class WorkflowService:
+    """Handle workflow creation and queries."""
+
+    def __init__(self, manager) -> None:
+        self._manager = manager
+
+    def create(
+        self,
+        name: str,
+        description: str,
+        tasks: List[str],
+        dependencies: Dict[str, List[str]],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        workflow_id = self._manager._generate_id()
+        workflow = Workflow(
+            id=workflow_id,
+            name=name,
+            description=description,
+            tasks=tasks,
+            dependencies=dependencies,
+            status=TaskStatus.PENDING,
+            created_at=self._manager._now_iso(),
+            started_at=None,
+            completed_at=None,
+            metadata=metadata or {},
+        )
+        with self._manager.workflow_lock:
+            self._manager.workflows[workflow_id] = workflow
+        self._manager._emit_event(
+            "workflow_created",
+            {"workflow_id": workflow_id, "name": name, "task_count": len(tasks)},
+        )
+        return workflow_id
+
+    def get_info(self, workflow_id: str) -> Optional[Workflow]:
+        return self._manager.workflows.get(workflow_id)

--- a/tests/unit/test_task_lifecycle_services.py
+++ b/tests/unit/test_task_lifecycle_services.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+from queue import PriorityQueue
+from typing import Dict
+
+from src.core.managers.task_lifecycle_services import (
+    TaskCancellationService,
+    TaskCreationService,
+    TaskMonitoringService,
+)
+from src.core.managers.task_manager import TaskManager
+from src.core.managers.task_models import Task, TaskPriority, TaskStatus, TaskType
+
+
+class DummyPersistence:
+    def __init__(self):
+        self.called = False
+
+    def persist(self, tasks, queue):  # type: ignore[override]
+        self.called = True
+
+
+class DummyHealth:
+    def is_healthy(self) -> bool:  # type: ignore[override]
+        return True
+
+
+def _sample_task(task_id: str = "t1", status: TaskStatus = TaskStatus.PENDING) -> Task:
+    return Task(
+        id=task_id,
+        name="task",
+        description="desc",
+        task_type=TaskType.CUSTOM,
+        priority=TaskPriority.NORMAL,
+        status=status,
+        created_at=datetime.now().isoformat(),
+        started_at=None,
+        completed_at=None,
+        duration=None,
+        result=None,
+        error=None,
+        metadata={},
+        dependencies=[],
+        retry_count=0,
+        max_retries=3,
+        timeout=60,
+        tags=[],
+    )
+
+
+def test_creation_service_creates_and_persists():
+    tasks: Dict[str, Task] = {}
+    queue: PriorityQueue = PriorityQueue()
+    persistence = DummyPersistence()
+    health = DummyHealth()
+    service = TaskCreationService(persistence, health)
+    task = _sample_task()
+    service._create(tasks, queue, task)
+    assert task.id in tasks
+    assert not queue.empty()
+    assert persistence.called
+    assert service.check_health()
+
+
+def test_cancellation_service_cancels_task():
+    task = _sample_task()
+    tasks: Dict[str, Task] = {task.id: task}
+    queue: PriorityQueue = PriorityQueue()
+    persistence = DummyPersistence()
+    health = DummyHealth()
+    service = TaskCancellationService(persistence, health)
+    assert service._cancel(task.id, tasks, queue) is True
+    assert tasks[task.id].status == TaskStatus.CANCELLED
+    assert persistence.called
+    assert service.check_health()
+
+
+def test_monitoring_service_counts_statuses():
+    t1 = _sample_task("t1", TaskStatus.PENDING)
+    t2 = _sample_task("t2", TaskStatus.CANCELLED)
+    tasks = {t1.id: t1, t2.id: t2}
+    health = DummyHealth()
+    service = TaskMonitoringService(health)
+    stats = service._monitor(tasks)
+    assert stats[TaskStatus.PENDING.value] == 1
+    assert stats[TaskStatus.CANCELLED.value] == 1
+    assert service.check_health()
+
+


### PR DESCRIPTION
## Summary
- split lifecycle services into dedicated modules and introduce execution, query, and workflow service layers
- reduce `TaskManager` to 200 lines by delegating responsibilities to new services
- remove legacy combined lifecycle module

## Testing
- `pre-commit run --files src/core/managers/task_lifecycle_services/interfaces.py src/core/managers/task_lifecycle_services/task_creation_service.py src/core/managers/task_lifecycle_services/task_cancellation_service.py src/core/managers/task_lifecycle_services/task_monitoring_service.py src/core/managers/task_lifecycle_services/__init__.py src/core/managers/task_execution_service.py src/core/managers/task_query_service.py src/core/managers/workflow_service.py src/core/managers/task_manager.py tests/unit/test_task_lifecycle_services.py` *(fails: command not found)*
- `pytest tests/unit/test_task_lifecycle_services.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af2266af008329b771ff060791808c