### PR TITLE
refactor: modularize metrics analysis

### DIFF
--- a/src/core/performance/metrics/__init__.py
+++ b/src/core/performance/metrics/__init__.py
@@ -9,6 +9,14 @@ Handles performance metrics collection and processing.
 from .collector import MetricsCollector
 from .types import MetricData, MetricType
 from .benchmarks import BenchmarkType, PerformanceBenchmark, PerformanceLevel
+from .analyzers import (
+    analyze_latency,
+    analyze_reliability,
+    analyze_response_times,
+    analyze_scalability,
+    analyze_throughput,
+)
+from .config import DEFAULT_BENCHMARK_TARGETS, DEFAULT_COLLECTION_INTERVAL
 
 __all__ = [
     "MetricsCollector",
@@ -17,4 +25,11 @@ __all__ = [
     "BenchmarkType",
     "PerformanceBenchmark",
     "PerformanceLevel",
+    "analyze_response_times",
+    "analyze_throughput",
+    "analyze_scalability",
+    "analyze_reliability",
+    "analyze_latency",
+    "DEFAULT_BENCHMARK_TARGETS",
+    "DEFAULT_COLLECTION_INTERVAL",
 ]

--- a/src/core/performance/metrics/analyzers/__init__.py
+++ b/src/core/performance/metrics/analyzers/__init__.py
@@ -1,0 +1,15 @@
+"""Utility analyzers for individual measurement types."""
+
+from .response_time import analyze_response_times
+from .throughput import analyze_throughput
+from .scalability import analyze_scalability
+from .reliability import analyze_reliability
+from .latency import analyze_latency
+
+__all__ = [
+    "analyze_response_times",
+    "analyze_throughput",
+    "analyze_scalability",
+    "analyze_reliability",
+    "analyze_latency",
+]

--- a/src/core/performance/metrics/analyzers/latency.py
+++ b/src/core/performance/metrics/analyzers/latency.py
@@ -1,0 +1,35 @@
+"""Latency measurement analysis utilities."""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_latency(latency_times: List[float]) -> Dict[str, float]:
+    """Analyze latency measurements.
+
+    Calculates summary statistics and key percentiles for latency samples.
+    Values are expected to be in milliseconds.
+    """
+    if not latency_times:
+        return {}
+
+    sorted_latencies = sorted(latency_times)
+    n = len(sorted_latencies)
+    metrics = {
+        "average_latency": statistics.mean(latency_times),
+        "min_latency": min(latency_times),
+        "max_latency": max(latency_times),
+        "median_latency": statistics.median(latency_times),
+        "p95_latency": sorted_latencies[int(0.95 * n)] if n > 0 else 0,
+        "p99_latency": sorted_latencies[int(0.99 * n)] if n > 0 else 0,
+        "latency_std_dev": statistics.stdev(latency_times)
+        if len(latency_times) > 1
+        else 0,
+    }
+    logger.debug("Analyzed latency metrics: %s", metrics)
+    return metrics

--- a/src/core/performance/metrics/analyzers/reliability.py
+++ b/src/core/performance/metrics/analyzers/reliability.py
@@ -1,0 +1,36 @@
+"""Reliability measurement analysis utilities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_reliability(
+    total_operations: int, failed_operations: int, duration: float
+) -> Dict[str, float]:
+    """Analyze reliability measurements.
+
+    Calculates success and failure rates along with mean time between failures.
+    Duration is expressed in seconds.
+    """
+    if total_operations == 0:
+        return {}
+
+    success_rate = ((total_operations - failed_operations) / total_operations) * 100
+    failure_rate = (failed_operations / total_operations) * 100
+    metrics = {
+        "total_operations": total_operations,
+        "successful_operations": total_operations - failed_operations,
+        "failed_operations": failed_operations,
+        "success_rate_percent": success_rate,
+        "failure_rate_percent": failure_rate,
+        "uptime_percentage": success_rate,
+        "mean_time_between_failures": duration / failed_operations
+        if failed_operations > 0
+        else float("inf"),
+    }
+    logger.debug("Analyzed reliability metrics: %s", metrics)
+    return metrics

--- a/src/core/performance/metrics/analyzers/response_time.py
+++ b/src/core/performance/metrics/analyzers/response_time.py
@@ -1,0 +1,35 @@
+"""Response time measurement analysis utilities."""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_response_times(response_times: List[float]) -> Dict[str, float]:
+    """Analyze response time measurements.
+
+    Calculates common statistics for response time values including
+    average, minimum, maximum, variance, median and standard deviation.
+    The values are expected to be in milliseconds.
+    """
+    if not response_times:
+        return {}
+
+    metrics = {
+        "average_response_time": statistics.mean(response_times),
+        "min_response_time": min(response_times),
+        "max_response_time": max(response_times),
+        "response_time_variance": statistics.variance(response_times)
+        if len(response_times) > 1
+        else 0,
+        "median_response_time": statistics.median(response_times),
+        "response_time_std_dev": statistics.stdev(response_times)
+        if len(response_times) > 1
+        else 0,
+    }
+    logger.debug("Analyzed response time metrics: %s", metrics)
+    return metrics

--- a/src/core/performance/metrics/analyzers/scalability.py
+++ b/src/core/performance/metrics/analyzers/scalability.py
@@ -1,0 +1,47 @@
+"""Scalability measurement analysis utilities."""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from typing import Any, Dict, List
+
+from ..benchmarks import BenchmarkManager
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_scalability(
+    scalability_results: List[Dict[str, Any]],
+    benchmarks: BenchmarkManager,
+) -> Dict[str, float]:
+    """Analyze scalability measurements.
+
+    Args:
+        scalability_results: Individual benchmark results for concurrent agent tests.
+        benchmarks: Benchmark manager used for advanced calculations.
+
+    Returns:
+        Dictionary with scalability score and related statistics.
+    """
+    if not scalability_results:
+        return {}
+
+    scalability_score = benchmarks.calculate_scalability_score(scalability_results)
+    max_ops_per_sec = max(
+        result.get("operations_per_second", 0) for result in scalability_results
+    )
+    avg_ops_per_sec = statistics.mean(
+        [result.get("operations_per_second", 0) for result in scalability_results]
+    )
+    metrics = {
+        "scalability_score": scalability_score,
+        "max_operations_per_second": max_ops_per_sec,
+        "average_operations_per_second": avg_ops_per_sec,
+        "concurrent_agent_tests": len(scalability_results),
+        "performance_degradation": benchmarks.calculate_performance_degradation(
+            scalability_results
+        ),
+    }
+    logger.debug("Analyzed scalability metrics: %s", metrics)
+    return metrics

--- a/src/core/performance/metrics/analyzers/throughput.py
+++ b/src/core/performance/metrics/analyzers/throughput.py
@@ -1,0 +1,33 @@
+"""Throughput measurement analysis utilities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_throughput(operations_count: int, duration: float) -> Dict[str, float]:
+    """Analyze throughput measurements.
+
+    Args:
+        operations_count: Number of operations performed.
+        duration: Time period in seconds during which operations were executed.
+
+    Returns:
+        Dictionary with throughput metrics per second, minute and hour.
+    """
+    if duration <= 0:
+        return {}
+
+    throughput = operations_count / duration
+    metrics = {
+        "total_operations": operations_count,
+        "test_duration": duration,
+        "throughput_ops_per_sec": throughput,
+        "operations_per_minute": throughput * 60,
+        "operations_per_hour": throughput * 3600,
+    }
+    logger.debug("Analyzed throughput metrics: %s", metrics)
+    return metrics

--- a/src/core/performance/metrics/collector.py
+++ b/src/core/performance/metrics/collector.py
@@ -8,10 +8,7 @@ a lightweight base interface for additional metrics collectors used by
 services.
 """
 
-import time
 import logging
-import statistics
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from .types import MetricData, MetricType
@@ -20,6 +17,14 @@ from .benchmarks import (
     BenchmarkType,
     PerformanceBenchmark,
     PerformanceLevel,
+)
+from .config import DEFAULT_BENCHMARK_TARGETS, DEFAULT_COLLECTION_INTERVAL
+from .analyzers import (
+    analyze_latency,
+    analyze_reliability,
+    analyze_response_times,
+    analyze_scalability,
+    analyze_throughput,
 )
 
 
@@ -32,7 +37,7 @@ class MetricsCollector:
     minimal interface expected by service-level collectors.
     """
 
-    def __init__(self, collection_interval: int = 60):
+    def __init__(self, collection_interval: int = DEFAULT_COLLECTION_INTERVAL):
         # Basic collector configuration used by service collectors
         self.collection_interval = collection_interval
         self.enabled = True
@@ -41,13 +46,7 @@ class MetricsCollector:
 
         # Benchmark storage
         self.benchmarks = BenchmarkManager()
-        self.benchmark_targets = {
-            BenchmarkType.RESPONSE_TIME: {"target": 100, "unit": "ms"},
-            BenchmarkType.THROUGHPUT: {"target": 1000, "unit": "ops/sec"},
-            BenchmarkType.SCALABILITY: {"target": 100, "unit": "concurrent_users"},
-            BenchmarkType.RELIABILITY: {"target": 99.9, "unit": "%"},
-            BenchmarkType.LATENCY: {"target": 50, "unit": "ms"},
-        }
+        self.benchmark_targets = DEFAULT_BENCHMARK_TARGETS.copy()
         self.logger = logging.getLogger(f"{__name__}.MetricsCollector")
 
     async def collect_metrics(self) -> List[MetricData]:
@@ -62,145 +61,66 @@ class MetricsCollector:
     def set_enabled(self, enabled: bool) -> None:
         """Enable or disable this collector."""
         self.enabled = enabled
-        self.logger.info(
-            "Metrics collector %s", "enabled" if enabled else "disabled"
-        )
-    
-    def collect_response_time_metrics(self, response_times: List[float]) -> Dict[str, float]:
-        """Collect and process response time metrics"""
+        self.logger.info("Metrics collector %s", "enabled" if enabled else "disabled")
+
+    def collect_response_time_metrics(
+        self, response_times: List[float]
+    ) -> Dict[str, float]:
+        """Collect and process response time metrics."""
         try:
-            if not response_times:
-                return {}
-            
-            metrics = {
-                "average_response_time": statistics.mean(response_times),
-                "min_response_time": min(response_times),
-                "max_response_time": max(response_times),
-                "response_time_variance": statistics.variance(response_times) if len(response_times) > 1 else 0,
-                "median_response_time": statistics.median(response_times),
-                "response_time_std_dev": statistics.stdev(response_times) if len(response_times) > 1 else 0,
-            }
-            
+            metrics = analyze_response_times(response_times)
             self.logger.debug(f"Collected response time metrics: {metrics}")
             return metrics
-            
         except Exception as e:
             self.logger.error(f"Failed to collect response time metrics: {e}")
             return {}
-    
-    def collect_throughput_metrics(self, operations_count: int, duration: float) -> Dict[str, float]:
-        """Collect and process throughput metrics"""
+
+    def collect_throughput_metrics(
+        self, operations_count: int, duration: float
+    ) -> Dict[str, float]:
+        """Collect and process throughput metrics."""
         try:
-            if duration <= 0:
-                return {}
-            
-            throughput = operations_count / duration
-            
-            metrics = {
-                "total_operations": operations_count,
-                "test_duration": duration,
-                "throughput_ops_per_sec": throughput,
-                "operations_per_minute": throughput * 60,
-                "operations_per_hour": throughput * 3600,
-            }
-            
+            metrics = analyze_throughput(operations_count, duration)
             self.logger.debug(f"Collected throughput metrics: {metrics}")
             return metrics
-            
         except Exception as e:
             self.logger.error(f"Failed to collect throughput metrics: {e}")
             return {}
-    
-    def collect_scalability_metrics(self, scalability_results: List[Dict[str, Any]]) -> Dict[str, float]:
-        """Collect and process scalability metrics"""
+
+    def collect_scalability_metrics(
+        self, scalability_results: List[Dict[str, Any]]
+    ) -> Dict[str, float]:
+        """Collect and process scalability metrics."""
         try:
-            if not scalability_results:
-                return {}
-            
-            # Calculate scalability score based on performance degradation
-            scalability_score = self.benchmarks.calculate_scalability_score(
-                scalability_results
-            )
-            
-            max_ops_per_sec = max(
-                result.get("operations_per_second", 0) for result in scalability_results
-            )
-            
-            avg_ops_per_sec = statistics.mean([
-                result.get("operations_per_second", 0) for result in scalability_results
-            ])
-            
-            metrics = {
-                "scalability_score": scalability_score,
-                "max_operations_per_second": max_ops_per_sec,
-                "average_operations_per_second": avg_ops_per_sec,
-                "concurrent_agent_tests": len(scalability_results),
-                "performance_degradation": self.benchmarks.calculate_performance_degradation(
-                    scalability_results
-                ),
-            }
-            
+            metrics = analyze_scalability(scalability_results, self.benchmarks)
             self.logger.debug(f"Collected scalability metrics: {metrics}")
             return metrics
-            
         except Exception as e:
             self.logger.error(f"Failed to collect scalability metrics: {e}")
             return {}
-    
-    def collect_reliability_metrics(self, total_operations: int, failed_operations: int, 
-                                  duration: float) -> Dict[str, float]:
-        """Collect and process reliability metrics"""
+
+    def collect_reliability_metrics(
+        self, total_operations: int, failed_operations: int, duration: float
+    ) -> Dict[str, float]:
+        """Collect and process reliability metrics."""
         try:
-            if total_operations == 0:
-                return {}
-            
-            success_rate = ((total_operations - failed_operations) / total_operations) * 100
-            failure_rate = (failed_operations / total_operations) * 100
-            
-            metrics = {
-                "total_operations": total_operations,
-                "successful_operations": total_operations - failed_operations,
-                "failed_operations": failed_operations,
-                "success_rate_percent": success_rate,
-                "failure_rate_percent": failure_rate,
-                "uptime_percentage": success_rate,  # Simplified uptime calculation
-                "mean_time_between_failures": duration / failed_operations if failed_operations > 0 else float('inf'),
-            }
-            
+            metrics = analyze_reliability(total_operations, failed_operations, duration)
             self.logger.debug(f"Collected reliability metrics: {metrics}")
             return metrics
-            
         except Exception as e:
             self.logger.error(f"Failed to collect reliability metrics: {e}")
             return {}
-    
+
     def collect_latency_metrics(self, latency_times: List[float]) -> Dict[str, float]:
-        """Collect and process latency metrics"""
+        """Collect and process latency metrics."""
         try:
-            if not latency_times:
-                return {}
-            
-            sorted_latencies = sorted(latency_times)
-            n = len(sorted_latencies)
-            
-            metrics = {
-                "average_latency": statistics.mean(latency_times),
-                "min_latency": min(latency_times),
-                "max_latency": max(latency_times),
-                "median_latency": statistics.median(latency_times),
-                "p95_latency": sorted_latencies[int(0.95 * n)] if n > 0 else 0,
-                "p99_latency": sorted_latencies[int(0.99 * n)] if n > 0 else 0,
-                "latency_std_dev": statistics.stdev(latency_times) if len(latency_times) > 1 else 0,
-            }
-            
+            metrics = analyze_latency(latency_times)
             self.logger.debug(f"Collected latency metrics: {metrics}")
             return metrics
-            
         except Exception as e:
             self.logger.error(f"Failed to collect latency metrics: {e}")
             return {}
-    
-    # Benchmark management wrappers -------------------------------------
+
     def store_benchmark(self, benchmark: PerformanceBenchmark) -> bool:
         return self.benchmarks.store(benchmark)
 

--- a/src/core/performance/metrics/config.py
+++ b/src/core/performance/metrics/config.py
@@ -1,0 +1,15 @@
+"""Configuration constants for performance metrics."""
+
+from __future__ import annotations
+
+from .benchmarks import BenchmarkType
+
+DEFAULT_COLLECTION_INTERVAL = 60
+
+DEFAULT_BENCHMARK_TARGETS = {
+    BenchmarkType.RESPONSE_TIME: {"target": 100, "unit": "ms"},
+    BenchmarkType.THROUGHPUT: {"target": 1000, "unit": "ops/sec"},
+    BenchmarkType.SCALABILITY: {"target": 100, "unit": "concurrent_users"},
+    BenchmarkType.RELIABILITY: {"target": 99.9, "unit": "%"},
+    BenchmarkType.LATENCY: {"target": 50, "unit": "ms"},
+}


### PR DESCRIPTION
## Summary
- split performance metric analysis into dedicated analyzer modules
- centralize metrics configuration constants
- expose analyzer utilities through metrics package

## Testing
- `pre-commit run --files src/core/performance/metrics/collector.py src/core/performance/metrics/analyzers/response_time.py src/core/performance/metrics/analyzers/throughput.py src/core/performance/metrics/analyzers/scalability.py src/core/performance/metrics/analyzers/reliability.py src/core/performance/metrics/analyzers/latency.py src/core/performance/metrics/analyzers/__init__.py src/core/performance/metrics/config.py src/core/performance/metrics/__init__.py` *(fails: Duplication Detector KeyboardInterrupt)*
- `PYTHONPATH=. pytest tests/performance/test_metrics_collector_module.py` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*

------
https://chatgpt.com/codex/tasks/task_e_68b03d8849ac83298d60b2d6d6e7cec5