### PR TITLE
Refactor validation into modular pipeline

### DIFF
--- a/src/services/validation_executor.py
+++ b/src/services/validation_executor.py
@@ -1,0 +1,88 @@
+"""Validation rule execution module.
+
+Handles applying validation rules to contract data and producing
+individual validation results.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Tuple
+
+from .validation_rules import (
+    ValidationRule,
+    ValidationRuleManager,
+    ValidationResult,
+    ValidationSeverity,
+)
+
+
+class ValidationExecutor:
+    """Execute validation rules against contract data."""
+
+    def __init__(self, rule_manager: ValidationRuleManager | None = None) -> None:
+        self.rule_manager = rule_manager or ValidationRuleManager()
+
+    def execute(self, contract_data: Dict[str, Any]) -> List[ValidationResult]:
+        """Run all enabled rules and return their results."""
+        results: List[ValidationResult] = []
+        enabled_rules = [
+            rule for rule in self.rule_manager.get_all_rules().values() if rule.enabled
+        ]
+        for rule in enabled_rules:
+            passed, message, details = self._apply_rule(rule, contract_data)
+            results.append(
+                ValidationResult(
+                    contract_id=contract_data.get("contract_id", "unknown"),
+                    rule_id=rule.rule_id,
+                    passed=passed,
+                    severity=rule.severity,
+                    message=message,
+                    details=details,
+                    timestamp=time.time(),
+                )
+            )
+        return results
+
+    def _apply_rule(self, rule: ValidationRule, contract_data: Dict[str, Any]) -> Tuple[bool, str, Dict[str, Any]]:
+        """Apply a single rule and return pass state, message and details."""
+        handler_name = f"_rule_{rule.rule_id}"
+        handler = getattr(self, handler_name, self._rule_generic)
+        return handler(contract_data)
+
+    # Rule handlers -----------------------------------------------------
+    def _rule_deadline_check(self, data: Dict[str, Any]) -> Tuple[bool, str, Dict[str, Any]]:
+        deadline = data.get("deadline")
+        delivery_date = data.get("delivery_date")
+        passed = bool(deadline and delivery_date and delivery_date <= deadline)
+        message = "Deadline met" if passed else "Deadline exceeded"
+        return passed, message, {"deadline": deadline, "delivery_date": delivery_date}
+
+    def _rule_quality_standard(self, data: Dict[str, Any]) -> Tuple[bool, str, Dict[str, Any]]:
+        quality_score = data.get("quality_score", 0)
+        minimum_standard = data.get("minimum_standard", 0)
+        passed = quality_score >= minimum_standard
+        message = "Quality standards met" if passed else "Quality below standard"
+        return passed, message, {
+            "quality_score": quality_score,
+            "minimum_standard": minimum_standard,
+        }
+
+    def _rule_resource_limit(self, data: Dict[str, Any]) -> Tuple[bool, str, Dict[str, Any]]:
+        usage = data.get("resource_usage", 0)
+        limit = data.get("resource_limit", 0)
+        passed = usage <= limit
+        message = "Resource usage within limits" if passed else "Resource usage exceeded"
+        return passed, message, {"resource_usage": usage, "resource_limit": limit}
+
+    def _rule_dependency_check(self, data: Dict[str, Any]) -> Tuple[bool, str, Dict[str, Any]]:
+        deps = data.get("dependencies", [])
+        completed = data.get("completed_dependencies", [])
+        all_done = all(dep in completed for dep in deps)
+        message = "All dependencies satisfied" if all_done else "Dependencies not satisfied"
+        return all_done, message, {
+            "dependencies": deps,
+            "completed_dependencies": completed,
+        }
+
+    def _rule_generic(self, data: Dict[str, Any]) -> Tuple[bool, str, Dict[str, Any]]:
+        return True, "Rule passed", {}

--- a/src/services/validation_pipeline.py
+++ b/src/services/validation_pipeline.py
@@ -1,0 +1,23 @@
+"""Validation pipeline assembly module."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .validation_rules import ValidationRuleManager
+from .validation_executor import ValidationExecutor
+from .validation_reporter import ValidationReporter
+
+
+class ValidationPipeline:
+    """Assemble and run the validation pipeline."""
+
+    def __init__(self, rule_manager: ValidationRuleManager | None = None) -> None:
+        self.rule_manager = rule_manager or ValidationRuleManager()
+        self.executor = ValidationExecutor(self.rule_manager)
+        self.reporter = ValidationReporter()
+
+    def run(self, contract_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute validation and return results with summary."""
+        results = self.executor.execute(contract_data)
+        summary = self.reporter.summarize(results)
+        return {"results": results, "summary": summary}

--- a/src/services/validation_reporter.py
+++ b/src/services/validation_reporter.py
@@ -1,0 +1,22 @@
+"""Validation reporting module.
+
+Summarises validation results into an easily consumable structure.
+"""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .validation_rules import ValidationResult
+
+
+class ValidationReporter:
+    """Aggregate validation results into summary statistics."""
+
+    def summarize(self, results: List[ValidationResult]) -> Dict[str, int]:
+        summary = {"passed": 0, "failed": 0}
+        for result in results:
+            if result.passed:
+                summary["passed"] += 1
+            else:
+                summary["failed"] += 1
+        return summary

--- a/tests/services/test_validation_executor.py
+++ b/tests/services/test_validation_executor.py
@@ -1,0 +1,16 @@
+"""Tests for validation executor module."""
+from src.services.validation_executor import ValidationExecutor
+from src.services.validation_rules import ValidationRuleManager
+
+
+def test_deadline_rule_failure():
+    manager = ValidationRuleManager()
+    executor = ValidationExecutor(manager)
+    contract = {
+        "contract_id": "c1",
+        "deadline": "2024-01-01",
+        "delivery_date": "2024-02-01",
+    }
+    results = executor.execute(contract)
+    deadline = next(r for r in results if r.rule_id == "deadline_check")
+    assert deadline.passed is False

--- a/tests/services/test_validation_pipeline.py
+++ b/tests/services/test_validation_pipeline.py
@@ -1,0 +1,14 @@
+"""Tests for validation pipeline assembly."""
+from src.services.validation_pipeline import ValidationPipeline
+
+
+def test_pipeline_runs_and_reports():
+    pipeline = ValidationPipeline()
+    contract = {
+        "contract_id": "c1",
+        "deadline": "2024-01-01",
+        "delivery_date": "2024-02-01",
+    }
+    report = pipeline.run(contract)
+    assert "results" in report and "summary" in report
+    assert report["summary"]["failed"] >= 1

--- a/tests/services/test_validation_reporter.py
+++ b/tests/services/test_validation_reporter.py
@@ -1,0 +1,29 @@
+"""Tests for validation reporter module."""
+from src.services.validation_reporter import ValidationReporter
+from src.services.validation_rules import ValidationResult, ValidationSeverity
+
+
+def test_summary_counts_pass_fail():
+    reporter = ValidationReporter()
+    results = [
+        ValidationResult(
+            contract_id="c1",
+            rule_id="r1",
+            passed=True,
+            severity=ValidationSeverity.INFO,
+            message="",
+            details={},
+            timestamp=0.0,
+        ),
+        ValidationResult(
+            contract_id="c1",
+            rule_id="r2",
+            passed=False,
+            severity=ValidationSeverity.ERROR,
+            message="",
+            details={},
+            timestamp=0.0,
+        ),
+    ]
+    summary = reporter.summarize(results)
+    assert summary == {"passed": 1, "failed": 1}


### PR DESCRIPTION
## Summary
- Add `ValidationExecutor` to apply rule logic
- Add `ValidationReporter` to summarize validation outcomes
- Provide `ValidationPipeline` interface assembling rules, execution, and reporting
- Introduce targeted unit tests for executor, reporter, and pipeline

## Testing
- `pytest tests/services/test_validation_executor.py tests/services/test_validation_reporter.py tests/services/test_validation_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b03d8c8b388329ad9ba30bc1233bd2