### PR TITLE
refactor: modularize refactoring toolkit

### DIFF
--- a/src/core/refactoring/analysis_tools.py
+++ b/src/core/refactoring/analysis_tools.py
@@ -1,0 +1,112 @@
+"""Analysis helpers for the refactoring toolkit."""
+
+from pathlib import Path
+from typing import Dict, Any, List
+
+
+def _get_extraction_recommendations(opportunities: List[str]) -> List[str]:
+    """Get extraction recommendations based on detected opportunities."""
+    recommendations: List[str] = []
+    if "file_size" in opportunities:
+        recommendations.append("Extract large functions into separate modules")
+    if "multiple_classes" in opportunities:
+        recommendations.append("Separate classes into focused modules")
+    if "many_functions" in opportunities:
+        recommendations.append("Group related functions into utility modules")
+    if "mixed_responsibilities" in opportunities:
+        recommendations.append(
+            "Separate imports, classes, and functions into focused modules"
+        )
+    return recommendations
+
+
+def analyze_file_for_extraction(file_path: Path) -> Dict[str, Any]:
+    """Analyze file for module extraction opportunities."""
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+            lines = content.split("\n")
+
+        line_count = len(lines)
+        class_count = content.count("class ")
+        function_count = content.count("def ")
+
+        extraction_opportunities: List[str] = []
+        if line_count > 300:
+            extraction_opportunities.append("file_size")
+        if class_count > 3:
+            extraction_opportunities.append("multiple_classes")
+        if function_count > 10:
+            extraction_opportunities.append("many_functions")
+        if any(
+            keyword in content.lower() for keyword in ["import", "class", "def", "if __name__"]
+        ):
+            if content.count("import") > 5 and class_count > 0 and function_count > 0:
+                extraction_opportunities.append("mixed_responsibilities")
+
+        return {
+            "file_path": str(file_path),
+            "line_count": line_count,
+            "class_count": class_count,
+            "function_count": function_count,
+            "extraction_opportunities": extraction_opportunities,
+            "recommended_actions": _get_extraction_recommendations(extraction_opportunities),
+        }
+    except Exception as e:  # pragma: no cover - safety net
+        return {"error": f"Analysis failed: {e}"}
+
+
+def find_duplicate_files(base_path: Path) -> List[Dict[str, Any]]:
+    """Find duplicate files in the codebase.
+
+    This is a simplified implementation using filename patterns.
+    """
+    duplicates: List[Dict[str, Any]] = []
+    duplicate_patterns = ["api_key_manager.py", "ai_agent_manager.py", "workflow_manager.py"]
+    for pattern in duplicate_patterns:
+        matches = list(base_path.rglob(f"*{pattern}"))
+        if len(matches) > 1:
+            duplicates.append(
+                {
+                    "pattern": pattern,
+                    "files": [str(f) for f in matches],
+                    "duplication_level": "high" if len(matches) > 2 else "medium",
+                }
+            )
+    return duplicates
+
+
+def analyze_architecture_patterns() -> Dict[str, Any]:
+    """Analyze architecture patterns in the codebase.
+
+    This function returns static data in lieu of real analysis.
+    """
+    patterns = [
+        {
+            "name": "BaseManager Inheritance",
+            "description": "Classes inheriting from BaseManager",
+            "count": 15,
+            "quality_score": 85,
+        },
+        {
+            "name": "Module Extraction",
+            "description": "Large files broken into focused modules",
+            "count": 25,
+            "quality_score": 90,
+        },
+        {
+            "name": "Single Responsibility",
+            "description": "Classes following SRP principle",
+            "count": 40,
+            "quality_score": 88,
+        },
+    ]
+    return {
+        "patterns": patterns,
+        "overall_quality_score": sum(p["quality_score"] for p in patterns) / len(patterns),
+        "recommendations": [
+            "Continue BaseManager inheritance pattern",
+            "Extract remaining large modules",
+            "Enforce SRP compliance",
+        ],
+    }

--- a/src/core/refactoring/config.py
+++ b/src/core/refactoring/config.py
@@ -1,0 +1,3 @@
+"""Configuration for the refactoring toolkit."""
+
+DEFAULT_MAX_WORKERS = 4

--- a/src/core/refactoring/metrics_tools.py
+++ b/src/core/refactoring/metrics_tools.py
@@ -1,0 +1,32 @@
+"""Metrics utilities for tracking refactoring performance."""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass
+class RefactoringMetrics:
+    """Refactoring performance metrics."""
+    total_files_processed: int = 0
+    total_lines_reduced: int = 0
+    total_time_saved: float = 0.0
+    duplication_eliminated: float = 0.0
+    architecture_improvements: int = 0
+    quality_score: float = 0.0
+    efficiency_gain: float = 0.0
+
+
+def update_metrics(metrics: RefactoringMetrics, task, result: Dict[str, Any]) -> None:
+    """Update refactoring metrics based on task result."""
+    if result.get("success"):
+        metrics.total_files_processed += 1
+        metrics_data = result.get("metrics", {})
+        if task.task_type == "extract_module":
+            metrics.total_lines_reduced += metrics_data.get("reduction", 0)
+            metrics.architecture_improvements += 1
+        elif task.task_type == "consolidate_duplicates":
+            metrics.duplication_eliminated += 10.0
+            metrics.total_lines_reduced += metrics_data.get("lines_eliminated", 0)
+        elif task.task_type == "optimize_architecture":
+            metrics.architecture_improvements += 1
+            metrics.quality_score += metrics_data.get("quality_improvement", 0)

--- a/src/core/refactoring/refactor_tools.py
+++ b/src/core/refactoring/refactor_tools.py
@@ -1,0 +1,132 @@
+"""Refactoring helpers for performing code modifications."""
+
+from pathlib import Path
+from typing import Dict, Any, List
+
+
+def create_extraction_plan(analysis: Dict[str, Any]) -> Dict[str, Any]:
+    """Create extraction plan based on analysis data."""
+    plan = {
+        "target_file": analysis["file_path"],
+        "extraction_modules": [],
+        "estimated_effort": 0.0,
+        "risk_assessment": "low",
+    }
+    opportunities = analysis.get("extraction_opportunities", [])
+    if "multiple_classes" in opportunities:
+        plan["extraction_modules"].append(
+            {
+                "type": "class_separation",
+                "description": "Separate classes into focused modules",
+                "estimated_effort": 2.0,
+            }
+        )
+        plan["estimated_effort"] += 2.0
+    if "many_functions" in opportunities:
+        plan["extraction_modules"].append(
+            {
+                "type": "function_grouping",
+                "description": "Group related functions into utility modules",
+                "estimated_effort": 1.5,
+            }
+        )
+        plan["estimated_effort"] += 1.5
+    if "mixed_responsibilities" in opportunities:
+        plan["extraction_modules"].append(
+            {
+                "type": "responsibility_separation",
+                "description": "Separate different responsibilities into focused modules",
+                "estimated_effort": 2.5,
+            }
+        )
+        plan["estimated_effort"] += 2.5
+    return plan
+
+
+def perform_extraction(file_path: Path, plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Perform the actual extraction based on plan."""
+    result = {
+        "success": True,
+        "created_modules": [],
+        "total_lines_after": 0,
+        "errors": [],
+    }
+    try:
+        modules_dir = file_path.parent / f"{file_path.stem}_modules"
+        modules_dir.mkdir(exist_ok=True)
+        for module_info in plan["extraction_modules"]:
+            module_name = f"{module_info['type']}_{file_path.stem}.py"
+            module_path = modules_dir / module_name
+            with open(module_path, "w") as f:
+                f.write(f"# {module_info['description']}\n")
+                f.write(f"# Extracted from {file_path.name}\n")
+                f.write("def placeholder_function():\n")
+                f.write("    \"\"\"Placeholder function - implement actual logic\"\"\"\n")
+                f.write("    pass\n")
+            result["created_modules"].append(str(module_path))
+        result["total_lines_after"] = max(100, plan.get("estimated_effort", 0) * 50)
+    except Exception as e:  # pragma: no cover - safety net
+        result["success"] = False
+        result["errors"].append(str(e))
+    return result
+
+
+def create_consolidation_plan(duplicates: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Create consolidation plan for duplicate files."""
+    plan = {"consolidation_targets": [], "estimated_effort": 0.0, "risk_assessment": "medium"}
+    for duplicate in duplicates:
+        consolidation_target = {
+            "pattern": duplicate["pattern"],
+            "source_files": duplicate["files"][1:],
+            "target_file": duplicate["files"][0],
+            "estimated_effort": len(duplicate["files"]) * 0.5,
+        }
+        plan["consolidation_targets"].append(consolidation_target)
+        plan["estimated_effort"] += consolidation_target["estimated_effort"]
+    return plan
+
+
+def perform_consolidation(plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Perform the actual consolidation."""
+    result = {"success": True, "files_consolidated": 0, "lines_eliminated": 0, "errors": []}
+    for target in plan["consolidation_targets"]:
+        try:
+            result["files_consolidated"] += len(target["source_files"])
+            result["lines_eliminated"] += len(target["source_files"]) * 100
+        except Exception as e:  # pragma: no cover - safety net
+            result["errors"].append(f"Failed to consolidate {target['pattern']}: {e}")
+    return result
+
+
+def create_optimization_plan(analysis: Dict[str, Any]) -> Dict[str, Any]:
+    """Create optimization plan based on architecture analysis."""
+    plan = {"optimization_targets": [], "estimated_effort": 0.0, "expected_improvement": 0.0}
+    for pattern in analysis["patterns"]:
+        if pattern["quality_score"] < 90:
+            optimization_target = {
+                "pattern": pattern["name"],
+                "current_score": pattern["quality_score"],
+                "target_score": 95,
+                "estimated_effort": (95 - pattern["quality_score"]) * 0.2,
+            }
+            plan["optimization_targets"].append(optimization_target)
+            plan["estimated_effort"] += optimization_target["estimated_effort"]
+            plan["expected_improvement"] += 95 - pattern["quality_score"]
+    return plan
+
+
+def perform_optimization(plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Perform the actual optimization."""
+    result = {"success": True, "applied_optimizations": [], "quality_score_improvement": 0.0, "errors": []}
+    for target in plan["optimization_targets"]:
+        try:
+            optimization = {
+                "pattern": target["pattern"],
+                "improvement": target["target_score"] - target["current_score"],
+                "effort_applied": target["estimated_effort"],
+            }
+            result["applied_optimizations"].append(optimization)
+            result["quality_score_improvement"] += optimization["improvement"]
+        except Exception as e:  # pragma: no cover - safety net
+            result["errors"].append(f"Failed to optimize {target['pattern']}: {e}")
+    return result

--- a/src/core/refactoring/toolkit.py
+++ b/src/core/refactoring/toolkit.py
@@ -1,0 +1,30 @@
+"""Facade module aggregating refactoring tools."""
+
+from .analysis_tools import (
+    analyze_file_for_extraction,
+    find_duplicate_files,
+    analyze_architecture_patterns,
+)
+from .refactor_tools import (
+    create_extraction_plan,
+    perform_extraction,
+    create_consolidation_plan,
+    perform_consolidation,
+    create_optimization_plan,
+    perform_optimization,
+)
+from .metrics_tools import RefactoringMetrics, update_metrics
+
+__all__ = [
+    "analyze_file_for_extraction",
+    "find_duplicate_files",
+    "analyze_architecture_patterns",
+    "create_extraction_plan",
+    "perform_extraction",
+    "create_consolidation_plan",
+    "perform_consolidation",
+    "create_optimization_plan",
+    "perform_optimization",
+    "RefactoringMetrics",
+    "update_metrics",
+]


### PR DESCRIPTION
## Summary
- extract analysis, refactor, and metrics helpers into separate modules
- centralize shared settings in a refactoring config module
- expose a facade aggregating refactoring utilities and update advanced toolkit to delegate to them

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b03d96f10c83299d40f86331631abf