### PR TITLE
Refactor dashboard validator rule handling

### DIFF
--- a/src/core/unified_dashboard_validator.py
+++ b/src/core/unified_dashboard_validator.py
@@ -373,7 +373,7 @@ class UnifiedDashboardValidator:
     ) -> ValidationResult:
         """Generate ValidationResult for a task claim."""
         return ValidationResult(
-            validation_id=f"validation_{int(time.time())}",
+            validation_id=f"validation_{time.time_ns()}",
             timestamp=datetime.now(),
             claim_id=claim_id,
             status=status,

--- a/src/core/unified_dashboard_validator.py
+++ b/src/core/unified_dashboard_validator.py
@@ -384,6 +384,7 @@ class UnifiedDashboardValidator:
 
     def _validate_task_completion(self, claim: DashboardClaim) -> ValidationResult:
         """Validate a task completion claim"""
+        validation_time = datetime.now()
         deliverables, expected_devlogs = self._parse_task_deliverables(claim)
         rules = self.validation_rules.get("TASK_COMPLETION", {})
         status, discrepancies, evidence, confidence = self._apply_task_validation_rules(
@@ -393,9 +394,10 @@ class UnifiedDashboardValidator:
             claim.task_id,
             self.base_path,
             rules,
+            validation_time,
         )
         return self._generate_task_validation_result(
-            claim.claim_id, status, discrepancies, evidence, confidence
+            claim.claim_id, status, discrepancies, evidence, confidence, validation_time
         )
     
     def _validate_system_status(self, claim: DashboardClaim) -> ValidationResult:

--- a/tests/unit/test_dashboard_validator_rules.py
+++ b/tests/unit/test_dashboard_validator_rules.py
@@ -22,3 +22,13 @@ def test_devlog_rule_detects_insufficient_entries(tmp_path, monkeypatch):
     )
     assert status == "PARTIAL"
     assert "Insufficient devlog entries" in discrepancies[0]
+
+def test_deliverable_rule_is_skipped_when_disabled(tmp_path):
+    validator = UnifiedDashboardValidator(base_path=tmp_path)
+    deliverables = ["missing.txt"]
+    rules = {"deliverables_exist": False, "devlog_entries_found": False}
+    status, discrepancies, evidence, confidence = validator._apply_task_validation_rules(
+        deliverables, 0, "agent", "task", tmp_path, rules
+    )
+    assert status == "VALID"
+    assert not discrepancies

--- a/tests/unit/test_dashboard_validator_rules.py
+++ b/tests/unit/test_dashboard_validator_rules.py
@@ -1,0 +1,24 @@
+from src.core.unified_dashboard_validator import UnifiedDashboardValidator
+
+
+def test_deliverable_rule_detects_missing_file(tmp_path):
+    validator = UnifiedDashboardValidator(base_path=tmp_path)
+    deliverables = ["missing.txt"]
+    rules = {"deliverables_exist": True, "devlog_entries_found": False}
+    status, discrepancies, evidence, confidence = validator._apply_task_validation_rules(
+        deliverables, 0, "agent", "task", tmp_path, rules
+    )
+    assert status == "PARTIAL"
+    assert "Deliverable not found" in discrepancies[0]
+
+
+def test_devlog_rule_detects_insufficient_entries(tmp_path, monkeypatch):
+    validator = UnifiedDashboardValidator(base_path=tmp_path)
+    monkeypatch.setattr(validator, "_count_devlog_entries", lambda a, t: 0)
+    deliverables = []
+    rules = {"deliverables_exist": False, "devlog_entries_found": True}
+    status, discrepancies, evidence, confidence = validator._apply_task_validation_rules(
+        deliverables, 2, "agent", "task", tmp_path, rules
+    )
+    assert status == "PARTIAL"
+    assert "Insufficient devlog entries" in discrepancies[0]


### PR DESCRIPTION
## Summary
- Separate task claim handling into deliverable parsing, rule application, and result reporting
- Remove implicit global state by passing base path and rules explicitly to validation helpers
- Add unit tests for deliverable existence and devlog entry validation rules

## Testing
- `pytest tests/unit/test_dashboard_validator_rules.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b03d9b36888329aa566159ab32c52a