### PR TITLE
refactor reporting and add plugin hooks

### DIFF
--- a/tests/unit/test_reporting_plugins.py
+++ b/tests/unit/test_reporting_plugins.py
@@ -1,0 +1,42 @@
+"""Tests for Reporting plugin hooks."""
+
+import importlib.util
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def load_reporting_class():
+    spec = importlib.util.spec_from_file_location(
+        "reporting", Path(__file__).resolve().parents[2] / "src/core/fsm/execution_engine/reporting.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.Reporting
+
+
+Reporting = load_reporting_class()
+
+
+@dataclass
+class DummyWorkflow:
+    workflow_name: str
+
+
+class DummyReporting(Reporting):
+    def __init__(self):
+        # Minimal attributes required by Reporting
+        self.workflows = {"1": DummyWorkflow("wf")}
+        self.logger = logging.getLogger("dummy")
+        self.active_workflows = set()
+        self.workflow_queue = []
+
+
+def test_reporting_plugin_extension():
+    reporter = DummyReporting()
+    reporter.register_report_plugin(
+        "custom", lambda data: "custom:" + data["workflow_name"]
+    )
+    output = reporter.export_workflow_report("1", "custom")
+    assert output == "custom:wf"
+


### PR DESCRIPTION
## Summary
- modularize reporting with distinct data gathering, formatting, and export steps
- introduce plugin registration for extensible report formats
- adopt templating for dynamic error messages
- add tests for reporting plugin hook

## Testing
- `pytest tests/unit/test_reporting_plugins.py -q`
- `pytest src/core/fsm/fsm_integration_test.py::FSMCoreIntegrationTest::test_workflow_reporting -q` *(fails: ModuleNotFoundError: No module named 'src.core.fsm.task_manager')*


------
https://chatgpt.com/codex/tasks/task_e_68b03da20630832984c0ddd2f9f927d7