### PR TITLE
refactor: unify shared JS utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "autodream-os",
+  "type": "module"
+}

--- a/src/web/static/js/portal/portal_framework.js
+++ b/src/web/static/js/portal/portal_framework.js
@@ -1,3 +1,5 @@
+import { dom as domUtils, createEventBus } from '../shared_utils.js';
+
 /**
  * Portal Framework JavaScript
  * Agent_Cellphone_V2_Repository - Unified Portal Architecture
@@ -11,7 +13,7 @@
         version: '1.0.0',
         config: {},
         components: {},
-        events: {},
+        events: createEventBus(),
         utils: {}
     };
 
@@ -47,115 +49,10 @@
         charts: null
     };
 
-    // Event System
-    PortalFramework.events = {
-        listeners: {},
-
-        on: function(event, callback) {
-            if (!this.listeners[event]) {
-                this.listeners[event] = [];
-            }
-            this.listeners[event].push(callback);
-        },
-
-        emit: function(event, data) {
-            if (this.listeners[event]) {
-                this.listeners[event].forEach(function(callback) {
-                    try {
-                        callback(data);
-                    } catch (error) {
-                        console.error('Error in event listener:', error);
-                    }
-                });
-            }
-        },
-
-        off: function(event, callback) {
-            if (this.listeners[event]) {
-                const index = this.listeners[event].indexOf(callback);
-                if (index > -1) {
-                    this.listeners[event].splice(index, 1);
-                }
-            }
-        }
-    };
-
     // Utility Functions
     PortalFramework.utils = {
         // DOM utilities
-        dom: {
-            ready: function(callback) {
-                if (document.readyState === 'loading') {
-                    document.addEventListener('DOMContentLoaded', callback);
-                } else {
-                    callback();
-                }
-            },
-
-            createElement: function(tag, attributes, content) {
-                const element = document.createElement(tag);
-
-                if (attributes) {
-                    Object.keys(attributes).forEach(function(key) {
-                        if (key === 'className') {
-                            element.className = attributes[key];
-                        } else if (key === 'textContent') {
-                            element.textContent = attributes[key];
-                        } else {
-                            element.setAttribute(key, attributes[key]);
-                        }
-                    });
-                }
-
-                if (content) {
-                    if (typeof content === 'string') {
-                        element.textContent = content;
-                    } else if (content instanceof HTMLElement) {
-                        element.appendChild(content);
-                    } else if (Array.isArray(content)) {
-                        content.forEach(function(item) {
-                            element.appendChild(item);
-                        });
-                    }
-                }
-
-                return element;
-            },
-
-            addClass: function(element, className) {
-                if (element.classList) {
-                    element.classList.add(className);
-                } else {
-                    element.className += ' ' + className;
-                }
-            },
-
-            removeClass: function(element, className) {
-                if (element.classList) {
-                    element.classList.remove(className);
-                } else {
-                    element.className = element.className.replace(
-                        new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' '
-                    );
-                }
-            },
-
-            hasClass: function(element, className) {
-                if (element.classList) {
-                    return element.classList.contains(className);
-                } else {
-                    return new RegExp('(^| )' + className + '( |$)', 'gi').test(element.className);
-                }
-            },
-
-            toggleClass: function(element, className) {
-                if (this.hasClass(element, className)) {
-                    this.removeClass(element, className);
-                } else {
-                    this.addClass(element, className);
-                }
-            }
-        },
+        dom: domUtils,
 
         // Storage utilities
         storage: {

--- a/src/web/static/js/shared_utils.js
+++ b/src/web/static/js/shared_utils.js
@@ -1,0 +1,120 @@
+export const dom = {
+    ready(callback) {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', callback);
+        } else {
+            callback();
+        }
+    },
+
+    createElement(tag, attributes, content) {
+        const element = document.createElement(tag);
+
+        if (attributes) {
+            Object.keys(attributes).forEach(key => {
+                if (key === 'className') {
+                    element.className = attributes[key];
+                } else if (key === 'textContent') {
+                    element.textContent = attributes[key];
+                } else {
+                    element.setAttribute(key, attributes[key]);
+                }
+            });
+        }
+
+        if (content) {
+            if (typeof content === 'string') {
+                element.textContent = content;
+            } else if (content instanceof HTMLElement) {
+                element.appendChild(content);
+            } else if (Array.isArray(content)) {
+                content.forEach(item => element.appendChild(item));
+            }
+        }
+
+        return element;
+    },
+
+    addClass(element, className, animationClass = null) {
+        if (element.classList) {
+            if (!element.classList.contains(className)) {
+                element.classList.add(className);
+                if (animationClass) {
+                    element.classList.add(animationClass);
+                    setTimeout(() => element.classList.remove(animationClass), 300);
+                }
+            }
+        } else {
+            element.className += ' ' + className;
+        }
+    },
+
+    removeClass(element, className, animationClass = null) {
+        if (element.classList) {
+            if (element.classList.contains(className)) {
+                if (animationClass) {
+                    element.classList.add(animationClass);
+                    setTimeout(() => {
+                        element.classList.remove(className);
+                        element.classList.remove(animationClass);
+                    }, 300);
+                } else {
+                    element.classList.remove(className);
+                }
+            }
+        } else {
+            element.className = element.className.replace(
+                new RegExp('(^|\b)' + className.split(' ').join('|') + '(\b|$)', 'gi'),
+                ' '
+            );
+        }
+    },
+
+    hasClass(element, className) {
+        if (element.classList) {
+            return element.classList.contains(className);
+        }
+        return new RegExp('(^| )' + className + '( |$)', 'gi').test(element.className);
+    },
+
+    toggleClass(element, className, animationClass = null) {
+        if (this.hasClass(element, className)) {
+            this.removeClass(element, className, animationClass);
+        } else {
+            this.addClass(element, className, animationClass);
+        }
+    }
+};
+
+export function createEventBus() {
+    const listeners = {};
+    return {
+        on(event, callback) {
+            if (!listeners[event]) {
+                listeners[event] = [];
+            }
+            listeners[event].push(callback);
+        },
+        off(event, callback) {
+            if (!listeners[event]) return;
+            const index = listeners[event].indexOf(callback);
+            if (index > -1) {
+                listeners[event].splice(index, 1);
+            }
+        },
+        emit(event, data) {
+            if (listeners[event]) {
+                listeners[event].forEach(callback => {
+                    try {
+                        callback(data);
+                    } catch (error) {
+                        console.error('Error in event listener:', error);
+                    }
+                });
+            }
+        },
+        trigger(event, data) {
+            this.emit(event, data);
+        }
+    };
+}

--- a/tests/js/shared_utils.test.js
+++ b/tests/js/shared_utils.test.js
@@ -1,0 +1,91 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { dom, createEventBus } from '../../src/web/static/js/shared_utils.js';
+
+// Basic DOM stubs
+const mockDocument = {
+    readyState: 'complete',
+    _callback: null,
+    addEventListener(event, cb) {
+        if (event === 'DOMContentLoaded') {
+            this._callback = cb;
+        }
+    },
+    createElement(tag) {
+        return {
+            tagName: tag.toUpperCase(),
+            attributes: {},
+            className: '',
+            textContent: '',
+            setAttribute(key, value) {
+                this.attributes[key] = value;
+                this[key] = value;
+            },
+            appendChild(child) {
+                (this.children ||= []).push(child);
+            },
+            classList: {
+                classes: new Set(),
+                add(cls) { this.classes.add(cls); },
+                remove(cls) { this.classes.delete(cls); },
+                contains(cls) { return this.classes.has(cls); }
+            }
+        };
+    }
+};
+
+global.document = mockDocument;
+global.window = {};
+global.HTMLElement = function() {};
+
+function createMockElement() {
+    return mockDocument.createElement('div');
+}
+
+test('addClass adds class', () => {
+    const el = createMockElement();
+    dom.addClass(el, 'test');
+    assert.ok(el.classList.contains('test'));
+});
+
+test('removeClass removes class', () => {
+    const el = createMockElement();
+    dom.addClass(el, 'test');
+    dom.removeClass(el, 'test');
+    assert.ok(!el.classList.contains('test'));
+});
+
+test('toggleClass toggles class', () => {
+    const el = createMockElement();
+    dom.toggleClass(el, 'test');
+    assert.ok(el.classList.contains('test'));
+    dom.toggleClass(el, 'test');
+    assert.ok(!el.classList.contains('test'));
+});
+
+test('ready calls callback immediately when document ready', () => {
+    mockDocument.readyState = 'complete';
+    let called = false;
+    dom.ready(() => { called = true; });
+    assert.ok(called);
+});
+
+test('createElement applies attributes and content', () => {
+    const el = dom.createElement('span', { className: 'x', id: 'y' }, 'hello');
+    assert.strictEqual(el.className, 'x');
+    assert.strictEqual(el.id, 'y');
+    assert.strictEqual(el.textContent, 'hello');
+});
+
+test('event bus emits and triggers events', () => {
+    const bus = createEventBus();
+    let data = null;
+    const handler = d => { data = d; };
+    bus.on('test', handler);
+    bus.emit('test', 42);
+    assert.strictEqual(data, 42);
+    bus.off('test', handler);
+    data = null;
+    bus.trigger('test', 1);
+    assert.strictEqual(data, null);
+});


### PR DESCRIPTION
## Summary
- centralize DOM and event bus helpers into a shared module
- replace duplicated utilities in portal and responsive frameworks with shared imports
- add unit tests for shared utilities

## Testing
- `pre-commit run --files package.json src/web/static/js/shared_utils.js src/web/static/js/portal/portal_framework.js src/web/static/js/responsive_framework.js tests/js/shared_utils.test.js`
- `node --test tests/js/shared_utils.test.js`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68b03da41758832997f5c6a51b79219e