### PR TITLE
refactor: centralize channel dispatch helper

### DIFF
--- a/src/core/health/alerting/channel_dispatch.py
+++ b/src/core/health/alerting/channel_dispatch.py
@@ -9,6 +9,20 @@ from .models import (
 )
 
 
+def dispatch_to_channels(
+    alert: HealthAlert,
+    channels: List[NotificationChannel],
+    configs: Dict[NotificationChannel, NotificationConfig],
+    recipients: Optional[List[str]] = None,
+) -> None:
+    """Helper to dispatch notifications to configured channels."""
+    for channel in channels:
+        if channel in configs:
+            config = configs[channel]
+            if config.enabled:
+                send_notification(alert, channel, config, recipients)
+
+
 def send_alert_notifications(
     alert: HealthAlert,
     rule: AlertRule,
@@ -16,11 +30,7 @@ def send_alert_notifications(
 ) -> None:
     """Send notifications for a new alert using configured channels."""
     try:
-        for channel in rule.notification_channels:
-            if channel in configs:
-                config = configs[channel]
-                if config.enabled:
-                    send_notification(alert, channel, config)
+        dispatch_to_channels(alert, rule.notification_channels, configs)
         alert.notification_sent = True
     except Exception as e:
         logger.error(f"Error sending alert notifications: {e}")

--- a/src/core/health/alerting/escalation.py
+++ b/src/core/health/alerting/escalation.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Dict, Optional
 
-from .channel_dispatch import send_notification
+from .channel_dispatch import dispatch_to_channels
 from .logging_utils import logger
 from .models import (
     HealthAlert,
@@ -34,11 +34,9 @@ def send_escalation_notifications(
     policy: EscalationPolicy,
     configs: Dict[NotificationChannel, NotificationConfig],
 ) -> None:
-    for channel in policy.notification_channels:
-        if channel in configs:
-            config = configs[channel]
-            if config.enabled:
-                send_notification(alert, channel, config, policy.contacts)
+    dispatch_to_channels(
+        alert, policy.notification_channels, configs, policy.contacts
+    )
 
 
 def escalate_alert(


### PR DESCRIPTION
## Summary
- extract `dispatch_to_channels` helper for routing notifications
- use the helper in alert and escalation notification flows

## Testing
- `pytest tests/core/health -q` *(fails: ImportError cannot import name 'HealthThresholdMonitoring')*

------
https://chatgpt.com/codex/tasks/task_e_68b03dadecfc83299fc7765bc37007a3