### PR TITLE
refactor: centralize channel helpers

### DIFF
--- a/src/core/communication/channel_utils.py
+++ b/src/core/communication/channel_utils.py
@@ -1,0 +1,56 @@
+"""Utility helpers for creating channels and their default statistics."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from .channels import Channel, ChannelType
+
+
+def create_channel(
+    channel_id: str,
+    name: str,
+    channel_type: ChannelType,
+    url: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> Channel:
+    """Create a Channel instance with default metadata.
+
+    Args:
+        channel_id: Unique identifier for the channel.
+        name: Human readable channel name.
+        channel_type: Type of the channel (HTTP, WEBSOCKET, etc.).
+        url: Endpoint associated with the channel.
+        config: Optional configuration dictionary.
+
+    Returns:
+        Configured :class:`~src.core.communication.channels.Channel` object.
+    """
+    now = datetime.now().isoformat()
+    return Channel(
+        id=channel_id,
+        name=name,
+        type=channel_type,
+        url=url,
+        config=config or {},
+        status="active",
+        created_at=now,
+        last_used=now,
+        message_count=0,
+        error_count=0,
+    )
+
+
+def default_channel_stats() -> Dict[str, Any]:
+    """Return a default statistics dictionary for a channel."""
+    now = datetime.now().isoformat()
+    return {
+        "total_messages": 0,
+        "successful_messages": 0,
+        "failed_messages": 0,
+        "last_activity": now,
+        "uptime_percentage": 100.0,
+        "average_response_time": 0.0,
+        "error_rate": 0.0,
+    }

--- a/src/core/communication/communication_manager.py
+++ b/src/core/communication/communication_manager.py
@@ -14,6 +14,7 @@ from ...services.messaging.types.v2_message_enums import (
 from .channels import Channel, ChannelType
 from .adapters import HTTPAdapter, HTTPSAdapter, WebSocketAdapter
 from .router import MessageRouter
+from .channel_utils import create_channel
 
 logger = logging.getLogger(__name__)
 
@@ -39,18 +40,7 @@ class CommunicationManager:
     ) -> str:
         """Register a new channel and initialise protocol adapters as needed."""
         channel_id = f"{channel_type.value}_{len(self.channels)}"
-        channel = Channel(
-            id=channel_id,
-            name=name,
-            type=channel_type,
-            url=url,
-            config=config or {},
-            status="active",
-            created_at=datetime.now().isoformat(),
-            last_used=datetime.now().isoformat(),
-            message_count=0,
-            error_count=0,
-        )
+        channel = create_channel(channel_id, name, channel_type, url, config)
         self.channels[channel_id] = channel
 
         if channel.type == ChannelType.WEBSOCKET:

--- a/src/core/managers/communication/channel_manager.py
+++ b/src/core/managers/communication/channel_manager.py
@@ -22,6 +22,7 @@ from dataclasses import asdict
 from ..base_manager import BaseManager, ManagerStatus, ManagerPriority
 from .models import Channel, ChannelType
 from .types import CommunicationTypes, CommunicationConfig
+from ...communication.channel_utils import create_channel, default_channel_stats
 
 logger = logging.getLogger(__name__)
 
@@ -74,31 +75,11 @@ class ChannelManager(BaseManager):
         try:
             channel_id = f"{channel_type.value}_{name}_{len(self.channels)}"
             
-            channel = Channel(
-                id=channel_id,
-                name=name,
-                type=channel_type,
-                url=url,
-                config=config or {},
-                status=CommunicationTypes.ChannelStatus.ACTIVE.value,
-                created_at=datetime.now().isoformat(),
-                last_used=datetime.now().isoformat(),
-                message_count=0,
-                error_count=0
-            )
-            
+            channel = create_channel(channel_id, name, channel_type, url, config)
             self.channels[channel_id] = channel
-            
+
             # Initialize stats
-            self.channel_stats[channel_id] = {
-                "total_messages": 0,
-                "successful_messages": 0,
-                "failed_messages": 0,
-                "last_activity": datetime.now().isoformat(),
-                "uptime_percentage": 100.0,
-                "average_response_time": 0.0,
-                "error_rate": 0.0
-            }
+            self.channel_stats[channel_id] = default_channel_stats()
             
             self._emit_event("channel_created", {
                 "channel_id": channel_id,

--- a/src/core/managers/communication/communication_core.py
+++ b/src/core/managers/communication/communication_core.py
@@ -27,8 +27,9 @@ from .api_manager import APIManager
 from .websocket_manager import WebSocketManager
 from .routing_manager import RoutingManager
 from .reporting_manager import ReportingManager
-from .models import Channel, ChannelType
-from .types import CommunicationTypes, CommunicationConfig
+from .models import ChannelType
+from .types import CommunicationConfig
+from ...communication.channel_utils import create_channel, default_channel_stats
 
 logger = logging.getLogger(__name__)
 
@@ -102,28 +103,15 @@ class CommunicationManager(BaseManager):
                 CommunicationConfig.DEFAULT_RETRY_COUNT,
             )
 
-            channel = Channel(
-                id="http_default",
-                name="Default HTTP",
-                type=ChannelType.HTTP,
-                url="http://localhost:8000",
-                config={"timeout": default_timeout, "retry_count": default_retry},
-                status=CommunicationTypes.ChannelStatus.ACTIVE.value,
-                created_at=datetime.now().isoformat(),
-                last_used=datetime.now().isoformat(),
-                message_count=0,
-                error_count=0,
+            channel = create_channel(
+                "http_default",
+                "Default HTTP",
+                ChannelType.HTTP,
+                "http://localhost:8000",
+                {"timeout": default_timeout, "retry_count": default_retry},
             )
             self.channel_manager.channels["http_default"] = channel
-            self.channel_manager.channel_stats["http_default"] = {
-                "total_messages": 0,
-                "successful_messages": 0,
-                "failed_messages": 0,
-                "last_activity": datetime.now().isoformat(),
-                "uptime_percentage": 100.0,
-                "average_response_time": 0.0,
-                "error_rate": 0.0,
-            }
+            self.channel_manager.channel_stats["http_default"] = default_channel_stats()
 
     def _setup_default_api_configs(self):
         """Setup default API configurations"""

--- a/tests/communication/test_channel_utils.py
+++ b/tests/communication/test_channel_utils.py
@@ -1,0 +1,31 @@
+import re
+
+from src.core.communication.channel_utils import create_channel, default_channel_stats
+from src.core.communication.channels import ChannelType
+
+
+def test_create_channel_defaults():
+    channel = create_channel("chan1", "Test", ChannelType.HTTP, "http://example.com")
+    assert channel.id == "chan1"
+    assert channel.name == "Test"
+    assert channel.type == ChannelType.HTTP
+    assert channel.url == "http://example.com"
+    assert channel.status == "active"
+    assert channel.message_count == 0
+    assert channel.error_count == 0
+    assert channel.config == {}
+    # ISO timestamp pattern for created_at/last_used
+    iso_pattern = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:")
+    assert iso_pattern.match(channel.created_at)
+    assert iso_pattern.match(channel.last_used)
+
+
+def test_default_channel_stats():
+    stats = default_channel_stats()
+    assert stats["total_messages"] == 0
+    assert stats["successful_messages"] == 0
+    assert stats["failed_messages"] == 0
+    assert "last_activity" in stats
+    assert stats["uptime_percentage"] == 100.0
+    assert stats["average_response_time"] == 0.0
+    assert stats["error_rate"] == 0.0


### PR DESCRIPTION
## Summary
- add `channel_utils` with helpers for creating channels and default stats
- refactor channel managers to use shared helpers and remove duplication
- test channel utility functions

## Testing
- `pytest tests/communication/test_channel_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b03dadefc483299a7eeb8659bb85fb