### PR TITLE
refactor: centralize frontend mock helpers

### DIFF
--- a/src/web/frontend/__init__.py
+++ b/src/web/frontend/__init__.py
@@ -45,7 +45,7 @@ from .frontend_testing import (
     TestSuite,
     MockDataGenerator,
 )
-from .ui_interactions import (
+from .utils import (
     create_mock_component,
     create_mock_route,
     create_mock_navigation_state,

--- a/src/web/frontend/testing/ui_utils.py
+++ b/src/web/frontend/testing/ui_utils.py
@@ -1,54 +1,25 @@
 """Utilities for simulating frontend UI interactions in tests."""
-from datetime import datetime
 
-from ..frontend_app import UIComponent, create_component
+from ..frontend_app import UIComponent
 from ..frontend_router_config import RouteConfig, NavigationState
+from ..utils import (
+    create_mock_component as _create_mock_component,
+    create_mock_route as _create_mock_route,
+    create_mock_navigation_state as _create_mock_navigation_state,
+)
 
 
 class UIInteractionUtilities:
     """Create mock frontend entities for testing UI behaviour."""
 
-    def create_mock_component(
-        self, component_type: str = "TestComponent"
-    ) -> UIComponent:
+    def create_mock_component(self, component_type: str = "TestComponent") -> UIComponent:
         """Return a mock :class:`UIComponent` instance."""
-        return create_component(
-            component_type,
-            {
-                "id": "test-id",
-                "className": "test-class",
-                "data-testid": "test-component",
-            },
-        )
+        return _create_mock_component(component_type)
 
     def create_mock_route(self, path: str = "/test") -> RouteConfig:
         """Return a mock :class:`RouteConfig` instance."""
-        return RouteConfig(
-            path=path,
-            name="test-route",
-            component="TestComponent",
-            props={"title": "Test Page"},
-            meta={"requiresAuth": False},
-            children=[],
-            guards=[],
-            middleware=[],
-            lazy_load=False,
-            cache=True,
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
-        )
+        return _create_mock_route(path)
 
     def create_mock_navigation_state(self) -> NavigationState:
         """Return a mock :class:`NavigationState` instance."""
-        return NavigationState(
-            current_route="/test",
-            previous_route="/",
-            route_params={"id": "123"},
-            query_params={"page": "1"},
-            navigation_history=["/", "/test"],
-            breadcrumbs=[
-                {"path": "/", "name": "Home"},
-                {"path": "/test", "name": "Test"},
-            ],
-            timestamp=datetime.now(),
-        )
+        return _create_mock_navigation_state()

--- a/src/web/frontend/ui_interactions.py
+++ b/src/web/frontend/ui_interactions.py
@@ -1,49 +1,13 @@
 """UI interaction utilities for frontend tests."""
 
-from datetime import datetime
+from .utils import (
+    create_mock_component,
+    create_mock_route,
+    create_mock_navigation_state,
+)
 
-from .frontend_app import UIComponent, create_component
-from .frontend_router_config import RouteConfig, NavigationState
-
-
-def create_mock_component(component_type: str = "TestComponent") -> UIComponent:
-    """Create a mock UI component for testing."""
-    return create_component(
-        component_type,
-        {
-            "id": "test-id",
-            "className": "test-class",
-            "data-testid": "test-component",
-        },
-    )
-
-
-def create_mock_route(path: str = "/test") -> RouteConfig:
-    """Create a mock route for testing."""
-    return RouteConfig(
-        path=path,
-        name="test-route",
-        component="TestComponent",
-        props={"title": "Test Page"},
-        meta={"requiresAuth": False},
-        children=[],
-        guards=[],
-        middleware=[],
-        lazy_load=False,
-        cache=True,
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-    )
-
-
-def create_mock_navigation_state() -> NavigationState:
-    """Create a mock navigation state for testing."""
-    return NavigationState(
-        current_route="/test",
-        previous_route="/",
-        route_params={"id": "123"},
-        query_params={"page": "1"},
-        navigation_history=["/", "/test"],
-        breadcrumbs=[{"path": "/", "name": "Home"}, {"path": "/test", "name": "Test"}],
-        timestamp=datetime.now(),
-    )
+__all__ = [
+    "create_mock_component",
+    "create_mock_route",
+    "create_mock_navigation_state",
+]

--- a/src/web/frontend/utils.py
+++ b/src/web/frontend/utils.py
@@ -1,0 +1,59 @@
+"""Utility functions for creating mock frontend components and state."""
+
+from datetime import datetime
+
+from .frontend_app import UIComponent, create_component
+from .frontend_router_config import RouteConfig, NavigationState
+
+
+def create_mock_component(component_type: str = "TestComponent") -> UIComponent:
+    """Create a mock UI component for testing."""
+    return create_component(
+        component_type,
+        {
+            "id": "test-id",
+            "className": "test-class",
+            "data-testid": "test-component",
+        },
+    )
+
+
+def create_mock_route(path: str = "/test") -> RouteConfig:
+    """Create a mock route configuration for testing."""
+    return RouteConfig(
+        path=path,
+        name="test-route",
+        component="TestComponent",
+        props={"title": "Test Page"},
+        meta={"requiresAuth": False},
+        children=[],
+        guards=[],
+        middleware=[],
+        lazy_load=False,
+        cache=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+def create_mock_navigation_state() -> NavigationState:
+    """Create a mock navigation state for testing."""
+    return NavigationState(
+        current_route="/test",
+        previous_route="/",
+        route_params={"id": "123"},
+        query_params={"page": "1"},
+        navigation_history=["/", "/test"],
+        breadcrumbs=[
+            {"path": "/", "name": "Home"},
+            {"path": "/test", "name": "Test"},
+        ],
+        timestamp=datetime.now(),
+    )
+
+
+__all__ = [
+    "create_mock_component",
+    "create_mock_route",
+    "create_mock_navigation_state",
+]

--- a/tests/web/frontend/conftest.py
+++ b/tests/web/frontend/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from src.web.frontend.frontend_testing import FrontendTestRunner, MockDataGenerator
 from src.web.frontend.frontend_app import FrontendAppFactory
 from src.web.frontend.frontend_router import create_router_with_default_routes
-from src.web.frontend.ui_interactions import (
+from src.web.frontend.utils import (
     create_mock_component,
     create_mock_route,
     create_mock_navigation_state,

--- a/tests/web/frontend/test_utils.py
+++ b/tests/web/frontend/test_utils.py
@@ -1,0 +1,19 @@
+from src.web.frontend import utils
+
+
+def test_create_mock_component_util():
+    component = utils.create_mock_component("SampleComponent")
+    assert component.type == "SampleComponent"
+    assert component.props["id"] == "test-id"
+
+
+def test_create_mock_route_util():
+    route = utils.create_mock_route("/sample")
+    assert route.path == "/sample"
+    assert route.component == "TestComponent"
+
+
+def test_create_mock_navigation_state_util():
+    state = utils.create_mock_navigation_state()
+    assert state.current_route == "/test"
+    assert state.previous_route == "/"


### PR DESCRIPTION
## Summary
- add shared frontend mock helpers for components, routes and navigation
- update UI interaction utilities to use the new helpers
- test frontend utilities

## Testing
- `pytest tests/web/frontend tests/unit/frontend/test_frontend_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b03daffb30832997ec8b52dee7bc40