### PR TITLE
refactor: centralize test suite execution

### DIFF
--- a/src/automation/__init__.py
+++ b/src/automation/__init__.py
@@ -1,0 +1,3 @@
+"""Automation utilities package."""
+
+__all__ = ["execute_test_suite"]

--- a/src/automation/common.py
+++ b/src/automation/common.py
@@ -1,0 +1,30 @@
+"""Common automation orchestration utilities."""
+
+import unittest
+from typing import Dict, Type
+
+
+def execute_test_suite(
+    suite_class: Type[unittest.TestCase], verbosity: int = 1
+) -> Dict[str, float]:
+    """Run a unittest TestCase and return summary metrics.
+
+    Args:
+        suite_class: TestCase class to execute.
+        verbosity: Verbosity level for TextTestRunner.
+
+    Returns:
+        Dictionary with total tests, failures, errors, and success rate.
+    """
+    suite = unittest.TestLoader().loadTestsFromTestCase(suite_class)
+    result = unittest.TextTestRunner(verbosity=verbosity).run(suite)
+    failures = len(result.failures)
+    errors = len(result.errors)
+    total = result.testsRun
+    success = ((total - failures - errors) / total * 100) if total > 0 else 0
+    return {
+        "total_tests": total,
+        "failures": failures,
+        "errors": errors,
+        "success_rate": success,
+    }

--- a/src/services/master_v2_test_orchestrator.py
+++ b/src/services/master_v2_test_orchestrator.py
@@ -7,7 +7,6 @@ Target: 300 LOC, Maximum: 350 LOC.
 Focus: Test orchestration, enterprise quality validation, comprehensive reporting.
 """
 
-import unittest
 import time
 import json
 import sys
@@ -20,6 +19,8 @@ from unittest.mock import Mock, patch
 
 # Add parent directory to path for imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from automation.common import execute_test_suite
 
 # Import test suites for orchestration
 try:
@@ -63,34 +64,17 @@ class MasterV2TestOrchestrator:
         print(f"🚀 Running {suite_name.upper()} Test Suite...")
 
         try:
-            # Create test suite
-            suite = unittest.TestLoader().loadTestsFromTestCase(suite_class)
-
-            # Run tests
-            runner = unittest.TextTestRunner(verbosity=1)
-            result = runner.run(suite)
-
-            # Store results
-            self.test_results[suite_name] = {
-                "total_tests": result.testsRun,
-                "failures": len(result.failures),
-                "errors": len(result.errors),
-                "success_rate": (
-                    (result.testsRun - len(result.failures) - len(result.errors))
-                    / result.testsRun
-                    * 100
-                )
-                if result.testsRun > 0
-                else 0,
-            }
-
-            print(f"✅ {suite_name.upper()} Test Suite completed!")
+            summary = execute_test_suite(suite_class)
+            self.test_results[suite_name] = summary
+            success = summary["failures"] == 0 and summary["errors"] == 0
+            if success:
+                print(f"✅ {suite_name.upper()} Test Suite completed!")
+            else:
+                print(f"⚠️  {suite_name.upper()} Test Suite completed with issues")
             print(
-                f"   Tests: {result.testsRun}, Success Rate: {self.test_results[suite_name]['success_rate']:.1f}%"
+                f"   Tests: {summary['total_tests']}, Success Rate: {summary['success_rate']:.1f}%"
             )
-
-            return True
-
+            return success
         except Exception as e:
             print(f"❌ {suite_name.upper()} Test Suite failed: {e}")
             self.test_results[suite_name] = {


### PR DESCRIPTION
## Summary
- add shared `execute_test_suite` helper under `automation/common.py`
- reuse shared test execution in master orchestrator and runner modules
- simplify test runner mock fallback structure

## Testing
- `pre-commit run --files src/automation/common.py src/automation/__init__.py src/services/master_v2_test_orchestrator.py src/services/master_v2_test_runner.py` *(fails: ModuleNotFoundError: No module named 'src')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b03db123308329877900730fafc3e1