### PR TITLE
refactor: organize baseline metrics utilities by domain

### DIFF
--- a/src/core/baseline/__init__.py
+++ b/src/core/baseline/__init__.py
@@ -5,5 +5,19 @@ Responsibilities:
 """
 
 from .measurements import RefactoringBaselineMeasurements
+from .metrics import (
+    average_latency,
+    max_latency,
+    min_latency,
+    calculate_throughput,
+    calculate_error_rate,
+)
 
-__all__ = ["RefactoringBaselineMeasurements"]
+__all__ = [
+    "RefactoringBaselineMeasurements",
+    "average_latency",
+    "max_latency",
+    "min_latency",
+    "calculate_throughput",
+    "calculate_error_rate",
+]

--- a/src/core/baseline/error_rate_metrics.py
+++ b/src/core/baseline/error_rate_metrics.py
@@ -1,0 +1,14 @@
+"""Error-rate measurement utilities."""
+from typing import Union
+
+Number = Union[int, float]
+
+
+def calculate_error_rate(errors: Number, total_operations: Number) -> float:
+    """Return the error rate as a floating point ratio.
+
+    Returns 0.0 when *total_operations* is zero to avoid division errors.
+    """
+    if total_operations == 0:
+        return 0.0
+    return float(errors) / float(total_operations)

--- a/src/core/baseline/latency_metrics.py
+++ b/src/core/baseline/latency_metrics.py
@@ -1,0 +1,26 @@
+"""Latency measurement utilities.
+
+Provides basic statistical helpers for latency samples.
+"""
+from statistics import mean
+from typing import Sequence
+
+
+def average_latency(samples: Sequence[float]) -> float:
+    """Return the average latency from a sequence of samples.
+
+    Returns 0.0 when *samples* is empty to avoid ZeroDivisionError.
+    """
+    if not samples:
+        return 0.0
+    return mean(samples)
+
+
+def max_latency(samples: Sequence[float]) -> float:
+    """Return the maximum latency value or 0.0 for empty input."""
+    return max(samples) if samples else 0.0
+
+
+def min_latency(samples: Sequence[float]) -> float:
+    """Return the minimum latency value or 0.0 for empty input."""
+    return min(samples) if samples else 0.0

--- a/src/core/baseline/metrics.py
+++ b/src/core/baseline/metrics.py
@@ -1,0 +1,15 @@
+"""Public API for baseline measurement utilities.
+
+This module re-exports domain specific helpers for easier consumption.
+"""
+from .latency_metrics import average_latency, max_latency, min_latency
+from .throughput_metrics import calculate_throughput
+from .error_rate_metrics import calculate_error_rate
+
+__all__ = [
+    "average_latency",
+    "max_latency",
+    "min_latency",
+    "calculate_throughput",
+    "calculate_error_rate",
+]

--- a/src/core/baseline/throughput_metrics.py
+++ b/src/core/baseline/throughput_metrics.py
@@ -1,0 +1,14 @@
+"""Throughput measurement utilities."""
+from typing import Union
+
+Number = Union[int, float]
+
+
+def calculate_throughput(total_work: Number, duration_seconds: Number) -> float:
+    """Calculate throughput as work per second.
+
+    Returns 0.0 when *duration_seconds* is zero to avoid division errors.
+    """
+    if duration_seconds == 0:
+        return 0.0
+    return float(total_work) / float(duration_seconds)


### PR DESCRIPTION
## Summary
- add latency, throughput, and error-rate metric helpers
- provide a wrapper module for a clean baseline metrics API
- expose new helpers in baseline package

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*

------
https://chatgpt.com/codex/tasks/task_e_68b0675ee1c88329821be44493810070