### PR TITLE
Refactor health report processing into modular components

### DIFF
--- a/scripts/analyze_health_reports.py
+++ b/scripts/analyze_health_reports.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Generate basic analytics from stored health reports."""
+from __future__ import annotations
+
+from src.monitoring.data_acquisition import load_health_reports
+from src.monitoring.metrics import average_health_score, status_counts
+from src.monitoring.visualization import plot_status_distribution
+
+
+def main() -> None:
+    reports = load_health_reports()
+    if not reports:
+        print("No health reports found.")
+        return
+
+    counts = status_counts(reports)
+    avg_score = average_health_score(reports)
+    chart_path = plot_status_distribution(counts)
+
+    print(f"Average health score: {avg_score:.2f}")
+    print(f"Status distribution chart saved to: {chart_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,10 @@
+"""Centralized constants for health monitoring modules."""
+from pathlib import Path
+
+# Repository root (two levels up from this file)
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+# Directories used by monitoring utilities
+HEALTH_REPORTS_DIR = ROOT_DIR / "health_reports"
+HEALTH_CHARTS_DIR = ROOT_DIR / "health_charts"
+MONITORING_DIR = ROOT_DIR / "agent_workspaces" / "monitoring"

--- a/src/monitoring/__init__.py
+++ b/src/monitoring/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for health report processing and visualization."""

--- a/src/monitoring/data_acquisition.py
+++ b/src/monitoring/data_acquisition.py
@@ -1,0 +1,29 @@
+"""Data loading utilities for health reports."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..constants import HEALTH_REPORTS_DIR
+
+
+def load_health_reports(directory: Path | None = None) -> List[Dict[str, Any]]:
+    """Load all health report JSON files.
+
+    Args:
+        directory: Optional override for the reports directory.
+
+    Returns:
+        List of report dictionaries loaded from JSON files.
+    """
+    reports_dir = directory or HEALTH_REPORTS_DIR
+    reports: List[Dict[str, Any]] = []
+
+    for path in sorted(reports_dir.glob("health_report_daily_summary_*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                reports.append(json.load(handle))
+        except json.JSONDecodeError:
+            continue
+    return reports

--- a/src/monitoring/metrics.py
+++ b/src/monitoring/metrics.py
@@ -1,0 +1,24 @@
+"""Metric calculation utilities for health reports."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def average_health_score(reports: List[Dict[str, Any]]) -> float:
+    """Compute the average health score from all reports."""
+    scores = [r.get("system_health", {}).get("health_score") for r in reports]
+    numeric_scores = [s for s in scores if isinstance(s, (int, float))]
+    if not numeric_scores:
+        return 0.0
+    return sum(numeric_scores) / len(numeric_scores)
+
+
+def status_counts(reports: List[Dict[str, Any]]) -> Dict[str, int]:
+    """Count occurrences of agent statuses across reports."""
+    counts: Dict[str, int] = {}
+    for report in reports:
+        agent_status = report.get("agent_status", {})
+        for status in agent_status.values():
+            state = status.get("status", "unknown")
+            counts[state] = counts.get(state, 0) + 1
+    return counts

--- a/src/monitoring/visualization.py
+++ b/src/monitoring/visualization.py
@@ -1,0 +1,39 @@
+"""Visualization helpers for health metrics."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import matplotlib.pyplot as plt
+
+from ..constants import HEALTH_CHARTS_DIR
+
+
+def plot_status_distribution(
+    counts: Dict[str, int], *, directory: Path | None = None
+) -> Path:
+    """Create a bar chart for agent status distribution.
+
+    Args:
+        counts: Mapping of status labels to occurrence counts.
+        directory: Optional override for output directory.
+
+    Returns:
+        Path to the saved chart image.
+    """
+    output_dir = directory or HEALTH_CHARTS_DIR
+    output_dir.mkdir(exist_ok=True)
+
+    labels = list(counts.keys())
+    values = list(counts.values())
+
+    plt.figure()
+    plt.bar(labels, values)
+    plt.title("Agent Status Distribution")
+    plt.xlabel("Status")
+    plt.ylabel("Count")
+
+    output_path = output_dir / "status_distribution.png"
+    plt.savefig(output_path)
+    plt.close()
+    return output_path

--- a/src/services/status_monitor_service.py
+++ b/src/services/status_monitor_service.py
@@ -7,16 +7,14 @@ Agent status tracking and performance monitoring service.
 Follows V2 standards: ≤ 200 LOC, SRP, OOP design, CLI interface.
 """
 
-import json
-import logging
-
-from src.utils.stability_improvements import stability_manager, safe_import
-from pathlib import Path
-from datetime import datetime, timedelta
-from typing import Dict, List, Any, Optional
-from dataclasses import dataclass
 import argparse
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
 
+from src.constants import MONITORING_DIR
 from src.services.performance_analysis import analyze_agent_activity
 
 
@@ -59,7 +57,7 @@ class StatusMonitorService:
     - Status reporting and alerts
     """
 
-    def __init__(self, monitoring_dir: str = "agent_workspaces/monitoring"):
+    def __init__(self, monitoring_dir: Path = MONITORING_DIR):
         """Initialize Status Monitor Service."""
         self.monitoring_dir = Path(monitoring_dir)
         self.monitoring_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- centralize shared directories in `constants.py`
- add dedicated modules for data acquisition, metrics, and visualization
- streamline status monitor to reuse constants and add CLI analytics script

## Testing
- `PYTHONPATH=. pre-commit run --files src/constants.py src/monitoring/__init__.py src/monitoring/data_acquisition.py src/monitoring/metrics.py src/monitoring/visualization.py src/services/status_monitor_service.py scripts/analyze_health_reports.py` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*

------
https://chatgpt.com/codex/tasks/task_e_68b08c1ff9608329a9ee6f52708e7964