### PR TITLE
refactor: modularize portal API

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -1,0 +1,9 @@
+"""Application-wide configuration settings (SSOT)."""
+
+from __future__ import annotations
+
+import os
+
+# Shared configuration values
+SECRET_KEY = os.getenv("PORTAL_SECRET_KEY", "change-me")
+DEBUG = os.getenv("PORTAL_DEBUG", "false").lower() == "true"

--- a/src/web/portal/unified/flask_app.py
+++ b/src/web/portal/unified/flask_app.py
@@ -11,19 +11,20 @@ License: MIT
 
 import logging
 
-from src.utils.stability_improvements import stability_manager, safe_import
-from typing import Dict, Any, Optional
-from flask import Flask, render_template, jsonify, request, session, redirect, url_for
+from typing import Optional
+from flask import Flask, request
 from flask_socketio import SocketIO, emit, join_room, leave_room
 
+from src.settings import SECRET_KEY
 from .portal_core import UnifiedPortal
-from .data_models import PortalConfig, AgentPortalInfo, PortalSection
+from .data_models import PortalConfig
+from .routes import register_routes
 
 
 class FlaskPortalApp:
     """
     Flask-based portal web application
-    
+
     Single responsibility: Flask web interface for portal.
     Follows V2 standards: OOP, SRP, clean production-grade code.
     """
@@ -32,159 +33,71 @@ class FlaskPortalApp:
         """Initialize Flask portal app"""
         self.portal = portal
         self.config = config or portal.config
-        
+
         # Initialize Flask app
         self.app = Flask(__name__)
-        self.app.secret_key = 'your-secret-key-here'  # Should be configurable
-        
+        self.app.secret_key = SECRET_KEY
+
         # Initialize SocketIO for real-time features
         if self.config.enable_websockets:
             self.socketio = SocketIO(self.app, cors_allowed_origins="*")
         else:
             self.socketio = None
-        
+
         self.logger = logging.getLogger(f"{__name__}.FlaskPortalApp")
-        self._setup_routes()
+        register_routes(self.app, self.portal)
         self.logger.info("Flask portal app initialized")
-
-    def _setup_routes(self):
-        """Setup Flask routes"""
-        
-        @self.app.route('/')
-        def index():
-            """Main portal page"""
-            return render_template('portal/index.html', 
-                                title=self.config.title,
-                                version=self.config.version)
-
-        @self.app.route('/api/status')
-        def api_status():
-            """Get portal status"""
-            return jsonify(self.portal.get_portal_status())
-
-        @self.app.route('/api/agents')
-        def api_agents():
-            """Get all agents"""
-            agents = [agent.to_dict() for agent in self.portal.agents.values()]
-            return jsonify({'agents': agents})
-
-        @self.app.route('/api/agents/<agent_id>')
-        def api_agent_detail(agent_id):
-            """Get specific agent details"""
-            agent = self.portal.get_agent_info(agent_id)
-            if agent:
-                return jsonify(agent.to_dict())
-            return jsonify({'error': 'Agent not found'}), 404
-
-        @self.app.route('/api/navigation')
-        def api_navigation():
-            """Get navigation state"""
-            return jsonify(self.portal.get_navigation_state())
-
-        @self.app.route('/api/navigation/<section>')
-        def api_navigate_to(section):
-            """Navigate to specific section"""
-            try:
-                portal_section = PortalSection(section)
-                self.portal.navigate_to_section(portal_section)
-                return jsonify({'success': True, 'section': section})
-            except ValueError:
-                return jsonify({'error': 'Invalid section'}), 400
-
-        @self.app.route('/api/sessions', methods=['POST'])
-        def api_create_session():
-            """Create new session"""
-            try:
-                data = request.get_json()
-                user_id = data.get('user_id')
-                metadata = data.get('metadata', {})
-                
-                if not user_id:
-                    return jsonify({'error': 'user_id required'}), 400
-                
-                session_id = self.portal.create_session(user_id, metadata)
-                return jsonify({'session_id': session_id, 'success': True})
-                
-            except Exception as e:
-                self.logger.error(f"Session creation failed: {e}")
-                return jsonify({'error': 'Session creation failed'}), 500
-
-        @self.app.route('/api/sessions/<session_id>', methods=['GET'])
-        def api_session_status(session_id):
-            """Get session status"""
-            is_valid = self.portal.validate_session(session_id)
-            return jsonify({'valid': is_valid, 'session_id': session_id})
-
-        @self.app.route('/api/sessions/<session_id>', methods=['DELETE'])
-        def api_terminate_session(session_id):
-            """Terminate session"""
-            success = self.portal.terminate_session(session_id)
-            return jsonify({'success': success, 'session_id': session_id})
-
-        @self.app.route('/api/statistics')
-        def api_statistics():
-            """Get portal statistics"""
-            return jsonify(self.portal.get_agent_statistics())
-
-        # Error handlers
-        @self.app.errorhandler(404)
-        def not_found(error):
-            return jsonify({'error': 'Not found'}), 404
-
-        @self.app.errorhandler(500)
-        def internal_error(error):
-            return jsonify({'error': 'Internal server error'}), 500
 
     def _setup_socketio_events(self):
         """Setup SocketIO event handlers"""
         if not self.socketio:
             return
-        
-        @self.socketio.on('connect')
+
+        @self.socketio.on("connect")
         def handle_connect():
             """Handle client connection"""
             connection_id = request.sid
             self.portal.add_connection(connection_id)
             self.logger.info(f"Client connected: {connection_id}")
-            emit('connected', {'status': 'connected', 'connection_id': connection_id})
+            emit("connected", {"status": "connected", "connection_id": connection_id})
 
-        @self.socketio.on('disconnect')
+        @self.socketio.on("disconnect")
         def handle_disconnect():
             """Handle client disconnection"""
             connection_id = request.sid
             self.portal.remove_connection(connection_id)
             self.logger.info(f"Client disconnected: {connection_id}")
 
-        @self.socketio.on('join_room')
+        @self.socketio.on("join_room")
         def handle_join_room(data):
             """Handle room joining"""
-            room = data.get('room')
+            room = data.get("room")
             if room:
                 join_room(room)
-                emit('room_joined', {'room': room}, room=room)
+                emit("room_joined", {"room": room}, room=room)
 
-        @self.socketio.on('leave_room')
+        @self.socketio.on("leave_room")
         def handle_leave_room(data):
             """Handle room leaving"""
-            room = data.get('room')
+            room = data.get("room")
             if room:
                 leave_room(room)
-                emit('room_left', {'room': room}, room=room)
+                emit("room_left", {"room": room}, room=room)
 
-        @self.socketio.on('portal_update')
+        @self.socketio.on("portal_update")
         def handle_portal_update(data):
             """Handle portal update requests"""
-            update_type = data.get('type')
-            if update_type == 'status':
-                emit('portal_status', self.portal.get_portal_status())
-            elif update_type == 'agents':
+            update_type = data.get("type")
+            if update_type == "status":
+                emit("portal_status", self.portal.get_portal_status())
+            elif update_type == "agents":
                 agents = [agent.to_dict() for agent in self.portal.agents.values()]
-                emit('agents_update', {'agents': agents})
+                emit("agents_update", {"agents": agents})
 
-    def run(self, host: str = '0.0.0.0', port: int = 5000, debug: bool = None):
+    def run(self, host: str = "0.0.0.0", port: int = 5000, debug: bool = None):
         """Run the Flask portal app"""
         debug_mode = debug if debug is not None else self.config.debug_mode
-        
+
         if self.config.enable_websockets:
             self._setup_socketio_events()
             self.socketio.run(self.app, host=host, port=port, debug=debug_mode)
@@ -198,4 +111,3 @@ class FlaskPortalApp:
     def get_socketio(self) -> Optional[SocketIO]:
         """Get the SocketIO instance if available"""
         return self.socketio
-

--- a/src/web/portal/unified/responses.py
+++ b/src/web/portal/unified/responses.py
@@ -1,0 +1,16 @@
+"""Response formatting helpers for the portal API."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+from flask import jsonify
+
+
+def json_response(data: Any, status: int = 200) -> Tuple[Any, int]:
+    """Return a JSON response with status code."""
+    return jsonify(data), status
+
+
+def error_response(message: str, status: int = 400) -> Tuple[Any, int]:
+    """Return a standardized error response."""
+    return jsonify({"error": message}), status

--- a/src/web/portal/unified/routes.py
+++ b/src/web/portal/unified/routes.py
@@ -1,0 +1,92 @@
+"""API route registrations for the portal Flask app."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from flask import Flask, render_template, request
+
+from . import services
+from .responses import json_response, error_response
+
+
+def register_routes(app: Flask, portal) -> None:
+    """Register Flask routes for the portal."""
+
+    @app.route("/")
+    def index() -> Any:
+        """Main portal page."""
+        return render_template(
+            "portal/index.html",
+            title=portal.config.title,
+            version=portal.config.version,
+        )
+
+    @app.route("/api/status")
+    def api_status() -> Any:
+        """Get portal status."""
+        return json_response(services.get_status(portal))
+
+    @app.route("/api/agents")
+    def api_agents() -> Any:
+        """Get all agents."""
+        return json_response({"agents": services.get_agents(portal)})
+
+    @app.route("/api/agents/<agent_id>")
+    def api_agent_detail(agent_id: str) -> Any:
+        """Get specific agent details."""
+        agent = services.get_agent(portal, agent_id)
+        if agent:
+            return json_response(agent)
+        return error_response("Agent not found", 404)
+
+    @app.route("/api/navigation")
+    def api_navigation() -> Any:
+        """Get navigation state."""
+        return json_response(services.get_navigation(portal))
+
+    @app.route("/api/navigation/<section>")
+    def api_navigate_to(section: str) -> Any:
+        """Navigate to a portal section."""
+        if services.navigate_to(portal, section):
+            return json_response({"success": True, "section": section})
+        return error_response("Invalid section", 400)
+
+    @app.route("/api/sessions", methods=["POST"])
+    def api_create_session() -> Any:
+        """Create a new session."""
+        data: Dict[str, Any] = request.get_json() or {}
+        user_id = data.get("user_id")
+        metadata = data.get("metadata", {})
+        if not user_id:
+            return error_response("user_id required", 400)
+        try:
+            session_id = services.create_session(portal, user_id, metadata)
+            return json_response({"session_id": session_id, "success": True})
+        except Exception:  # noqa: BLE001
+            return error_response("Session creation failed", 500)
+
+    @app.route("/api/sessions/<session_id>", methods=["GET"])
+    def api_session_status(session_id: str) -> Any:
+        """Get session status."""
+        valid = services.validate_session(portal, session_id)
+        return json_response({"valid": valid, "session_id": session_id})
+
+    @app.route("/api/sessions/<session_id>", methods=["DELETE"])
+    def api_terminate_session(session_id: str) -> Any:
+        """Terminate a session."""
+        success = services.terminate_session(portal, session_id)
+        return json_response({"success": success, "session_id": session_id})
+
+    @app.route("/api/statistics")
+    def api_statistics() -> Any:
+        """Get portal statistics."""
+        return json_response(services.get_statistics(portal))
+
+    @app.errorhandler(404)
+    def not_found(_):  # type: ignore[override]
+        return error_response("Not found", 404)
+
+    @app.errorhandler(500)
+    def internal_error(_):  # type: ignore[override]
+        return error_response("Internal server error", 500)

--- a/src/web/portal/unified/services.py
+++ b/src/web/portal/unified/services.py
@@ -1,0 +1,61 @@
+"""Data service layer for portal API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .portal_core import UnifiedPortal
+from .enums import PortalSection
+
+
+def get_status(portal: UnifiedPortal) -> Dict[str, Any]:
+    """Return portal status information."""
+    return portal.get_portal_status()
+
+
+def get_agents(portal: UnifiedPortal) -> List[Dict[str, Any]]:
+    """Return all agents as a list of dictionaries."""
+    return [agent.to_dict() for agent in portal.agents.values()]
+
+
+def get_agent(portal: UnifiedPortal, agent_id: str) -> Optional[Dict[str, Any]]:
+    """Return a specific agent or None if not found."""
+    agent = portal.get_agent_info(agent_id)
+    return agent.to_dict() if agent else None
+
+
+def get_navigation(portal: UnifiedPortal) -> Dict[str, Any]:
+    """Return navigation state."""
+    return portal.get_navigation_state()
+
+
+def navigate_to(portal: UnifiedPortal, section: str) -> bool:
+    """Navigate to a portal section."""
+    try:
+        portal_section = PortalSection(section)
+        portal.navigate_to_section(portal_section)
+        return True
+    except ValueError:
+        return False
+
+
+def create_session(
+    portal: UnifiedPortal, user_id: str, metadata: Dict[str, Any]
+) -> str:
+    """Create a new session and return its ID."""
+    return portal.create_session(user_id, metadata)
+
+
+def validate_session(portal: UnifiedPortal, session_id: str) -> bool:
+    """Validate a session ID."""
+    return portal.validate_session(session_id)
+
+
+def terminate_session(portal: UnifiedPortal, session_id: str) -> bool:
+    """Terminate a session by ID."""
+    return portal.terminate_session(session_id)
+
+
+def get_statistics(portal: UnifiedPortal) -> Dict[str, Any]:
+    """Return portal statistics."""
+    return portal.get_agent_statistics()


### PR DESCRIPTION
## Summary
- split portal API into routes, services, and response helper modules
- centralize shared config in settings.py
- streamline FlaskPortalApp and apply formatting

## Testing
- `ruff check src/settings.py src/web/portal/unified/responses.py src/web/portal/unified/services.py src/web/portal/unified/routes.py src/web/portal/unified/flask_app.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*


------
https://chatgpt.com/codex/tasks/task_e_68b08c0abe248329a33f96b4ac4daccc