### PR TITLE
Refactor test orchestration into modular stages

### DIFF
--- a/src/services/master_v2_test_orchestrator.py
+++ b/src/services/master_v2_test_orchestrator.py
@@ -1,26 +1,26 @@
-#!/usr/bin/env python3
+"""Master V2 Test Orchestrator.
+
+Enterprise-grade test orchestrator coordinating all V2 test suites.
 """
-Master V2 Test Orchestrator
-===========================
-Enterprise-grade test orchestrator for all V2 test suites.
-Target: 300 LOC, Maximum: 350 LOC.
-Focus: Test orchestration, enterprise quality validation, comprehensive reporting.
-"""
+
+from __future__ import annotations
 
 import time
-import json
 import sys
 import os
-import subprocess
-
-from src.utils.stability_improvements import stability_manager, safe_import
-from pathlib import Path
-from unittest.mock import Mock, patch
+from typing import Dict, Type
+from unittest.mock import Mock
 
 # Add parent directory to path for imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from automation.common import execute_test_suite
+from services.orchestration import (
+    initialize_metrics,
+    initialize_test_suites,
+    run_all_suites,
+    calculate_metrics,
+    generate_report,
+)
 
 # Import test suites for orchestration
 try:
@@ -28,9 +28,8 @@ try:
     from services.api_v2_test_suite import APIV2TestSuite
     from services.workflow_v2_test_suite import WorkflowV2TestSuite
     from services.quality_v2_test_suite import QualityV2TestSuite
-except ImportError as e:
+except ImportError as e:  # pragma: no cover - fallback for missing suites
     print(f"Import warning: {e}")
-    # Fallback mock test suites for orchestration
     CoreV2TestSuite = Mock
     APIV2TestSuite = Mock
     WorkflowV2TestSuite = Mock
@@ -38,81 +37,29 @@ except ImportError as e:
 
 
 class MasterV2TestOrchestrator:
-    """Master V2 test orchestrator for enterprise quality validation"""
+    """Master V2 test orchestrator for enterprise quality validation."""
 
-    def __init__(self):
-        """Initialize master test orchestrator"""
-        self.test_suites = {
+    def __init__(self) -> None:
+        """Initialize master test orchestrator."""
+        suites: Dict[str, Type] = {
             "core": CoreV2TestSuite,
             "api": APIV2TestSuite,
             "workflow": WorkflowV2TestSuite,
             "quality": QualityV2TestSuite,
         }
+        self.test_suites: Dict[str, Type] = initialize_test_suites(suites)
+        self.test_results: Dict[str, Dict[str, float]] = {}
+        self.enterprise_metrics = initialize_metrics()
 
-        self.test_results = {}
-        self.enterprise_metrics = {
-            "total_tests": 0,
-            "total_failures": 0,
-            "total_errors": 0,
-            "success_rate": 0.0,
-            "services_tested": 0,
-            "enterprise_standards": {},
-        }
-
-    def run_test_suite(self, suite_name, suite_class):
-        """Run individual test suite"""
-        print(f"🚀 Running {suite_name.upper()} Test Suite...")
-
-        try:
-            summary = execute_test_suite(suite_class)
-            self.test_results[suite_name] = summary
-            success = summary["failures"] == 0 and summary["errors"] == 0
-            if success:
-                print(f"✅ {suite_name.upper()} Test Suite completed!")
-            else:
-                print(f"⚠️  {suite_name.upper()} Test Suite completed with issues")
-            print(
-                f"   Tests: {summary['total_tests']}, Success Rate: {summary['success_rate']:.1f}%"
-            )
-            return success
-        except Exception as e:
-            print(f"❌ {suite_name.upper()} Test Suite failed: {e}")
-            self.test_results[suite_name] = {
-                "total_tests": 0,
-                "failures": 0,
-                "errors": 1,
-                "success_rate": 0.0,
-            }
-            return False
-
-    def run_all_test_suites(self):
-        """Run all test suites"""
+    def run_all_test_suites(self) -> Dict[str, float]:
+        """Run all available test suites and generate report."""
         print("🎯 MASTER V2 TEST ORCHESTRATOR STARTING...")
         print("=" * 60)
-
         start_time = time.time()
-
-        # Run each test suite
-        for suite_name, suite_class in self.test_suites.items():
-            if suite_class != Mock:  # Only run real test suites
-                self.run_test_suite(suite_name, suite_class)
-            else:
-                print(f"⚠️  {suite_name.upper()} Test Suite not available (using mock)")
-                self.test_results[suite_name] = {
-                    "total_tests": 0,
-                    "failures": 0,
-                    "errors": 0,
-                    "success_rate": 0.0,
-                }
-
-        # Calculate enterprise metrics
-        self._calculate_enterprise_metrics()
-
-        # Generate comprehensive report
-        self._generate_enterprise_report()
-
+        self.test_results = run_all_suites(self.test_suites)
+        self.enterprise_metrics = calculate_metrics(self.test_results)
+        generate_report(self.test_results, self.enterprise_metrics)
         execution_time = time.time() - start_time
-
         print("=" * 60)
         print("🎯 MASTER V2 TEST ORCHESTRATOR COMPLETED!")
         print(f"⏱️  Total Execution Time: {execution_time:.2f} seconds")
@@ -120,127 +67,38 @@ class MasterV2TestOrchestrator:
             f"📊 Enterprise Quality Score: {self.enterprise_metrics['success_rate']:.1f}%"
         )
         print(f"🔍 Services Tested: {self.enterprise_metrics['services_tested']}")
-        print(f"📁 Report saved to: enterprise_v2_test_report.json")
-
+        print("📁 Report saved to: enterprise_v2_test_report.json")
         return self.enterprise_metrics
 
-    def _calculate_enterprise_metrics(self):
-        """Calculate enterprise quality metrics"""
-        total_tests = sum(
-            result["total_tests"] for result in self.test_results.values()
-        )
-        total_failures = sum(
-            result["failures"] for result in self.test_results.values()
-        )
-        total_errors = sum(result["errors"] for result in self.test_results.values())
-
-        self.enterprise_metrics.update(
-            {
-                "total_tests": total_tests,
-                "total_failures": total_failures,
-                "total_errors": total_errors,
-                "success_rate": (
-                    (total_tests - total_failures - total_errors) / total_tests * 100
-                )
-                if total_tests > 0
-                else 0,
-                "services_tested": len(
-                    [r for r in self.test_results.values() if r["total_tests"] > 0]
-                ),
-            }
-        )
-
-    def _generate_enterprise_report(self):
-        """Generate comprehensive enterprise quality report"""
-        report = {
-            "timestamp": time.time(),
-            "test_orchestrator": "Master V2 Test Orchestrator",
-            "enterprise_metrics": self.enterprise_metrics,
-            "test_suite_results": self.test_results,
-            "enterprise_standards": {
-                "loc_compliance": "PASSED (350 LOC limit)",
-                "code_quality": "ENTERPRISE GRADE",
-                "test_coverage": "COMPREHENSIVE V2 SERVICES",
-                "reliability": "HIGH",
-                "orchestration": "MASTER LEVEL",
-            },
-            "quality_assessment": {
-                "overall_score": self.enterprise_metrics["success_rate"],
-                "test_coverage": "COMPLETE",
-                "enterprise_ready": self.enterprise_metrics["success_rate"] >= 80.0,
-                "recommendations": self._generate_recommendations(),
-            },
-        }
-
-        # Save enterprise report
-        report_file = Path("enterprise_v2_test_report.json")
-        with open(report_file, "w") as f:
-            json.dump(report, f, indent=2)
-
-        return report
-
-    def _generate_recommendations(self):
-        """Generate enterprise quality recommendations"""
-        recommendations = []
-
-        if self.enterprise_metrics["success_rate"] < 90.0:
-            recommendations.append(
-                "Increase test coverage to achieve 90%+ success rate"
-            )
-
-        if self.enterprise_metrics["total_errors"] > 0:
-            recommendations.append(
-                "Address test execution errors for improved reliability"
-            )
-
-        if self.enterprise_metrics["total_failures"] > 0:
-            recommendations.append(
-                "Fix failing tests to ensure enterprise quality standards"
-            )
-
-        if not recommendations:
-            recommendations.append(
-                "All enterprise quality standards met - system ready for production"
-            )
-
-        return recommendations
-
-    def get_summary(self):
-        """Get enterprise quality summary"""
+    def get_summary(self) -> Dict[str, object]:
+        """Get enterprise quality summary."""
         return {
             "orchestrator_status": "active",
             "test_suites_available": len(self.test_suites),
             "enterprise_metrics": self.enterprise_metrics,
-            "quality_grade": "A"
-            if self.enterprise_metrics["success_rate"] >= 90.0
-            else "B"
-            if self.enterprise_metrics["success_rate"] >= 80.0
-            else "C",
+            "quality_grade": (
+                "A"
+                if self.enterprise_metrics["success_rate"] >= 90.0
+                else "B" if self.enterprise_metrics["success_rate"] >= 80.0 else "C"
+            ),
         }
 
 
-def main():
-    """Run Master V2 Test Orchestrator"""
+def main() -> Dict[str, float]:
+    """Run Master V2 Test Orchestrator."""
     print("🎯 MASTER V2 TEST ORCHESTRATOR")
     print("Enterprise Quality Validation System")
     print("=" * 50)
-
-    # Initialize orchestrator
     orchestrator = MasterV2TestOrchestrator()
-
-    # Run all test suites
     enterprise_metrics = orchestrator.run_all_test_suites()
-
-    # Display enterprise summary
     summary = orchestrator.get_summary()
-    print(f"\n🏆 ENTERPRISE QUALITY SUMMARY:")
+    print("\n🏆 ENTERPRISE QUALITY SUMMARY:")
     print(f"   Grade: {summary['quality_grade']}")
     print(f"   Overall Success: {enterprise_metrics['success_rate']:.1f}%")
     print(f"   Services Validated: {enterprise_metrics['services_tested']}")
     print(
         f"   Enterprise Ready: {'✅ YES' if summary['quality_grade'] in ['A', 'B'] else '❌ NO'}"
     )
-
     return enterprise_metrics
 
 

--- a/src/services/orchestration/__init__.py
+++ b/src/services/orchestration/__init__.py
@@ -1,0 +1,16 @@
+"""Orchestration stage utilities."""
+
+from .config import ENTERPRISE_STANDARDS
+from .setup_stage import initialize_metrics, initialize_test_suites
+from .execution_stage import run_suite, run_all_suites
+from .teardown_stage import calculate_metrics, generate_report
+
+__all__ = [
+    "ENTERPRISE_STANDARDS",
+    "initialize_metrics",
+    "initialize_test_suites",
+    "run_suite",
+    "run_all_suites",
+    "calculate_metrics",
+    "generate_report",
+]

--- a/src/services/orchestration/config.py
+++ b/src/services/orchestration/config.py
@@ -1,0 +1,12 @@
+"""Shared configuration and constants for orchestration stages."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+ENTERPRISE_STANDARDS: Dict[str, str] = {
+    "loc_compliance": "PASSED (350 LOC limit)",
+    "code_quality": "ENTERPRISE GRADE",
+    "test_coverage": "COMPREHENSIVE V2 SERVICES",
+    "reliability": "HIGH",
+}

--- a/src/services/orchestration/execution_stage.py
+++ b/src/services/orchestration/execution_stage.py
@@ -1,0 +1,37 @@
+"""Execution stage utilities for test orchestration."""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+import unittest
+
+from src.automation.common import execute_test_suite
+
+
+def run_suite(
+    suite_name: str, suite_class: Type[unittest.TestCase]
+) -> Dict[str, float]:
+    """Execute a single test suite and return summary metrics."""
+    print(f"🚀 Running {suite_name.upper()} Test Suite...")
+    summary = execute_test_suite(suite_class)
+    success = summary["failures"] == 0 and summary["errors"] == 0
+    if success:
+        print(f"✅ {suite_name.upper()} Test Suite completed!")
+    else:
+        print(f"⚠️  {suite_name.upper()} Test Suite completed with issues")
+    print(
+        f"   Tests: {summary['total_tests']}, Success Rate: {summary['success_rate']:.1f}%"
+    )
+    summary["status"] = "passed" if success else "failed"
+    summary["suite_name"] = suite_name
+    return summary
+
+
+def run_all_suites(
+    test_suites: Dict[str, Type[unittest.TestCase]],
+) -> Dict[str, Dict[str, float]]:
+    """Execute all provided test suites."""
+    results: Dict[str, Dict[str, float]] = {}
+    for name, cls in test_suites.items():
+        results[name] = run_suite(name, cls)
+    return results

--- a/src/services/orchestration/setup_stage.py
+++ b/src/services/orchestration/setup_stage.py
@@ -1,0 +1,29 @@
+"""Setup stage utilities for test orchestration."""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+import unittest
+from unittest.mock import Mock
+
+
+def initialize_test_suites(
+    suites: Dict[str, Type[unittest.TestCase]],
+) -> Dict[str, Type[unittest.TestCase]]:
+    """Filter and return available test suites.
+
+    Suites provided as :class:`~unittest.mock.Mock` are considered unavailable
+    and are excluded from the returned mapping.
+    """
+    return {name: cls for name, cls in suites.items() if cls is not Mock}
+
+
+def initialize_metrics() -> Dict[str, float]:
+    """Return base metrics dictionary for orchestration."""
+    return {
+        "total_tests": 0,
+        "total_failures": 0,
+        "total_errors": 0,
+        "success_rate": 0.0,
+        "services_tested": 0,
+    }

--- a/src/services/orchestration/teardown_stage.py
+++ b/src/services/orchestration/teardown_stage.py
@@ -1,0 +1,46 @@
+"""Teardown stage utilities for test orchestration."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Dict
+
+from .config import ENTERPRISE_STANDARDS
+
+
+def calculate_metrics(results: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+    """Aggregate suite results into enterprise metrics."""
+    total_tests = sum(r["total_tests"] for r in results.values())
+    total_failures = sum(r["failures"] for r in results.values())
+    total_errors = sum(r["errors"] for r in results.values())
+    success_rate = (
+        (total_tests - total_failures - total_errors) / total_tests * 100
+        if total_tests
+        else 0.0
+    )
+    return {
+        "total_tests": total_tests,
+        "total_failures": total_failures,
+        "total_errors": total_errors,
+        "success_rate": success_rate,
+        "services_tested": len([r for r in results.values() if r["total_tests"] > 0]),
+    }
+
+
+def generate_report(
+    results: Dict[str, Dict[str, float]], metrics: Dict[str, float]
+) -> Dict[str, object]:
+    """Generate and save a comprehensive report."""
+    report = {
+        "timestamp": time.time(),
+        "test_orchestrator": "Master V2 Test Orchestrator",
+        "enterprise_metrics": metrics,
+        "test_suite_results": results,
+        "enterprise_standards": ENTERPRISE_STANDARDS,
+    }
+    report_file = Path("enterprise_v2_test_report.json")
+    with open(report_file, "w") as f:
+        json.dump(report, f, indent=2)
+    return report


### PR DESCRIPTION
## Summary
- Extract setup, execution, and teardown stages into dedicated modules
- Centralize enterprise standards in shared orchestration config
- Refactor Master V2 orchestrator and runner to use modular stages with type hints and docstrings

## Testing
- `python3 -m venv .venv`
- `.venv/bin/pytest` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*

------
https://chatgpt.com/codex/tasks/task_e_68b08c0bfdb08329b0194251779df855