### PR TITLE
refactor: modularize dashboard metrics

### DIFF
--- a/src/services/dashboard_collectors.py
+++ b/src/services/dashboard_collectors.py
@@ -1,0 +1,22 @@
+"""Data collection module for dashboard metrics."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .dashboard_utils import TIMESTAMP_KEY, VALUE_KEY, current_timestamp
+
+
+class MetricsCollector:
+    """Collects metric data points."""
+
+    def __init__(self) -> None:
+        self.metrics: Dict[str, List[Dict[str, float]]] = {}
+
+    def record(self, name: str, value: float) -> None:
+        """Record a metric value with a timestamp."""
+        if name not in self.metrics:
+            self.metrics[name] = []
+        self.metrics[name].append(
+            {TIMESTAMP_KEY: current_timestamp(), VALUE_KEY: value}
+        )

--- a/src/services/dashboard_processing.py
+++ b/src/services/dashboard_processing.py
@@ -1,0 +1,17 @@
+"""Processing module for dashboard metrics."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Any
+
+from .dashboard_utils import TIMESTAMP_KEY, iso_timestamp
+
+
+def summarize_metrics(metrics: Dict[str, List[Dict[str, float]]]) -> Dict[str, Any]:
+    """Return summary statistics for collected metrics."""
+    total_metrics = sum(len(values) for values in metrics.values())
+    return {
+        "total_metrics": total_metrics,
+        "metrics_tracked": len(metrics),
+        TIMESTAMP_KEY: iso_timestamp(),
+    }

--- a/src/services/dashboard_renderer.py
+++ b/src/services/dashboard_renderer.py
@@ -1,0 +1,14 @@
+"""Dashboard rendering module."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+class DashboardRenderer:
+    """Render dashboard summaries to JSON."""
+
+    def render(self, summary: Dict[str, Any]) -> str:
+        """Return a JSON string for the dashboard summary."""
+        return json.dumps(summary, indent=2)

--- a/src/services/dashboard_utils.py
+++ b/src/services/dashboard_utils.py
@@ -1,0 +1,20 @@
+"""Utility functions and constants for dashboard modules."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+
+# Constants used across dashboard modules
+TIMESTAMP_KEY = "timestamp"
+VALUE_KEY = "value"
+
+
+def current_timestamp() -> float:
+    """Return the current time as a UNIX timestamp."""
+    return time.time()
+
+
+def iso_timestamp() -> str:
+    """Return the current time in ISO 8601 format."""
+    return datetime.now().isoformat()

--- a/src/services/metrics_dashboard_service.py
+++ b/src/services/metrics_dashboard_service.py
@@ -1,35 +1,37 @@
-#!/usr/bin/env python3
-"""
-Simple Metrics Dashboard Service for testing
-"""
+"""Simple Metrics Dashboard Service for testing"""
 
-import json
-import time
+from __future__ import annotations
 
-from src.utils.stability_improvements import stability_manager, safe_import
-from datetime import datetime
+from typing import Any, Dict
+
+from .dashboard_collectors import MetricsCollector
+from .dashboard_processing import summarize_metrics
+from .dashboard_renderer import DashboardRenderer
 
 
 class MetricsDashboardService:
-    def __init__(self):
-        self.metrics = {}
+    """Orchestrates metric collection, processing, and rendering."""
+
+    def __init__(self) -> None:
+        self.collector = MetricsCollector()
+        self.renderer = DashboardRenderer()
         print("Metrics Dashboard Service initialized")
 
-    def record_metric(self, name, value):
-        if name not in self.metrics:
-            self.metrics[name] = []
-        self.metrics[name].append({"timestamp": time.time(), "value": value})
+    def record_metric(self, name: str, value: float) -> None:
+        """Record a metric value."""
+        self.collector.record(name, value)
         print(f"Recorded metric {name}: {value}")
 
-    def get_summary(self):
-        return {
-            "total_metrics": sum(len(values) for values in self.metrics.values()),
-            "metrics_tracked": len(self.metrics),
-            "timestamp": datetime.now().isoformat(),
-        }
+    def get_summary(self) -> Dict[str, Any]:
+        """Return summarized metric information."""
+        return summarize_metrics(self.collector.metrics)
+
+    def render_summary(self) -> str:
+        """Render the summary as a JSON string."""
+        return self.renderer.render(self.get_summary())
 
 
-def main():
+def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Simple Metrics Dashboard Service")
@@ -48,8 +50,7 @@ def main():
         dashboard.record_metric("system.cpu", 45.2)
 
         # Show summary
-        summary = dashboard.get_summary()
-        print(f"\\nSummary: {json.dumps(summary, indent=2)}")
+        print(f"\nSummary: {dashboard.render_summary()}")
         print("Test completed successfully!")
 
         return

--- a/tests/services/test_metrics_dashboard_service.py
+++ b/tests/services/test_metrics_dashboard_service.py
@@ -1,0 +1,16 @@
+"""Tests for MetricsDashboardService and related modules."""
+
+from __future__ import annotations
+
+from src.services.metrics_dashboard_service import MetricsDashboardService
+
+
+def test_record_and_summarize() -> None:
+    service = MetricsDashboardService()
+    service.record_metric("alpha", 1.0)
+    service.record_metric("alpha", 2.0)
+    summary = service.get_summary()
+    assert summary["total_metrics"] == 2
+    assert summary["metrics_tracked"] == 1
+    rendered = service.render_summary()
+    assert "metrics_tracked" in rendered


### PR DESCRIPTION
## Summary
- add `dashboard_utils` for shared constants and timestamp helpers
- split metrics dashboard service into collector, processing, and rendering modules
- add unit test for new metrics dashboard modules

## Testing
- `pytest tests/services/test_metrics_dashboard_service.py -q` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*
- `PYTHONPATH=. pre-commit run --files src/services/dashboard_utils.py src/services/dashboard_collectors.py src/services/dashboard_processing.py src/services/dashboard_renderer.py src/services/metrics_dashboard_service.py tests/services/test_metrics_dashboard_service.py` *(fails: No module named 'src.core.performance.performance_types')*

------
https://chatgpt.com/codex/tasks/task_e_68b08bc440588329a7e7e631b3f61b5c