### PR TITLE
Refactor reporting into modular components

### DIFF
--- a/src/autonomous_development/reporting/config.py
+++ b/src/autonomous_development/reporting/config.py
@@ -1,0 +1,153 @@
+"""Reporting module configuration constants.
+
+This module provides a single source of truth for templates, icon
+mappings and filesystem paths used by the reporting subsystem.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+# Directory where report artifacts can be persisted if a file based backend
+# is used.  Modules can import this constant instead of hard coding paths.
+DEFAULT_REPORT_ARCHIVE_PATH = "reporting_archive"
+
+# ---------------------------------------------------------------------------
+# Icon mappings
+# ---------------------------------------------------------------------------
+PRIORITY_ICONS: Dict[str, str] = {
+    "high": "🔴",
+    "medium": "🟡",
+    "low": "🟢",
+}
+
+COMPLEXITY_ICONS: Dict[str, str] = {
+    "high": "🔥",
+    "medium": "⚡",
+    "low": "💡",
+}
+
+STATUS_ICONS: Dict[str, str] = {
+    "available": "🟢",
+    "claimed": "🟡",
+    "in_progress": "🔄",
+    "completed": "✅",
+    "blocked": "🚫",
+}
+
+# ---------------------------------------------------------------------------
+# Message templates
+# ---------------------------------------------------------------------------
+# These templates are used by the formatting helpers.  Keeping them here
+# avoids duplication and makes it easy to tweak messaging from one place.
+WORKFLOW_START_TEMPLATE = """🚀 AUTONOMOUS OVERNIGHT DEVELOPMENT WORKFLOW STARTED!
+
+📋 AGENT-1: Task Manager Role
+   - Building and updating task list
+   - Monitoring progress and coordination
+   - Managing task priorities
+
+🔍 AGENTS 2-8: Autonomous Workforce
+   - Review available tasks
+   - Claim tasks based on skills and availability
+   - Work autonomously and report progress
+   - Complete tasks and claim new ones
+
+🔄 WORKFLOW CYCLE:
+   1. Task review and claiming
+   2. Autonomous work execution
+   3. Progress reporting
+   4. Task completion and new task claiming
+   5. Repeat cycle
+
+⏰ CYCLE DURATION: 1 hour
+🌙 OPERATION: Continuous overnight
+🎯 GOAL: Maximize autonomous development progress
+
+Ready to begin autonomous development! 🚀"""
+
+AGENT1_TEMPLATE = """🎯 AGENT-1: You are now the Task Manager!
+
+Your responsibilities:
+1. 📋 Monitor task list and create new tasks as needed
+2. 📊 Track progress and identify bottlenecks
+3. 🔄 Coordinate workflow and resolve conflicts
+4. 📈 Optimize task distribution and priorities
+5. 🚨 Handle emergencies and blocked tasks
+
+Start by reviewing the current task list and identifying areas for improvement!"""
+
+NO_TASKS_TEMPLATE = """📋 NO TASKS AVAILABLE
+
+🎯 All current tasks have been claimed or completed!
+⏰ Waiting for Agent-1 to create new tasks...
+
+🔄 Next cycle will focus on:
+   • Progress monitoring
+   • Task completion
+   • New task creation by Agent-1
+
+Stay ready for new development opportunities! 🚀"""
+
+TASK_CLAIMED_TEMPLATE = """🎯 TASK CLAIMED: {title}
+
+📋 Task Details:
+   • ID: {task_id}
+   • Priority: {priority}
+   • Complexity: {complexity}
+   • Estimated Time: {estimated_hours}h
+   • Required Skills: {skills}
+
+🚀 Status: Ready to start work
+⏰ Next: Begin task execution in next cycle
+
+Good luck with your autonomous development! 🚀"""
+
+PROGRESS_UPDATE_BLOCKERS_TEMPLATE = """⚠️ PROGRESS UPDATE - BLOCKERS DETECTED
+
+📊 Task: {title}
+📈 Progress: {progress:.1f}%
+🚫 Blockers: {blockers}
+
+🔧 Action Required: Address blockers before continuing
+⏰ Next Update: In next cycle"""
+
+PROGRESS_UPDATE_TEMPLATE = """📊 PROGRESS UPDATE
+
+📋 Task: {title}
+📈 Progress: {progress:.1f}%
+✅ Status: Making good progress
+
+🚀 Continue autonomous development!
+⏰ Next Update: In next cycle"""
+
+WORKFLOW_COMPLETE_TEMPLATE = """🌅 OVERNIGHT WORKFLOW COMPLETE
+
+📊 Final Summary:
+   • Total Cycles: {overnight_cycles}
+   • Autonomous Hours: {autonomous_hours}
+   • Tasks Completed: {total_tasks_completed}
+
+🎯 Great work on autonomous development!
+🔄 System ready for next overnight session
+
+Good morning! ☀️"""
+
+REMAINING_TASKS_TEMPLATE = "📋 {count} tasks still available for claiming in next cycle."
+
+__all__ = [
+    "DEFAULT_REPORT_ARCHIVE_PATH",
+    "PRIORITY_ICONS",
+    "COMPLEXITY_ICONS",
+    "STATUS_ICONS",
+    "WORKFLOW_START_TEMPLATE",
+    "AGENT1_TEMPLATE",
+    "NO_TASKS_TEMPLATE",
+    "TASK_CLAIMED_TEMPLATE",
+    "PROGRESS_UPDATE_BLOCKERS_TEMPLATE",
+    "PROGRESS_UPDATE_TEMPLATE",
+    "WORKFLOW_COMPLETE_TEMPLATE",
+    "REMAINING_TASKS_TEMPLATE",
+]

--- a/src/autonomous_development/reporting/formatting.py
+++ b/src/autonomous_development/reporting/formatting.py
@@ -1,0 +1,235 @@
+"""Utility helpers for formatting development reports.
+
+Functions in this module are intentionally stateless and reusable.  They
+consume simple data structures and return formatted strings suitable for
+CLI output or message dispatching.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from .config import (
+    AGENT1_TEMPLATE,
+    COMPLEXITY_ICONS,
+    NO_TASKS_TEMPLATE,
+    PRIORITY_ICONS,
+    PROGRESS_UPDATE_BLOCKERS_TEMPLATE,
+    PROGRESS_UPDATE_TEMPLATE,
+    REMAINING_TASKS_TEMPLATE,
+    STATUS_ICONS,
+    TASK_CLAIMED_TEMPLATE,
+    WORKFLOW_COMPLETE_TEMPLATE,
+    WORKFLOW_START_TEMPLATE,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from src.autonomous_development.core import DevelopmentTask
+    from src.core.task_manager import DevelopmentTaskManager as TaskManager
+
+
+# ---------------------------------------------------------------------------
+# Basic icon helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_priority_icon(priority: int) -> str:
+    """Return emoji representing a numeric priority."""
+    if priority >= 8:
+        return PRIORITY_ICONS["high"]
+    if priority >= 5:
+        return PRIORITY_ICONS["medium"]
+    return PRIORITY_ICONS["low"]
+
+
+def _get_complexity_icon(complexity: str) -> str:
+    """Return emoji representing complexity."""
+    return COMPLEXITY_ICONS.get(complexity, COMPLEXITY_ICONS["low"])
+
+
+def _get_status_icon(status: str) -> str:
+    """Return emoji representing task status."""
+    return STATUS_ICONS.get(status, "❓")
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def format_task_list(tasks: List["DevelopmentTask"]) -> str:
+    """Format task list for agents."""
+    if not tasks:
+        return "No tasks available for claiming."
+
+    task_lines: List[str] = []
+    for task in sorted(tasks, key=lambda t: t.priority, reverse=True):
+        priority_icon = _get_priority_icon(task.priority)
+        complexity_icon = _get_complexity_icon(task.complexity)
+        task_lines.append(
+            f"{priority_icon} **{task.title}** (Priority: {task.priority})\n"
+            f"   {complexity_icon} Complexity: {task.complexity.title()}\n"
+            f"   ⏱️ Estimated: {task.estimated_hours}h\n"
+            f"   🎯 Skills: {', '.join(task.required_skills)}\n"
+            f"   📝 {task.description}\n"
+            f"   🆔 Task ID: {task.task_id}\n"
+        )
+    return "\n".join(task_lines)
+
+
+def format_progress_summary(task_manager: "TaskManager") -> str:
+    """Format progress summary for all agents."""
+    active_tasks = [
+        t for t in task_manager.tasks.values() if t.status in ["claimed", "in_progress"]
+    ]
+    if not active_tasks:
+        return "No active tasks to report progress on."
+
+    progress_lines: List[str] = []
+    for task in active_tasks:
+        status_icon = _get_status_icon(task.status)
+        progress_lines.append(
+            f"{status_icon} **{task.title}** (Agent: {task.claimed_by})\n"
+            f"   📊 Progress: {task.progress_percentage:.1f}%\n"
+            f"   🚫 Blockers: {', '.join(task.blockers) if task.blockers else 'None'}\n"
+        )
+    return "\n".join(progress_lines)
+
+
+def format_cycle_summary(task_manager: "TaskManager") -> str:
+    """Format cycle summary with statistics from the task manager."""
+    summary = task_manager.get_task_summary()
+    cycle_message = f"""🔄 CYCLE COMPLETE - SUMMARY:
+
+📊 Task Status:
+   • Total Tasks: {summary['total_tasks']}
+   • Available: {summary['available_tasks']}
+   • Claimed: {summary['claimed_tasks']}
+   • In Progress: {summary['in_progress_tasks']}
+   • Completed: {summary['completed_tasks']}
+   • Completion Rate: {summary['completion_rate']:.1f}%
+
+⏰ Overnight Progress:
+   • Cycles Completed: {summary['workflow_stats']['overnight_cycles']}
+   • Autonomous Hours: {summary['workflow_stats']['autonomous_hours']}
+   • Total Tasks Completed: {summary['workflow_stats']['total_tasks_completed']}
+
+🎯 Next Cycle: Task review and claiming phase begins..."""
+    return cycle_message
+
+
+def format_workflow_start_message() -> str:
+    """Return workflow start announcement."""
+    return WORKFLOW_START_TEMPLATE
+
+
+def format_agent1_message() -> str:
+    """Return Agent-1 role description."""
+    return AGENT1_TEMPLATE
+
+
+def format_no_tasks_message() -> str:
+    """Return message when there are no tasks available."""
+    return NO_TASKS_TEMPLATE
+
+
+def format_task_claimed_message(task: "DevelopmentTask") -> str:
+    """Return message when a task is claimed."""
+    return TASK_CLAIMED_TEMPLATE.format(
+        title=task.title,
+        task_id=task.task_id,
+        priority=task.priority,
+        complexity=task.complexity,
+        estimated_hours=task.estimated_hours,
+        skills=", ".join(task.required_skills),
+    )
+
+
+def format_progress_update_message(
+    task: "DevelopmentTask", new_progress: float, blockers: Optional[List[str]] = None
+) -> str:
+    """Return progress update message for an agent."""
+    if blockers:
+        return PROGRESS_UPDATE_BLOCKERS_TEMPLATE.format(
+            title=task.title,
+            progress=new_progress,
+            blockers=", ".join(blockers),
+        )
+    return PROGRESS_UPDATE_TEMPLATE.format(title=task.title, progress=new_progress)
+
+
+def format_workflow_complete_message(task_manager: "TaskManager") -> str:
+    """Return final workflow completion message."""
+    stats = task_manager.get_task_summary()["workflow_stats"]
+    return WORKFLOW_COMPLETE_TEMPLATE.format(**stats)
+
+
+def format_remaining_tasks_message(remaining_count: int) -> str:
+    """Return message about remaining available tasks."""
+    return REMAINING_TASKS_TEMPLATE.format(count=remaining_count)
+
+
+def format_detailed_task_status(task_manager: "TaskManager") -> str:
+    """Format detailed task status for CLI display."""
+    summary = task_manager.get_task_summary()
+    status_lines = [
+        "📋 Current Development Task Status:",
+        "=" * 60,
+        f"Total Tasks: {summary['total_tasks']}",
+        f"Available: {summary['available_tasks']}",
+        f"Claimed: {summary['claimed_tasks']}",
+        f"In Progress: {summary['in_progress_tasks']}",
+        f"Completed: {summary['completed_tasks']}",
+        f"Completion Rate: {summary['completion_rate']:.1f}%",
+        "",
+        "📊 Detailed Task List:",
+    ]
+    for task in task_manager.tasks.values():
+        status_icon = _get_status_icon(task.status)
+        status_lines.append(f"{status_icon} {task.task_id}: {task.title}")
+        status_lines.append(f"   Status: {task.status}")
+        if task.claimed_by:
+            status_lines.append(f"   Agent: {task.claimed_by}")
+        if task.progress_percentage > 0:
+            status_lines.append(f"   Progress: {task.progress_percentage:.1f}%")
+        status_lines.append("")
+    return "\n".join(status_lines)
+
+
+def format_workflow_statistics(task_manager: "TaskManager") -> str:
+    """Format workflow statistics for CLI display."""
+    summary = task_manager.get_task_summary()
+    stats = summary["workflow_stats"]
+    status_lines = [
+        "📊 Autonomous Development Workflow Statistics:",
+        "=" * 60,
+        "📋 Task Statistics:",
+        f"   Total Tasks Created: {stats['total_tasks_created']}",
+        f"   Total Tasks Completed: {stats['total_tasks_completed']}",
+        f"   Total Tasks Claimed: {stats['total_tasks_claimed']}",
+        "",
+        "🌙 Overnight Statistics:",
+        f"   Overnight Cycles: {stats['overnight_cycles']}",
+        f"   Autonomous Hours: {stats['autonomous_hours']}",
+    ]
+    if stats["total_tasks_created"] > 0:
+        completion_rate = (
+            stats["total_tasks_completed"] / stats["total_tasks_created"]
+        ) * 100
+        status_lines.append(f"   Overall Completion Rate: {completion_rate:.1f}%")
+    return "\n".join(status_lines)
+
+
+__all__ = [
+    "format_task_list",
+    "format_progress_summary",
+    "format_cycle_summary",
+    "format_workflow_start_message",
+    "format_agent1_message",
+    "format_no_tasks_message",
+    "format_task_claimed_message",
+    "format_progress_update_message",
+    "format_workflow_complete_message",
+    "format_remaining_tasks_message",
+    "format_detailed_task_status",
+    "format_workflow_statistics",
+]

--- a/src/autonomous_development/reporting/generation.py
+++ b/src/autonomous_development/reporting/generation.py
@@ -1,0 +1,45 @@
+"""Report generation helpers.
+
+Currently only a performance report is implemented.  Additional report
+builders can be added here in the future without touching the manager.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from src.core.task_manager import DevelopmentTaskManager as TaskManager
+
+
+def generate_performance_report(task_manager: "TaskManager") -> Dict[str, Any]:
+    """Create a performance report from task manager statistics."""
+    summary = task_manager.get_task_summary()
+    stats = summary["workflow_stats"]
+
+    total_tasks = summary["total_tasks"]
+    completed_tasks = summary["completed_tasks"]
+
+    efficiency_score = (completed_tasks / total_tasks) * 100 if total_tasks > 0 else 0.0
+    avg_cycle_efficiency = (
+        completed_tasks / stats["overnight_cycles"]
+        if stats["overnight_cycles"] > 0
+        else 0.0
+    )
+
+    report = {
+        "summary": summary,
+        "workflow_stats": stats,
+        "performance_metrics": {
+            "efficiency_score": efficiency_score,
+            "avg_cycle_efficiency": avg_cycle_efficiency,
+            "task_completion_rate": summary["completion_rate"],
+            "autonomous_productivity": completed_tasks
+            / max(stats["autonomous_hours"], 1),
+        },
+        "generated_at": datetime.utcnow().isoformat(),
+    }
+    return report
+
+
+__all__ = ["generate_performance_report"]

--- a/src/autonomous_development/reporting/persistence.py
+++ b/src/autonomous_development/reporting/persistence.py
@@ -1,0 +1,63 @@
+"""Persistence utilities for report data."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Protocol
+
+
+class ReportStorageBackend(Protocol):
+    """Protocol describing storage backends for reports."""
+
+    def save_reports(self, reports: List[Dict[str, Any]]) -> None:
+        """Persist a list of report dictionaries."""
+
+    def load_reports(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Retrieve report history."""
+
+
+class InMemoryReportStorage:
+    """Simple in-memory storage backend for reports."""
+
+    def __init__(self) -> None:
+        self._history: List[Dict[str, Any]] = []
+
+    def save_reports(
+        self, reports: List[Dict[str, Any]]
+    ) -> None:  # pragma: no cover - trivial
+        self._history.extend(reports)
+
+    def load_reports(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        if limit is None:
+            return list(self._history)
+        return self._history[-limit:]
+
+
+def save_report_history(
+    storage: ReportStorageBackend,
+    report_history: List[Dict[str, Any]],
+    reports_generated: int,
+    last_report_time: Optional[str],
+) -> None:
+    """Persist report history using the configured storage backend."""
+    payload = {
+        "reports": list(report_history),
+        "metadata": {
+            "reports_generated": reports_generated,
+            "last_report_time": last_report_time,
+        },
+    }
+    storage.save_reports([payload])
+
+
+def load_report_history(
+    storage: ReportStorageBackend, limit: Optional[int] = None
+) -> List[Dict[str, Any]]:
+    """Load report history from backend."""
+    return storage.load_reports(limit)
+
+
+__all__ = [
+    "ReportStorageBackend",
+    "InMemoryReportStorage",
+    "save_report_history",
+    "load_report_history",
+]


### PR DESCRIPTION
## Summary
- split reporting into formatting, generation, and persistence modules
- centralize templates, icons and paths in reporting config
- update ReportingManager to delegate work and simplify report history saving

## Testing
- `PYTHONPATH=. pre-commit run --files src/autonomous_development/reporting/config.py src/autonomous_development/reporting/formatting.py src/autonomous_development/reporting/generation.py src/autonomous_development/reporting/persistence.py src/autonomous_development/reporting/manager.py` *(fails: ModuleNotFoundError: src.core.performance.performance_types)*
- `pytest` *(fails: ModuleNotFoundError: src.core.performance.performance_types)*

------
https://chatgpt.com/codex/tasks/task_e_68b08bc45024832995309873b944b6c5