### PR TITLE
Modularize testing orchestrator configuration and logging

### DIFF
--- a/src/testing/execution.py
+++ b/src/testing/execution.py
@@ -5,9 +5,9 @@ from typing import List, Dict, Any
 import pytest
 import coverage
 
-from src.utils.logger import get_logger
+from .logging_utils import setup_logger
 
-logger = get_logger(__name__)
+logger = setup_logger(__name__)
 
 def run_tests(test_files: List[Path], source_dir: Path) -> Dict[str, Any]:
     """Execute tests and return pass status and coverage percentage."""

--- a/src/testing/logging_utils.py
+++ b/src/testing/logging_utils.py
@@ -1,0 +1,13 @@
+"""Logging utilities for testing orchestrator modules."""
+from __future__ import annotations
+
+import logging
+from src.utils.logger import get_logger
+from .orchestrator_config import DEFAULT_LOG_LEVEL
+
+
+def setup_logger(name: str) -> logging.Logger:
+    """Return a logger configured for the testing orchestrator."""
+    logger = get_logger(name)
+    logger.setLevel(getattr(logging, DEFAULT_LOG_LEVEL))
+    return logger

--- a/src/testing/monitoring.py
+++ b/src/testing/monitoring.py
@@ -1,8 +1,8 @@
 from typing import Dict, Any
 
-from src.utils.logger import get_logger
+from .logging_utils import setup_logger
 
-logger = get_logger(__name__)
+logger = setup_logger(__name__)
 
 def summarize(result: Dict[str, Any]) -> Dict[str, Any]:
     """Log and return execution results."""

--- a/src/testing/orchestrator_config.py
+++ b/src/testing/orchestrator_config.py
@@ -1,0 +1,4 @@
+"""Shared configuration for testing orchestrator modules."""
+
+DEFAULT_LOG_LEVEL = "INFO"
+

--- a/src/testing/planning.py
+++ b/src/testing/planning.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 from typing import List
 
-from src.utils.logger import get_logger
+from .logging_utils import setup_logger
 
-logger = get_logger(__name__)
+logger = setup_logger(__name__)
 
 def collect_tests(tests_dir: Path) -> List[Path]:
     """Gather test files from the given directory."""

--- a/src/testing/resource.py
+++ b/src/testing/resource.py
@@ -1,0 +1,19 @@
+"""Resource orchestration helpers for test environment."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .logging_utils import setup_logger
+
+
+class ResourceOrchestrator:
+    """Prepare and manage resources required for testing."""
+
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = Path(workspace)
+        self.logger = setup_logger(__name__)
+
+    def prepare(self) -> None:
+        """Ensure the workspace directory exists."""
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        self.logger.info("Workspace %s prepared", self.workspace)

--- a/src/testing/scheduler.py
+++ b/src/testing/scheduler.py
@@ -1,0 +1,24 @@
+"""Task scheduling for orchestrated test execution."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any, List
+
+from . import planning, execution, monitoring
+from .logging_utils import setup_logger
+
+
+class TaskScheduler:
+    """Schedule test tasks and aggregate results."""
+
+    def __init__(self, source_dir: Path, tests_dir: Path) -> None:
+        self.source_dir = Path(source_dir)
+        self.tests_dir = Path(tests_dir)
+        self.logger = setup_logger(__name__)
+
+    def execute(self) -> Dict[str, Any]:
+        """Plan, run, and summarize tests."""
+        test_plan: List[Path] = planning.collect_tests(self.tests_dir)
+        result = execution.run_tests(test_plan, self.source_dir)
+        self.logger.info("Scheduled %d test(s)", len(test_plan))
+        return monitoring.summarize(result)


### PR DESCRIPTION
## Summary
- Split testing workflow into resource, scheduler, and logging submodules
- Centralize orchestrator constants in `orchestrator_config.py`
- Update planning, execution, monitoring, and orchestrator to use the new submodules

## Testing
- `pytest --noconftest tests/unit/test_orchestrator_module.py tests/unit/test_utils_module.py tests/unit/test_dependency_manager_module.py`


------
https://chatgpt.com/codex/tasks/task_e_68b08c1fb8f88329953b44155f513c88