### PR TITLE
Refactor frontend routing into modular components

### DIFF
--- a/src/web/frontend/controllers.py
+++ b/src/web/frontend/controllers.py
@@ -1,0 +1,63 @@
+"""Controller functions for frontend routes.
+
+The controllers operate on generic state and registry objects to allow
+use with different web frameworks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Dict, TYPE_CHECKING
+
+from jinja2 import Template
+
+from .templates import INDEX_HTML
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type hints
+    from .frontend_app import ComponentRegistry, StateManager
+
+
+def render_index(state_manager: "StateManager") -> str:
+    """Return rendered HTML for the index page."""
+    template = Template(INDEX_HTML)
+    return template.render(app_name=state_manager.get_state().app_name)
+
+
+def current_state(state_manager: "StateManager") -> Dict[str, Any]:
+    """Return current frontend state."""
+    return asdict(state_manager.get_state())
+
+
+def component_listing(registry: "ComponentRegistry") -> Dict[str, Any]:
+    """Return available component and template names."""
+    return {
+        "components": registry.list_components(),
+        "templates": list(registry.templates.keys()),
+    }
+
+
+def route_info(route_path: str) -> Dict[str, Any]:
+    """Return basic route information for *route_path*."""
+    return {"path": f"/{route_path}", "component": "PageComponent", "props": {}}
+
+
+def apply_theme(state_manager: "StateManager", theme: str) -> Dict[str, str]:
+    """Update theme setting and return status."""
+    state_manager.update_state({"theme": theme})
+    return {"status": "success"}
+
+
+def get_theme(state_manager: "StateManager") -> Dict[str, str]:
+    """Return current theme information."""
+    return {"theme": state_manager.get_state().theme}
+
+
+def update_state(
+    state_manager: "StateManager", updates: Dict[str, Any]
+) -> Dict[str, str]:
+    """Apply *updates* to the global state and report status."""
+    try:
+        state_manager.update_state(updates)
+        return {"status": "success", "message": "State updated"}
+    except Exception as exc:  # pragma: no cover - simple error wrapper
+        return {"status": "error", "message": str(exc)}

--- a/src/web/frontend/frontend_app.py
+++ b/src/web/frontend/frontend_app.py
@@ -15,27 +15,21 @@ Author: Web Development & UI Framework Specialist
 License: MIT
 """
 
-import json
 import logging
-import asyncio
-import secrets
-
-from src.utils.stability_improvements import stability_manager, safe_import
-from pathlib import Path
-from typing import Dict, List, Any, Optional, Callable
+from typing import Any, Callable, Dict, List, Optional
 from dataclasses import dataclass, asdict
 from datetime import datetime
 import uuid
 
-# Frontend imports
-from flask import Flask, render_template, jsonify, request, session
+from flask import Flask, request
 from flask_socketio import SocketIO, emit, join_room, leave_room
 from flask_cors import CORS
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, JSONResponse
-from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
+
+from .routes import register_flask_routes, register_fastapi_routes
+from .settings import get_settings
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -190,15 +184,14 @@ class StateManager:
 class FlaskFrontendApp:
     """Flask-based frontend application"""
 
-    def __init__(self, config: Dict[str, Any] = None):
-        self.config = config or {}
+    def __init__(self, config: Dict[str, Any] | None = None):
+        settings = get_settings()
+        self.config = {**asdict(settings), **(config or {})}
         self.app = Flask(__name__)
-        self.app.config["SECRET_KEY"] = self.config.get(
-            "secret_key", secrets.token_hex(32)
-        )  # SECURITY: Random secret key
-        self.app.config["DEBUG"] = self.config.get(
-            "debug", False
-        )  # SECURITY: Debug disabled by default
+        self.app.config["SECRET_KEY"] = self.config["secret_key"]
+        self.app.config["DEBUG"] = self.config[
+            "debug"
+        ]  # SECURITY: Debug disabled by default
 
         # Initialize extensions
         self.socketio = SocketIO(self.app, cors_allowed_origins="*")
@@ -209,54 +202,11 @@ class FlaskFrontendApp:
         self.state_manager = StateManager()
 
         # Setup routes and WebSocket events
-        self._setup_routes()
+        register_flask_routes(self.app, self.state_manager, self.component_registry)
         self._setup_websocket_events()
         self._register_default_components()
 
         logger.info("Flask frontend application initialized")
-
-    def _setup_routes(self):
-        """Setup Flask routes for frontend"""
-
-        @self.app.route("/")
-        def index():
-            """Main frontend application"""
-            return render_template(
-                "frontend/index.html", app_name=self.state_manager.get_state().app_name
-            )
-
-        @self.app.route("/api/frontend/state")
-        def get_state():
-            """Get current frontend state"""
-            return jsonify(asdict(self.state_manager.get_state()))
-
-        @self.app.route("/api/frontend/components")
-        def get_components():
-            """Get available components"""
-            return jsonify(
-                {
-                    "components": self.component_registry.list_components(),
-                    "templates": list(self.component_registry.templates.keys()),
-                }
-            )
-
-        @self.app.route("/api/frontend/route/<path:route_path>")
-        def get_route(route_path):
-            """Get route configuration"""
-            # This would typically come from a routing configuration
-            return jsonify(
-                {"path": f"/{route_path}", "component": "PageComponent", "props": {}}
-            )
-
-        @self.app.route("/api/frontend/theme", methods=["GET", "POST"])
-        def theme_endpoint():
-            """Get or set theme"""
-            if request.method == "POST":
-                data = request.get_json()
-                self.state_manager.update_state({"theme": data.get("theme", "light")})
-                return jsonify({"status": "success"})
-            else:
-                return jsonify({"theme": self.state_manager.get_state().theme})
 
     def _setup_websocket_events(self):
         """Setup WebSocket events for real-time communication"""
@@ -367,16 +317,15 @@ class FlaskFrontendApp:
 class FastAPIFrontendApp:
     """FastAPI-based frontend application"""
 
-    def __init__(self, config: Dict[str, Any] = None):
-        self.config = config or {}
+    def __init__(self, config: Dict[str, Any] | None = None):
+        settings = get_settings()
+        self.config = {**asdict(settings), **(config or {})}
 
         # Initialize FastAPI app
         self.app = FastAPI(
-            title=self.config.get("title", "Agent_Cellphone_V2 Frontend API"),
-            description=self.config.get(
-                "description", "Modern Frontend API with WebSocket Support"
-            ),
-            version=self.config.get("version", "2.0.0"),
+            title=self.config["title"],
+            description=self.config["description"],
+            version=self.config["version"],
             docs_url="/docs",
             redoc_url="/redoc",
         )
@@ -389,7 +338,7 @@ class FastAPIFrontendApp:
         self.state_manager = StateManager()
 
         # Setup routes and WebSocket endpoints
-        self._setup_routes()
+        register_fastapi_routes(self.app, self.state_manager, self.component_registry)
         self._setup_websocket_endpoints()
         self._register_default_components()
 
@@ -404,51 +353,6 @@ class FastAPIFrontendApp:
             allow_methods=["*"],
             allow_headers=["*"],
         )
-
-    def _setup_routes(self):
-        """Setup FastAPI routes for frontend"""
-
-        @self.app.get("/", response_class=HTMLResponse)
-        async def index():
-            """Main frontend application"""
-            return f"""
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <title>{self.state_manager.get_state().app_name}</title>
-                <meta charset="utf-8">
-                <meta name="viewport" content="width=device-width, initial-scale=1">
-            </head>
-            <body>
-                <div id="app">
-                    <h1>{self.state_manager.get_state().app_name}</h1>
-                    <p>FastAPI Frontend Application</p>
-                </div>
-            </body>
-            </html>
-            """
-
-        @self.app.get("/api/frontend/state")
-        async def get_state():
-            """Get current frontend state"""
-            return asdict(self.state_manager.get_state())
-
-        @self.app.get("/api/frontend/components")
-        async def get_components():
-            """Get available components"""
-            return {
-                "components": self.component_registry.list_components(),
-                "templates": list(self.component_registry.templates.keys()),
-            }
-
-        @self.app.post("/api/frontend/state")
-        async def update_state(updates: Dict[str, Any]):
-            """Update frontend state"""
-            try:
-                self.state_manager.update_state(updates)
-                return {"status": "success", "message": "State updated"}
-            except Exception as e:
-                return {"status": "error", "message": str(e)}
 
     def _setup_websocket_endpoints(self):
         """Setup WebSocket endpoints for real-time communication"""

--- a/src/web/frontend/routes.py
+++ b/src/web/frontend/routes.py
@@ -1,0 +1,69 @@
+"""Route definitions for different web frameworks."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, TYPE_CHECKING
+
+from flask import Flask, jsonify, request
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+
+from . import controllers
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type hints
+    from .frontend_app import ComponentRegistry, StateManager
+
+
+def register_flask_routes(
+    app: Flask, state_manager: "StateManager", registry: "ComponentRegistry"
+) -> None:
+    """Attach route handlers to a Flask ``app``."""
+
+    @app.route("/")
+    def index() -> str:
+        return controllers.render_index(state_manager)
+
+    @app.route("/api/frontend/state")
+    def get_state() -> Any:
+        return jsonify(controllers.current_state(state_manager))
+
+    @app.route("/api/frontend/components")
+    def get_components() -> Any:
+        return jsonify(controllers.component_listing(registry))
+
+    @app.route("/api/frontend/route/<path:route_path>")
+    def get_route(route_path: str) -> Any:
+        return jsonify(controllers.route_info(route_path))
+
+    @app.route("/api/frontend/theme", methods=["GET", "POST"])
+    def theme_endpoint() -> Any:
+        if request.method == "POST":
+            data: Dict[str, Any] = request.get_json() or {}
+            return jsonify(
+                controllers.apply_theme(state_manager, data.get("theme", "light"))
+            )
+        return jsonify(controllers.get_theme(state_manager))
+
+
+def register_fastapi_routes(
+    app: FastAPI, state_manager: "StateManager", registry: "ComponentRegistry"
+) -> None:
+    """Attach route handlers to a FastAPI ``app``."""
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index() -> str:  # pragma: no cover - simple wrapper
+        return controllers.render_index(state_manager)
+
+    @app.get("/api/frontend/state")
+    async def get_state() -> Dict[str, Any]:  # pragma: no cover - simple wrapper
+        return controllers.current_state(state_manager)
+
+    @app.get("/api/frontend/components")
+    async def get_components() -> Dict[str, Any]:  # pragma: no cover - simple wrapper
+        return controllers.component_listing(registry)
+
+    @app.post("/api/frontend/state")
+    async def update_state(
+        updates: Dict[str, Any],
+    ) -> Dict[str, Any]:  # pragma: no cover
+        return controllers.update_state(state_manager, updates)

--- a/src/web/frontend/settings.py
+++ b/src/web/frontend/settings.py
@@ -1,0 +1,26 @@
+"""Shared configuration for frontend modules.
+
+This module centralizes configuration values used across the frontend
+application to provide a single source of truth (SSOT).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import secrets
+
+
+@dataclass(frozen=True)
+class FrontendSettings:
+    """Configuration values for the frontend layer."""
+
+    secret_key: str = field(default_factory=lambda: secrets.token_hex(32))
+    debug: bool = False
+    title: str = "Agent_Cellphone_V2 Frontend API"
+    description: str = "Modern Frontend API with WebSocket Support"
+    version: str = "2.0.0"
+
+
+def get_settings() -> FrontendSettings:
+    """Return application settings."""
+    return FrontendSettings()

--- a/src/web/frontend/templates.py
+++ b/src/web/frontend/templates.py
@@ -1,0 +1,17 @@
+"""HTML template strings for the frontend."""
+
+from __future__ import annotations
+
+INDEX_HTML = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ app_name }}</title>
+</head>
+<body>
+  <h1>{{ app_name }}</h1>
+  <p>Frontend Application</p>
+</body>
+</html>
+"""


### PR DESCRIPTION
## Summary
- modularize frontend routes, controllers, and templates
- centralize frontend configuration via settings module
- update frontend app to use new modules and typings

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*
- `pre-commit run --files src/web/frontend/settings.py src/web/frontend/controllers.py src/web/frontend/templates.py src/web/frontend/routes.py src/web/frontend/frontend_app.py` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*


------
https://chatgpt.com/codex/tasks/task_e_68b08c1f95608329a6cca6140720a6f0