### PR TITLE
refactor: modularize metrics pipeline

### DIFF
--- a/src/services/metrics_dashboard_service.py
+++ b/src/services/metrics_dashboard_service.py
@@ -1,32 +1,46 @@
 #!/usr/bin/env python3
-"""
-Simple Metrics Dashboard Service for testing
-"""
+"""Simple metrics dashboard demonstrating the metrics pipeline modules."""
+
+from __future__ import annotations
 
 import json
-import time
 
-from src.utils.stability_improvements import stability_manager, safe_import
-from datetime import datetime
+from .metrics_pipeline.data_collection import MetricsDataCollector
+from .metrics_pipeline.data_exporter import MetricsExporter
+from .metrics_pipeline.data_transformer import MetricsTransformer
+from .metrics_pipeline.metrics_config import DEFAULT_EXPORT_PATH
 
 
 class MetricsDashboardService:
-    def __init__(self):
-        self.metrics = {}
+    """Coordinates the data collection, transformation and export stages."""
+
+    def __init__(self) -> None:
+        self.collector = MetricsDataCollector()
+        self.transformer = MetricsTransformer()
+        self.exporter = MetricsExporter()
         print("Metrics Dashboard Service initialized")
 
-    def record_metric(self, name, value):
-        if name not in self.metrics:
-            self.metrics[name] = []
-        self.metrics[name].append({"timestamp": time.time(), "value": value})
+    def record_metric(self, name: str, value: float) -> None:
+        """Record a single metric value."""
+
+        self.collector.record(name, value)
         print(f"Recorded metric {name}: {value}")
 
-    def get_summary(self):
-        return {
-            "total_metrics": sum(len(values) for values in self.metrics.values()),
-            "metrics_tracked": len(self.metrics),
-            "timestamp": datetime.now().isoformat(),
-        }
+    def get_summary(self) -> dict:
+        """Return a summary of collected metrics."""
+
+        return self.transformer.summarize(self.collector.metrics)
+
+    def export_metrics(self, path: str = DEFAULT_EXPORT_PATH) -> bool:
+        """Export collected metrics to ``path``.
+
+        Returns ``True`` when the export succeeds.
+        """
+
+        success = self.exporter.export(self.collector.metrics, filename=path)
+        if success:
+            print(f"Exported metrics to {path}")
+        return success
 
 
 def main():

--- a/src/services/metrics_pipeline/__init__.py
+++ b/src/services/metrics_pipeline/__init__.py
@@ -1,0 +1,21 @@
+"""Utilities supporting the simple metrics pipeline."""
+
+from .data_collection import MetricsDataCollector
+from .data_exporter import MetricsExporter
+from .data_transformer import MetricsTransformer
+from .metrics_config import (
+    DEFAULT_EXPORT_PATH,
+    SUMMARY_METRICS_TRACKED,
+    SUMMARY_TOTAL_METRICS,
+    MetricRecord,
+)
+
+__all__ = [
+    "MetricsDataCollector",
+    "MetricsExporter",
+    "MetricsTransformer",
+    "DEFAULT_EXPORT_PATH",
+    "SUMMARY_METRICS_TRACKED",
+    "SUMMARY_TOTAL_METRICS",
+    "MetricRecord",
+]

--- a/src/services/metrics_pipeline/data_collection.py
+++ b/src/services/metrics_pipeline/data_collection.py
@@ -1,0 +1,25 @@
+"""Metrics data collection utilities."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, List
+
+from .metrics_config import MetricRecord
+
+
+class MetricsDataCollector:
+    """Collects metric values in memory."""
+
+    def __init__(self) -> None:
+        self.metrics: Dict[str, List[MetricRecord]] = {}
+
+    def record(self, name: str, value: float) -> None:
+        """Record a metric value under ``name``."""
+
+        self.metrics.setdefault(name, []).append(
+            MetricRecord(timestamp=time.time(), value=value)
+        )
+
+
+__all__ = ["MetricsDataCollector"]

--- a/src/services/metrics_pipeline/data_exporter.py
+++ b/src/services/metrics_pipeline/data_exporter.py
@@ -1,0 +1,36 @@
+"""Export metrics to external storage formats."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+from .metrics_config import DEFAULT_EXPORT_PATH, MetricRecord
+
+
+class MetricsExporter:
+    """Handles exporting collected metrics to JSON files."""
+
+    def export(
+        self,
+        metrics: Dict[str, List[MetricRecord]],
+        filename: str = DEFAULT_EXPORT_PATH,
+    ) -> bool:
+        """Export ``metrics`` to ``filename``.
+
+        Returns ``True`` if the export succeeds, otherwise ``False``.
+        """
+
+        try:
+            serializable = {
+                name: [record.__dict__ for record in values]
+                for name, values in metrics.items()
+            }
+            with open(filename, "w", encoding="utf-8") as f:
+                json.dump(serializable, f, indent=2)
+            return True
+        except OSError:
+            return False
+
+
+__all__ = ["MetricsExporter"]

--- a/src/services/metrics_pipeline/data_transformer.py
+++ b/src/services/metrics_pipeline/data_transformer.py
@@ -1,0 +1,29 @@
+"""Transform collected metrics into useful summaries."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List
+
+from .metrics_config import (
+    SUMMARY_METRICS_TRACKED,
+    SUMMARY_TOTAL_METRICS,
+    MetricRecord,
+)
+
+
+class MetricsTransformer:
+    """Provides simple aggregation helpers for metric data."""
+
+    def summarize(self, metrics: Dict[str, List[MetricRecord]]) -> Dict[str, int | str]:
+        """Return a summary dictionary for the provided metrics."""
+
+        total = sum(len(values) for values in metrics.values())
+        return {
+            SUMMARY_TOTAL_METRICS: total,
+            SUMMARY_METRICS_TRACKED: len(metrics),
+            "timestamp": datetime.now().isoformat(),
+        }
+
+
+__all__ = ["MetricsTransformer"]

--- a/src/services/metrics_pipeline/metrics_config.py
+++ b/src/services/metrics_pipeline/metrics_config.py
@@ -1,0 +1,45 @@
+"""Shared configuration and definitions for the metrics pipeline.
+
+This module centralizes metric-related constants and simple data
+structures so they can be reused across the data collection,
+transformation and export modules.  Keeping these definitions in one
+place reduces coupling and makes the pipeline easier to maintain.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# General constants
+# ---------------------------------------------------------------------------
+
+# Default path used when exporting metrics to disk.  Individual callers may
+# override this value if a custom destination is required.
+DEFAULT_EXPORT_PATH = "metrics_export.json"
+
+# Keys used in summary dictionaries returned by the transformer.  Using
+# constants avoids hard-coded strings being scattered through the codebase.
+SUMMARY_TOTAL_METRICS = "total_metrics"
+SUMMARY_METRICS_TRACKED = "metrics_tracked"
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MetricRecord:
+    """Represents a single recorded metric value."""
+
+    timestamp: float
+    value: float
+
+
+__all__ = [
+    "DEFAULT_EXPORT_PATH",
+    "SUMMARY_METRICS_TRACKED",
+    "SUMMARY_TOTAL_METRICS",
+    "MetricRecord",
+]


### PR DESCRIPTION
## Summary
- modularize metrics dashboard into collector, transformer, and exporter modules
- centralize metric constants in `metrics_config`
- streamline dashboard service and add documentation

## Testing
- `PYTHONPATH=. pre-commit run --files src/services/metrics_dashboard_service.py src/services/metrics_pipeline/metrics_config.py src/services/metrics_pipeline/data_collection.py src/services/metrics_pipeline/data_transformer.py src/services/metrics_pipeline/data_exporter.py src/services/metrics_pipeline/__init__.py` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*
- `python -m py_compile src/services/metrics_dashboard_service.py src/services/metrics_pipeline/metrics_config.py src/services/metrics_pipeline/data_collection.py src/services/metrics_pipeline/data_transformer.py src/services/metrics_pipeline/data_exporter.py src/services/metrics_pipeline/__init__.py`
- `python -m src.services.metrics_dashboard_service --test` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*


------
https://chatgpt.com/codex/tasks/task_e_68b08c1fc4348329a5864fae93d50710