### PR TITLE
refactor: modularize ai/ml managers

### DIFF
--- a/src/ai_ml/ai_ml_common.py
+++ b/src/ai_ml/ai_ml_common.py
@@ -1,0 +1,43 @@
+"""Shared utilities and protocol definitions for AI/ML managers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol
+
+
+class DataService(Protocol):
+    """Protocol for services that supply datasets."""
+
+    def fetch(self, query: Any) -> Any:
+        """Return data for the given ``query``."""
+
+
+class ModelStore(Protocol):
+    """Protocol defining persistence operations for models."""
+
+    def save(self, model: Any, path: str) -> None:
+        """Persist ``model`` at ``path``."""
+
+    def load(self, path: str) -> Any:
+        """Load a model from ``path``."""
+
+
+class TrainingFramework(Protocol):
+    """Protocol describing required behaviour of training frameworks."""
+
+    def create_model(self, model_config: Dict[str, Any]) -> Any:
+        """Create a model using ``model_config``."""
+
+    def train_model(self, model: Any, data: Any) -> Dict[str, Any]:
+        """Train ``model`` on ``data`` and return training metadata."""
+
+
+class EvaluationFramework(Protocol):
+    """Protocol describing required behaviour of evaluation frameworks."""
+
+    def evaluate_model(self, model: Any, data: Any) -> Dict[str, float]:
+        """Evaluate ``model`` with ``data`` and return metrics."""
+
+
+DEFAULT_MODEL_DIR = "models"
+"""Default directory used for storing models."""

--- a/src/ai_ml/managers/__init__.py
+++ b/src/ai_ml/managers/__init__.py
@@ -1,0 +1,7 @@
+"""Manager modules for model lifecycle, training, and evaluation."""
+
+from .model_manager import ModelManager
+from .training_manager import TrainingManager
+from .evaluation_manager import EvaluationManager
+
+__all__ = ["ModelManager", "TrainingManager", "EvaluationManager"]

--- a/src/ai_ml/managers/evaluation_manager.py
+++ b/src/ai_ml/managers/evaluation_manager.py
@@ -2,27 +2,17 @@ from __future__ import annotations
 
 """Model evaluation built around dependency injection."""
 
-from typing import Any, Dict, Protocol
+from typing import Any, Dict
+
+from ai_ml.ai_ml_common import DataService, EvaluationFramework
 
 
-class Framework(Protocol):
-    """Protocol describing required evaluation behaviour."""
-
-    def evaluate_model(self, model: Any, data: Any) -> Dict[str, float]:
-        ...
-
-
-class DataService(Protocol):
-    """Protocol for providing evaluation data."""
-
-    def fetch(self, query: Any) -> Any:
-        """Return evaluation data for ``query``."""
-
-
-class Evaluator:
+class EvaluationManager:
     """Evaluate models using injected services."""
 
-    def __init__(self, framework: Framework, data_service: DataService, logger: Any) -> None:
+    def __init__(
+        self, framework: EvaluationFramework, data_service: DataService, logger: Any
+    ) -> None:
         self._framework = framework
         self._data_service = data_service
         self._logger = logger

--- a/src/ai_ml/managers/model_manager.py
+++ b/src/ai_ml/managers/model_manager.py
@@ -2,20 +2,12 @@ from __future__ import annotations
 
 """Utilities for managing the lifecycle of ML models."""
 
-from typing import Any, Protocol
+from typing import Any
+
+from ai_ml.ai_ml_common import ModelStore
 
 
-class ModelStore(Protocol):
-    """Protocol defining how models are persisted."""
-
-    def save(self, model: Any, path: str) -> None:
-        """Persist a model at ``path``."""
-
-    def load(self, path: str) -> Any:
-        """Retrieve a model from ``path``."""
-
-
-class ModelLifecycle:
+class ModelManager:
     """Handle saving and loading models.
 
     Parameters

--- a/src/ai_ml/managers/training_manager.py
+++ b/src/ai_ml/managers/training_manager.py
@@ -2,27 +2,12 @@ from __future__ import annotations
 
 """Training orchestration built around dependency injection."""
 
-from typing import Any, Dict, Protocol
+from typing import Any, Dict
+
+from ai_ml.ai_ml_common import DataService, TrainingFramework
 
 
-class Framework(Protocol):
-    """Protocol describing required framework behaviour."""
-
-    def create_model(self, model_config: Dict[str, Any]) -> Any:
-        ...
-
-    def train_model(self, model: Any, data: Any) -> Dict[str, Any]:
-        ...
-
-
-class DataService(Protocol):
-    """Protocol for providing training data."""
-
-    def fetch(self, query: Any) -> Any:
-        """Return training data for ``query``."""
-
-
-class TrainingOrchestrator:
+class TrainingManager:
     """Coordinate data retrieval and model training.
 
     Parameters
@@ -35,7 +20,9 @@ class TrainingOrchestrator:
         Logging interface for status messages.
     """
 
-    def __init__(self, framework: Framework, data_service: DataService, logger: Any) -> None:
+    def __init__(
+        self, framework: TrainingFramework, data_service: DataService, logger: Any
+    ) -> None:
         self._framework = framework
         self._data_service = data_service
         self._logger = logger


### PR DESCRIPTION
## Summary
- relocate model, training, and evaluation components under managers package
- centralize shared ML protocols and defaults in `ai_ml_common.py`
- update tests to reflect new modular structure

## Testing
- `pre-commit run --files src/ai_ml/ai_ml_common.py src/ai_ml/managers/__init__.py src/ai_ml/managers/model_manager.py src/ai_ml/managers/training_manager.py src/ai_ml/managers/evaluation_manager.py tests/ai_ml/test_model_components.py` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*
- `pytest tests/ai_ml/test_model_components.py` *(fails: ModuleNotFoundError: No module named 'src.core.performance.performance_types')*

------
https://chatgpt.com/codex/tasks/task_e_68b08bd0ce4c832994df12511fbc4e87