### PR TITLE
Refactor status monitor metrics into modular components

### DIFF
--- a/src/services/status_monitor/calculations.py
+++ b/src/services/status_monitor/calculations.py
@@ -1,0 +1,103 @@
+"""Health calculations for the status monitor service."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable
+
+from .constants import (
+    ERROR_PENALTY,
+    WARNING_PENALTY,
+    MIN_ACTIVE_AGENTS,
+    LOW_ACTIVE_AGENT_PENALTY,
+)
+from .metrics import AgentMetrics
+
+
+@dataclass
+class SystemHealth:
+    """Aggregated system health details."""
+
+    total_agents: int
+    active_agents: int = 0
+    system_status: str = "initializing"
+    overall_health_score: float = 100.0
+    critical_issues: int = 0
+    warnings: int = 0
+    last_health_check: datetime = field(default_factory=datetime.now)
+
+
+def assess_system_health(
+    agent_metrics: Iterable[AgentMetrics], health: SystemHealth
+) -> SystemHealth:
+    """Update system health based on agent metrics."""
+    active_agents = sum(1 for m in agent_metrics if m.status == "active")
+    total_errors = sum(m.error_count for m in agent_metrics)
+    total_warnings = sum(1 for m in agent_metrics if m.success_rate < 90.0)
+
+    health_score = 100.0
+    if total_errors:
+        health_score -= total_errors * ERROR_PENALTY
+    if total_warnings:
+        health_score -= total_warnings * WARNING_PENALTY
+    if active_agents < MIN_ACTIVE_AGENTS:
+        health_score -= LOW_ACTIVE_AGENT_PENALTY
+    health_score = max(0.0, health_score)
+
+    if health_score >= 90:
+        system_status = "healthy"
+    elif health_score >= 70:
+        system_status = "warning"
+    elif health_score >= 50:
+        system_status = "critical"
+    else:
+        system_status = "failing"
+
+    health.active_agents = active_agents
+    health.system_status = system_status
+    health.overall_health_score = health_score
+    health.critical_issues = total_errors
+    health.warnings = total_warnings
+    health.last_health_check = datetime.now()
+    return health
+
+
+def get_system_summary(
+    agent_metrics: Dict[str, AgentMetrics], health: SystemHealth
+) -> Dict[str, Any]:
+    """Generate a full system summary."""
+    agent_status_summary = {
+        agent_id: {
+            "status": m.status,
+            "success_rate": m.success_rate,
+            "error_count": m.error_count,
+            "last_activity": m.last_activity.isoformat() if m.last_activity else None,
+        }
+        for agent_id, m in agent_metrics.items()
+    }
+    overall_metrics = {
+        "total_coordinations": sum(
+            m.coordination_count for m in agent_metrics.values()
+        ),
+        "total_errors": sum(m.error_count for m in agent_metrics.values()),
+        "total_tasks": sum(
+            m.tasks_completed + m.tasks_failed for m in agent_metrics.values()
+        ),
+        "average_success_rate": (
+            sum(m.success_rate for m in agent_metrics.values()) / len(agent_metrics)
+            if agent_metrics
+            else 0.0
+        ),
+    }
+    return {
+        "system_health": {
+            "status": health.system_status,
+            "health_score": health.overall_health_score,
+            "active_agents": health.active_agents,
+            "total_agents": health.total_agents,
+            "critical_issues": health.critical_issues,
+            "warnings": health.warnings,
+            "last_health_check": health.last_health_check.isoformat(),
+        },
+        "agent_status": agent_status_summary,
+        "overall_metrics": overall_metrics,
+    }

--- a/src/services/status_monitor/constants.py
+++ b/src/services/status_monitor/constants.py
@@ -1,0 +1,23 @@
+"""Shared constants for the status monitor service."""
+
+# Default agent IDs monitored by the service
+DEFAULT_AGENT_IDS = [
+    "Agent-1",
+    "Agent-2",
+    "Agent-3",
+    "Agent-4",
+    "Agent-5",
+]
+
+# Health score adjustments
+ERROR_PENALTY = 10
+WARNING_PENALTY = 5
+MIN_ACTIVE_AGENTS = 2
+LOW_ACTIVE_AGENT_PENALTY = 20
+
+# Status display helpers
+STATUS_EMOJIS = {
+    "active": "🟢",
+    "standby": "🟡",
+    "offline": "🔴",
+}

--- a/src/services/status_monitor/metrics.py
+++ b/src/services/status_monitor/metrics.py
@@ -1,0 +1,92 @@
+"""Metric gathering utilities for the status monitor service."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+from .constants import DEFAULT_AGENT_IDS
+
+
+@dataclass
+class AgentMetrics:
+    """Per-agent performance metrics."""
+
+    agent_id: str
+    status: str = "standby"
+    last_activity: Optional[datetime] = None
+    coordination_count: int = 0
+    error_count: int = 0
+    success_rate: float = 100.0
+    response_time_avg: float = 0.0
+    tasks_completed: int = 0
+    tasks_failed: int = 0
+
+
+class MetricsCollector:
+    """Collect and update agent metrics."""
+
+    def __init__(self) -> None:
+        self.agent_metrics: Dict[str, AgentMetrics] = {
+            agent_id: AgentMetrics(agent_id=agent_id) for agent_id in DEFAULT_AGENT_IDS
+        }
+
+    def update_agent_status(
+        self, agent_id: str, status: str, activity_type: str = "coordination"
+    ) -> None:
+        """Update an agent's status and activity counts."""
+        metrics = self.agent_metrics.get(agent_id)
+        if not metrics:
+            return
+        metrics.status = status
+        metrics.last_activity = datetime.now()
+        if activity_type == "coordination":
+            metrics.coordination_count += 1
+        elif activity_type == "task_completion":
+            metrics.tasks_completed += 1
+        elif activity_type == "task_failure":
+            metrics.tasks_failed += 1
+        total_tasks = metrics.tasks_completed + metrics.tasks_failed
+        if total_tasks:
+            metrics.success_rate = (metrics.tasks_completed / total_tasks) * 100
+
+    def record_agent_error(
+        self, agent_id: str, error_message: str, log_dir: Path
+    ) -> None:
+        """Record an error for the given agent."""
+        metrics = self.agent_metrics.get(agent_id)
+        if not metrics:
+            return
+        metrics.error_count += 1
+        log_dir.mkdir(exist_ok=True)
+        with open(log_dir / f"{agent_id}_errors.log", "a") as f:
+            f.write(f"[{datetime.now().isoformat()}] {error_message}\n")
+
+    def record_agent_response_time(self, agent_id: str, response_time: float) -> None:
+        """Record response time for the given agent."""
+        metrics = self.agent_metrics.get(agent_id)
+        if not metrics:
+            return
+        if metrics.response_time_avg == 0.0:
+            metrics.response_time_avg = response_time
+        else:
+            metrics.response_time_avg = (metrics.response_time_avg + response_time) / 2
+
+    def get_agent_metrics(self, agent_id: str) -> Optional[Dict[str, object]]:
+        """Return metrics for a specific agent as a dictionary."""
+        metrics = self.agent_metrics.get(agent_id)
+        if not metrics:
+            return None
+        return {
+            "agent_id": metrics.agent_id,
+            "status": metrics.status,
+            "last_activity": (
+                metrics.last_activity.isoformat() if metrics.last_activity else None
+            ),
+            "coordination_count": metrics.coordination_count,
+            "error_count": metrics.error_count,
+            "success_rate": metrics.success_rate,
+            "response_time_avg": metrics.response_time_avg,
+            "tasks_completed": metrics.tasks_completed,
+            "tasks_failed": metrics.tasks_failed,
+        }

--- a/src/services/status_monitor/visualization.py
+++ b/src/services/status_monitor/visualization.py
@@ -1,0 +1,38 @@
+"""Visualization utilities for the status monitor service."""
+
+from datetime import datetime
+from typing import Any, Dict
+
+from .constants import STATUS_EMOJIS
+
+
+def generate_health_report(summary: Dict[str, Any]) -> str:
+    """Generate a human-readable health report from the summary."""
+    report = f"""📊 AGENT CELLPHONE V2 SYSTEM HEALTH REPORT
+Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
+{'=' * 60}
+
+🏥 SYSTEM HEALTH STATUS
+  Status: {summary['system_health']['status'].upper()}
+  Health Score: {summary['system_health']['health_score']:.1f}/100
+  Active Agents: {summary['system_health']['active_agents']}/{summary['system_health']['total_agents']}
+  Critical Issues: {summary['system_health']['critical_issues']}
+  Warnings: {summary['system_health']['warnings']}
+
+🤖 AGENT STATUS SUMMARY
+"""
+    for agent_id, status in summary["agent_status"].items():
+        status_emoji = STATUS_EMOJIS.get(status["status"], "🔴")
+        report += (
+            f"  {status_emoji} {agent_id}: {status['status']} (Success: {status['success_rate']:.1f}%, "
+            f"Errors: {status['error_count']})\n"
+        )
+
+    report += f"""📈 OVERALL METRICS
+  Total Coordinations: {summary['overall_metrics']['total_coordinations']}
+  Total Errors: {summary['overall_metrics']['total_errors']}
+  Total Tasks: {summary['overall_metrics']['total_tasks']}
+  Average Success Rate: {summary['overall_metrics']['average_success_rate']:.1f}%
+
+{'=' * 60}"""
+    return report.strip()


### PR DESCRIPTION
## Summary
- Split status monitoring into dedicated modules for metrics gathering, health calculations, and report visualization
- Centralize common constants and status emojis for single source of truth
- Simplify StatusMonitorService to orchestrate new modules and remove unused code

## Testing
- `PYTHONPATH=. pre-commit run --files src/services/status_monitor/constants.py src/services/status_monitor/metrics.py src/services/status_monitor/calculations.py src/services/status_monitor/visualization.py src/services/status_monitor/__init__.py src/services/status_monitor_service.py` *(fails: ModuleNotFoundError: No module named 'src')*
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'coverage')*

------
https://chatgpt.com/codex/tasks/task_e_68b08c0755e48329a8a09ea6157b2f81