### PR TITLE
refactor: modularize fsm compliance components

### DIFF
--- a/src/core/fsm/constants.py
+++ b/src/core/fsm/constants.py
@@ -1,0 +1,76 @@
+from .fsm_core import StateDefinition, TransitionDefinition, TransitionType
+
+START_STATE = StateDefinition(
+    name="start",
+    description="Starting state",
+    entry_actions=[],
+    exit_actions=[],
+    timeout_seconds=None,
+    retry_count=0,
+    retry_delay=0.0,
+    required_resources=[],
+    dependencies=[],
+    metadata={},
+)
+
+PROCESS_STATE = StateDefinition(
+    name="process",
+    description="Processing state",
+    entry_actions=[],
+    exit_actions=[],
+    timeout_seconds=None,
+    retry_count=0,
+    retry_delay=0.0,
+    required_resources=[],
+    dependencies=[],
+    metadata={},
+)
+
+END_STATE = StateDefinition(
+    name="end",
+    description="Ending state",
+    entry_actions=[],
+    exit_actions=[],
+    timeout_seconds=None,
+    retry_count=0,
+    retry_delay=0.0,
+    required_resources=[],
+    dependencies=[],
+    metadata={},
+)
+
+DEFAULT_STATES = [START_STATE, PROCESS_STATE, END_STATE]
+
+TRANSITION_START_PROCESS = TransitionDefinition(
+    from_state="start",
+    to_state="process",
+    transition_type=TransitionType.AUTOMATIC,
+    condition=None,
+    priority=1,
+    timeout_seconds=None,
+    actions=[],
+    metadata={},
+)
+
+TRANSITION_PROCESS_END = TransitionDefinition(
+    from_state="process",
+    to_state="end",
+    transition_type=TransitionType.AUTOMATIC,
+    condition=None,
+    priority=1,
+    timeout_seconds=None,
+    actions=[],
+    metadata={},
+)
+
+DEFAULT_TRANSITIONS = [TRANSITION_START_PROCESS, TRANSITION_PROCESS_END]
+
+__all__ = [
+    "START_STATE",
+    "PROCESS_STATE",
+    "END_STATE",
+    "DEFAULT_STATES",
+    "TRANSITION_START_PROCESS",
+    "TRANSITION_PROCESS_END",
+    "DEFAULT_TRANSITIONS",
+]

--- a/src/core/fsm/definitions.py
+++ b/src/core/fsm/definitions.py
@@ -1,0 +1,14 @@
+"""Workflow definition utilities for the FSM package."""
+from typing import List, Tuple
+from .fsm_core import StateDefinition, TransitionDefinition
+from .constants import DEFAULT_STATES, DEFAULT_TRANSITIONS
+
+
+def get_default_definitions() -> (
+    Tuple[List[StateDefinition], List[TransitionDefinition]]
+):
+    """Return default states and transitions used across the project."""
+    return DEFAULT_STATES, DEFAULT_TRANSITIONS
+
+
+__all__ = ["get_default_definitions"]

--- a/src/core/fsm/fsm_compliance_integration.py
+++ b/src/core/fsm/fsm_compliance_integration.py
@@ -12,11 +12,13 @@ License: MIT
 """
 
 import logging
-import json
 import time
-from typing import Dict, List, Optional, Any, Union
+from typing import Dict, List, Optional, Any
 from datetime import datetime
 from pathlib import Path
+
+from .validation import validate_workflow
+from .reporting import generate_report, export_report
 
 # Import FSM system
 try:
@@ -48,28 +50,34 @@ except ImportError:
 # Import compliance monitoring system
 try:
     from ..compliance_monitoring_system import (
-        ComplianceMonitoringSystem, ComplianceCheck, AgentProgress
+        ComplianceMonitoringSystem,
+        ComplianceCheck,
+        AgentProgress,
     )
 except ImportError:
     try:
         # Fallback for direct execution
         from compliance_monitoring_system import (
-            ComplianceMonitoringSystem, ComplianceCheck, AgentProgress
+            ComplianceMonitoringSystem,
+            ComplianceCheck,
+            AgentProgress,
         )
     except ImportError:
         # Mock classes if compliance system not available
         class ComplianceMonitoringSystem:
             def __init__(self):
                 self.agent_progress = {}
+
             def track_agent_progress(self, agent_id, task_id, progress_data):
                 key = f"{agent_id}_{task_id}"
                 self.agent_progress[key] = progress_data
+
             def get_compliance_report(self):
                 return {"total_checks": 0}
-        
+
         class ComplianceCheck:
             pass
-        
+
         class AgentProgress:
             pass
 
@@ -77,15 +85,15 @@ except ImportError:
 class FSMComplianceIntegration:
     """
     Integrates FSM Core V2 with compliance monitoring system.
-    
+
     Single responsibility: Provide seamless integration between FSM and compliance
     systems following V2 architecture standards - use existing systems first.
     """
-    
+
     def __init__(self):
         """Initialize FSM compliance integration."""
         self.logger = logging.getLogger(f"{__name__}.FSMComplianceIntegration")
-        
+
         # Initialize FSM system
         try:
             self.fsm_system = FSMCoreV2()
@@ -94,7 +102,7 @@ class FSMComplianceIntegration:
         except Exception as e:
             self.logger.error(f"❌ Failed to initialize FSM system: {e}")
             self.fsm_system = None
-        
+
         # Initialize compliance monitoring system
         try:
             self.compliance_system = ComplianceMonitoringSystem()
@@ -102,29 +110,40 @@ class FSMComplianceIntegration:
         except Exception as e:
             self.logger.error(f"❌ Failed to initialize compliance system: {e}")
             self.compliance_system = None
-        
+
         # Integration state
         self.compliance_workflows: Dict[str, Dict[str, Any]] = {}
-        self.fsm_compliance_mapping: Dict[str, str] = {}  # FSM workflow ID -> Compliance task ID
-        self.compliance_fsm_mapping: Dict[str, str] = {}  # Compliance task ID -> FSM workflow ID
-        
+        self.fsm_compliance_mapping: Dict[
+            str, str
+        ] = {}  # FSM workflow ID -> Compliance task ID
+        self.compliance_fsm_mapping: Dict[
+            str, str
+        ] = {}  # Compliance task ID -> FSM workflow ID
+
         # Integration status
         self.integration_status = {
             "fsm_system": "CONNECTED" if self.fsm_system else "DISCONNECTED",
-            "compliance_system": "CONNECTED" if self.compliance_system else "DISCONNECTED",
+            "compliance_system": "CONNECTED"
+            if self.compliance_system
+            else "DISCONNECTED",
             "integration_active": bool(self.fsm_system and self.compliance_system),
-            "last_health_check": datetime.now().isoformat()
+            "last_health_check": datetime.now().isoformat(),
         }
-        
+
         self.logger.info("✅ FSMComplianceIntegration initialized")
-    
-    def create_compliance_workflow(self, task_id: str, agent_id: str, 
-                                   workflow_name: str, states: List[StateDefinition],
-                                   transitions: List[TransitionDefinition],
-                                   priority: WorkflowPriority = WorkflowPriority.NORMAL) -> Optional[str]:
+
+    def create_compliance_workflow(
+        self,
+        task_id: str,
+        agent_id: str,
+        workflow_name: str,
+        states: List[StateDefinition],
+        transitions: List[TransitionDefinition],
+        priority: WorkflowPriority = WorkflowPriority.NORMAL,
+    ) -> Optional[str]:
         """
         Create a workflow that integrates FSM with compliance monitoring.
-        
+
         Args:
             task_id: Compliance task identifier
             agent_id: Agent performing the task
@@ -132,7 +151,7 @@ class FSMComplianceIntegration:
             states: FSM state definitions
             transitions: FSM transition definitions
             priority: Workflow priority level
-        
+
         Returns:
             Integrated workflow ID or None if creation fails
         """
@@ -140,25 +159,33 @@ class FSMComplianceIntegration:
             if not self.integration_status["integration_active"]:
                 self.logger.error("❌ Integration not active - cannot create workflow")
                 return None
-            
+
+            if not validate_workflow(states, transitions):
+                self.logger.error("❌ Invalid workflow definition")
+                return None
+
             # Create FSM workflow
-            fsm_workflow_id = self._create_fsm_workflow(workflow_name, states, transitions, priority)
+            fsm_workflow_id = self._create_fsm_workflow(
+                workflow_name, states, transitions, priority
+            )
             if not fsm_workflow_id:
                 self.logger.error("❌ Failed to create FSM workflow")
                 return None
-            
+
             # Create compliance tracking
-            compliance_task_id = self._create_compliance_task(task_id, agent_id, workflow_name)
+            compliance_task_id = self._create_compliance_task(
+                task_id, agent_id, workflow_name
+            )
             if not compliance_task_id:
                 self.logger.error("❌ Failed to create compliance task")
                 # Cleanup FSM workflow
                 self._cleanup_fsm_workflow(fsm_workflow_id)
                 return None
-            
+
             # Store integration mapping
             self.fsm_compliance_mapping[fsm_workflow_id] = compliance_task_id
             self.compliance_fsm_mapping[compliance_task_id] = fsm_workflow_id
-            
+
             # Store integration metadata
             self.compliance_workflows[fsm_workflow_id] = {
                 "fsm_workflow_id": fsm_workflow_id,
@@ -170,59 +197,72 @@ class FSMComplianceIntegration:
                 "transitions": transitions,
                 "priority": priority.value,
                 "created_at": datetime.now().isoformat(),
-                "status": "integrated"
+                "status": "integrated",
             }
-            
-            self.logger.info(f"✅ Created compliance workflow: {fsm_workflow_id} <-> {compliance_task_id}")
+
+            self.logger.info(
+                f"✅ Created compliance workflow: {fsm_workflow_id} <-> {compliance_task_id}"
+            )
             return fsm_workflow_id
-            
+
         except Exception as e:
             self.logger.error(f"❌ Failed to create compliance workflow: {e}")
             return None
-    
-    def _create_fsm_workflow(self, workflow_name: str, states: List[StateDefinition],
-                             transitions: List[TransitionDefinition], priority: WorkflowPriority) -> Optional[str]:
+
+    def _create_fsm_workflow(
+        self,
+        workflow_name: str,
+        states: List[StateDefinition],
+        transitions: List[TransitionDefinition],
+        priority: WorkflowPriority,
+    ) -> Optional[str]:
         """Create workflow in FSM system."""
         try:
             if not self.fsm_system:
                 return None
-            
+
             # Add states to FSM
             for state in states:
                 if not self.fsm_system.add_state(state):
                     self.logger.error(f"❌ Failed to add state: {state.name}")
                     return None
-            
+
             # Add transitions to FSM
             for transition in transitions:
                 if not self.fsm_system.add_transition(transition):
-                    self.logger.error(f"❌ Failed to add transition: {transition.from_state} -> {transition.to_state}")
+                    self.logger.error(
+                        f"❌ Failed to add transition: {transition.from_state} -> {transition.to_state}"
+                    )
                     return None
-            
+
             # Create FSM workflow
             initial_state = states[0].name if states else "start"
-            fsm_workflow_id = self.fsm_system.create_workflow(workflow_name, initial_state, priority)
-            
+            fsm_workflow_id = self.fsm_system.create_workflow(
+                workflow_name, initial_state, priority
+            )
+
             if fsm_workflow_id:
                 self.logger.info(f"✅ Created FSM workflow: {fsm_workflow_id}")
                 return fsm_workflow_id
             else:
                 self.logger.error("❌ Failed to create FSM workflow")
                 return None
-                
+
         except Exception as e:
             self.logger.error(f"❌ Failed to create FSM workflow: {e}")
             return None
-    
-    def _create_compliance_task(self, task_id: str, agent_id: str, workflow_name: str) -> Optional[str]:
+
+    def _create_compliance_task(
+        self, task_id: str, agent_id: str, workflow_name: str
+    ) -> Optional[str]:
         """Create compliance tracking task."""
         try:
             if not self.compliance_system:
                 return None
-            
+
             # Create unique compliance task identifier
             compliance_task_id = f"compliance_{task_id}_{int(time.time())}"
-            
+
             # Initialize progress tracking
             progress_data = {
                 "percentage": 0.0,
@@ -230,41 +270,49 @@ class FSMComplianceIntegration:
                 "deliverables": {
                     "fsm_workflow": "PENDING",
                     "compliance_tracking": "ACTIVE",
-                    "validation": "PENDING"
+                    "validation": "PENDING",
                 },
                 "code_changes": [f"Created compliance workflow: {workflow_name}"],
-                "devlog_entries": [f"FSM compliance integration initialized for {workflow_name}"]
+                "devlog_entries": [
+                    f"FSM compliance integration initialized for {workflow_name}"
+                ],
             }
-            
-            self.compliance_system.track_agent_progress(agent_id, task_id, progress_data)
-            
+
+            self.compliance_system.track_agent_progress(
+                agent_id, task_id, progress_data
+            )
+
             self.logger.info(f"✅ Created compliance task: {compliance_task_id}")
             return compliance_task_id
-            
+
         except Exception as e:
             self.logger.error(f"❌ Failed to create compliance task: {e}")
             return None
-    
+
     def start_compliance_workflow(self, fsm_workflow_id: str) -> bool:
         """Start a compliance workflow in both systems."""
         try:
             if fsm_workflow_id not in self.compliance_workflows:
-                self.logger.error(f"❌ Workflow {fsm_workflow_id} not found in compliance workflows")
+                self.logger.error(
+                    f"❌ Workflow {fsm_workflow_id} not found in compliance workflows"
+                )
                 return False
-            
+
             integration_data = self.compliance_workflows[fsm_workflow_id]
             compliance_task_id = integration_data["compliance_task_id"]
             task_id = integration_data["task_id"]
             agent_id = integration_data["agent_id"]
-            
+
             # Start FSM workflow
             if self.fsm_system and fsm_workflow_id in self.fsm_system.workflows:
                 if self.fsm_system.start_workflow(fsm_workflow_id):
                     self.logger.info(f"✅ Started FSM workflow: {fsm_workflow_id}")
                 else:
-                    self.logger.error(f"❌ Failed to start FSM workflow: {fsm_workflow_id}")
+                    self.logger.error(
+                        f"❌ Failed to start FSM workflow: {fsm_workflow_id}"
+                    )
                     return False
-            
+
             # Update compliance progress
             progress_data = {
                 "percentage": 25.0,
@@ -272,87 +320,98 @@ class FSMComplianceIntegration:
                 "deliverables": {
                     "fsm_workflow": "ACTIVE",
                     "compliance_tracking": "ACTIVE",
-                    "validation": "PENDING"
+                    "validation": "PENDING",
                 },
                 "code_changes": [f"Started FSM workflow: {fsm_workflow_id}"],
-                "devlog_entries": [f"Compliance workflow execution started"]
+                "devlog_entries": [f"Compliance workflow execution started"],
             }
-            
-            self.compliance_system.track_agent_progress(agent_id, task_id, progress_data)
-            
+
+            self.compliance_system.track_agent_progress(
+                agent_id, task_id, progress_data
+            )
+
             # Update integration status
             integration_data["status"] = "running"
             integration_data["started_at"] = datetime.now().isoformat()
-            
+
             self.logger.info(f"✅ Started compliance workflow: {fsm_workflow_id}")
             return True
-            
+
         except Exception as e:
             self.logger.error(f"❌ Failed to start compliance workflow: {e}")
             return False
-    
-    def update_compliance_progress(self, fsm_workflow_id: str, progress_percentage: float, 
-                                  phase: str, deliverables: Dict[str, str] = None,
-                                  code_changes: List[str] = None, devlog_entries: List[str] = None) -> bool:
+
+    def update_compliance_progress(
+        self,
+        fsm_workflow_id: str,
+        progress_percentage: float,
+        phase: str,
+        deliverables: Dict[str, str] = None,
+        code_changes: List[str] = None,
+        devlog_entries: List[str] = None,
+    ) -> bool:
         """Update compliance progress for a workflow."""
         try:
             if fsm_workflow_id not in self.compliance_workflows:
-                self.logger.error(f"❌ Workflow {fsm_workflow_id} not found in compliance workflows")
+                self.logger.error(
+                    f"❌ Workflow {fsm_workflow_id} not found in compliance workflows"
+                )
                 return False
-            
+
             integration_data = self.compliance_workflows[fsm_workflow_id]
             task_id = integration_data["task_id"]
             agent_id = integration_data["agent_id"]
-            
+
             # Prepare progress data
-            progress_data = {
-                "percentage": progress_percentage,
-                "phase": phase
-            }
-            
+            progress_data = {"percentage": progress_percentage, "phase": phase}
+
             if deliverables:
                 progress_data["deliverables"] = deliverables
-            
+
             if code_changes:
                 progress_data["code_changes"] = code_changes
-            
+
             if devlog_entries:
                 progress_data["devlog_entries"] = devlog_entries
-            
+
             # Update compliance tracking
-            self.compliance_system.track_agent_progress(agent_id, task_id, progress_data)
-            
+            self.compliance_system.track_agent_progress(
+                agent_id, task_id, progress_data
+            )
+
             # Update integration metadata
             integration_data["last_progress_update"] = datetime.now().isoformat()
             integration_data["current_progress"] = progress_percentage
             integration_data["current_phase"] = phase
-            
-            self.logger.info(f"✅ Updated compliance progress: {fsm_workflow_id} - {progress_percentage}% - {phase}")
+
+            self.logger.info(
+                f"✅ Updated compliance progress: {fsm_workflow_id} - {progress_percentage}% - {phase}"
+            )
             return True
-            
+
         except Exception as e:
             self.logger.error(f"❌ Failed to update compliance progress: {e}")
             return False
-    
+
     def validate_compliance_workflow(self, fsm_workflow_id: str) -> Dict[str, Any]:
         """Validate compliance workflow against requirements."""
         try:
             if fsm_workflow_id not in self.compliance_workflows:
                 return {"valid": False, "error": "Workflow not found"}
-            
+
             integration_data = self.compliance_workflows[fsm_workflow_id]
             task_id = integration_data["task_id"]
             agent_id = integration_data["agent_id"]
-            
+
             validation_results = {
                 "workflow_id": fsm_workflow_id,
                 "task_id": task_id,
                 "agent_id": agent_id,
                 "validation_timestamp": datetime.now().isoformat(),
                 "checks": {},
-                "overall_valid": True
+                "overall_valid": True,
             }
-            
+
             # Check FSM workflow status
             if self.fsm_system and fsm_workflow_id in self.fsm_system.workflows:
                 fsm_workflow = self.fsm_system.get_workflow(fsm_workflow_id)
@@ -361,15 +420,21 @@ class FSMComplianceIntegration:
                         "status": "VALID",
                         "current_state": fsm_workflow.current_state,
                         "workflow_status": fsm_workflow.status.value,
-                        "error_count": fsm_workflow.error_count
+                        "error_count": fsm_workflow.error_count,
                     }
                 else:
-                    validation_results["checks"]["fsm_workflow"] = {"status": "INVALID", "error": "Workflow not found"}
+                    validation_results["checks"]["fsm_workflow"] = {
+                        "status": "INVALID",
+                        "error": "Workflow not found",
+                    }
                     validation_results["overall_valid"] = False
             else:
-                validation_results["checks"]["fsm_workflow"] = {"status": "INVALID", "error": "FSM system unavailable"}
+                validation_results["checks"]["fsm_workflow"] = {
+                    "status": "INVALID",
+                    "error": "FSM system unavailable",
+                }
                 validation_results["overall_valid"] = False
-            
+
             # Check compliance tracking
             if self.compliance_system:
                 # Get agent progress
@@ -380,42 +445,60 @@ class FSMComplianceIntegration:
                         "status": "VALID",
                         "progress_percentage": progress.get("percentage", 0.0),
                         "current_phase": progress.get("phase", "UNKNOWN"),
-                        "last_update": datetime.now().isoformat()
+                        "last_update": datetime.now().isoformat(),
                     }
                 else:
-                    validation_results["checks"]["compliance_tracking"] = {"status": "INVALID", "error": "Progress not found"}
+                    validation_results["checks"]["compliance_tracking"] = {
+                        "status": "INVALID",
+                        "error": "Progress not found",
+                    }
                     validation_results["overall_valid"] = False
             else:
-                validation_results["checks"]["compliance_tracking"] = {"status": "INVALID", "error": "Compliance system unavailable"}
+                validation_results["checks"]["compliance_tracking"] = {
+                    "status": "INVALID",
+                    "error": "Compliance system unavailable",
+                }
                 validation_results["overall_valid"] = False
-            
+
             # Update compliance progress with validation results
-            validation_phase = "VALIDATION_COMPLETE" if validation_results["overall_valid"] else "VALIDATION_FAILED"
+            validation_phase = (
+                "VALIDATION_COMPLETE"
+                if validation_results["overall_valid"]
+                else "VALIDATION_FAILED"
+            )
             self.update_compliance_progress(
-                fsm_workflow_id, 
+                fsm_workflow_id,
                 100.0 if validation_results["overall_valid"] else 75.0,
                 validation_phase,
-                deliverables={"validation": "COMPLETE" if validation_results["overall_valid"] else "FAILED"},
-                devlog_entries=[f"Compliance validation: {'PASSED' if validation_results['overall_valid'] else 'FAILED'}"]
+                deliverables={
+                    "validation": "COMPLETE"
+                    if validation_results["overall_valid"]
+                    else "FAILED"
+                },
+                devlog_entries=[
+                    f"Compliance validation: {'PASSED' if validation_results['overall_valid'] else 'FAILED'}"
+                ],
             )
-            
+
             return validation_results
-            
+
         except Exception as e:
             self.logger.error(f"❌ Failed to validate compliance workflow: {e}")
             return {"valid": False, "error": str(e)}
-    
-    def get_compliance_workflow_status(self, fsm_workflow_id: str) -> Optional[Dict[str, Any]]:
+
+    def get_compliance_workflow_status(
+        self, fsm_workflow_id: str
+    ) -> Optional[Dict[str, Any]]:
         """Get comprehensive status of a compliance workflow."""
         try:
             if fsm_workflow_id not in self.compliance_workflows:
                 return None
-            
+
             integration_data = self.compliance_workflows[fsm_workflow_id]
             compliance_task_id = integration_data["compliance_task_id"]
             task_id = integration_data["task_id"]
             agent_id = integration_data["agent_id"]
-            
+
             # Get FSM workflow status
             fsm_status = None
             if self.fsm_system and fsm_workflow_id in self.fsm_system.workflows:
@@ -427,9 +510,9 @@ class FSMComplianceIntegration:
                         "start_time": fsm_workflow.start_time.isoformat(),
                         "last_update": fsm_workflow.last_update.isoformat(),
                         "error_count": fsm_workflow.error_count,
-                        "retry_count": fsm_workflow.retry_count
+                        "retry_count": fsm_workflow.retry_count,
                     }
-            
+
             # Get compliance status
             compliance_status = None
             if self.compliance_system:
@@ -443,9 +526,9 @@ class FSMComplianceIntegration:
                         "last_update": datetime.now().isoformat(),
                         "deliverables_status": progress.get("deliverables", {}),
                         "code_changes_count": len(progress.get("code_changes", [])),
-                        "devlog_entries_count": len(progress.get("devlog_entries", []))
+                        "devlog_entries_count": len(progress.get("devlog_entries", [])),
                     }
-            
+
             # Compile comprehensive status
             status = {
                 "fsm_workflow_id": fsm_workflow_id,
@@ -457,49 +540,55 @@ class FSMComplianceIntegration:
                 "fsm_status": fsm_status,
                 "compliance_status": compliance_status,
                 "created_at": integration_data["created_at"],
-                "priority": integration_data["priority"]
+                "priority": integration_data["priority"],
             }
-            
+
             if "started_at" in integration_data:
                 status["started_at"] = integration_data["started_at"]
             if "last_progress_update" in integration_data:
-                status["last_progress_update"] = integration_data["last_progress_update"]
+                status["last_progress_update"] = integration_data[
+                    "last_progress_update"
+                ]
             if "current_progress" in integration_data:
                 status["current_progress"] = integration_data["current_progress"]
             if "current_phase" in integration_data:
                 status["current_phase"] = integration_data["current_phase"]
-            
+
             return status
-            
+
         except Exception as e:
             self.logger.error(f"❌ Failed to get workflow status: {e}")
             return None
-    
-    def list_compliance_workflows(self, status_filter: Optional[str] = None) -> List[Dict[str, Any]]:
+
+    def list_compliance_workflows(
+        self, status_filter: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
         """List all compliance workflows with optional status filter."""
         try:
             workflows = []
             for fsm_workflow_id, integration_data in self.compliance_workflows.items():
                 if status_filter and integration_data["status"] != status_filter:
                     continue
-                
-                workflows.append({
-                    "fsm_workflow_id": fsm_workflow_id,
-                    "compliance_task_id": integration_data["compliance_task_id"],
-                    "task_id": integration_data["task_id"],
-                    "agent_id": integration_data["agent_id"],
-                    "workflow_name": integration_data["workflow_name"],
-                    "status": integration_data["status"],
-                    "priority": integration_data["priority"],
-                    "created_at": integration_data["created_at"]
-                })
-            
+
+                workflows.append(
+                    {
+                        "fsm_workflow_id": fsm_workflow_id,
+                        "compliance_task_id": integration_data["compliance_task_id"],
+                        "task_id": integration_data["task_id"],
+                        "agent_id": integration_data["agent_id"],
+                        "workflow_name": integration_data["workflow_name"],
+                        "status": integration_data["status"],
+                        "priority": integration_data["priority"],
+                        "created_at": integration_data["created_at"],
+                    }
+                )
+
             return workflows
-            
+
         except Exception as e:
             self.logger.error(f"❌ Failed to list compliance workflows: {e}")
             return []
-    
+
     def get_integration_health(self) -> Dict[str, Any]:
         """Get integration system health status."""
         try:
@@ -511,46 +600,55 @@ class FSMComplianceIntegration:
                 fsm_system_health = "stopped"
             else:
                 fsm_system_health = "operational"
-            
+
             # Check compliance system health
             compliance_system_health = "healthy"
             if not self.compliance_system:
                 compliance_system_health = "disconnected"
             else:
                 compliance_system_health = "operational"
-            
+
             # Overall integration health
             overall_health = "healthy"
             if fsm_system_health != "healthy" or compliance_system_health != "healthy":
                 overall_health = "degraded"
-            if fsm_system_health == "disconnected" or compliance_system_health == "disconnected":
+            if (
+                fsm_system_health == "disconnected"
+                or compliance_system_health == "disconnected"
+            ):
                 overall_health = "critical"
-            
+
             health_status = {
                 "overall_health": overall_health,
                 "fsm_system": {
                     "status": fsm_system_health,
                     "connected": bool(self.fsm_system),
-                    "running": self.fsm_system.is_running if self.fsm_system else False
+                    "running": self.fsm_system.is_running if self.fsm_system else False,
                 },
                 "compliance_system": {
                     "status": compliance_system_health,
-                    "connected": bool(self.compliance_system)
+                    "connected": bool(self.compliance_system),
                 },
                 "integration": {
                     "active": self.integration_status["integration_active"],
                     "total_workflows": len(self.compliance_workflows),
-                    "running_workflows": len([w for w in self.compliance_workflows.values() if w["status"] == "running"])
+                    "running_workflows": len(
+                        [
+                            w
+                            for w in self.compliance_workflows.values()
+                            if w["status"] == "running"
+                        ]
+                    ),
                 },
-                "last_health_check": datetime.now().isoformat()
+                "last_health_check": datetime.now().isoformat(),
             }
-            
+
             return health_status
-            
+
         except Exception as e:
             self.logger.error(f"❌ Failed to get integration health: {e}")
             return {"overall_health": "unknown", "error": str(e)}
-    
+
     def _cleanup_fsm_workflow(self, fsm_workflow_id: str) -> None:
         """Clean up FSM workflow if creation fails."""
         try:
@@ -558,31 +656,17 @@ class FSMComplianceIntegration:
                 # Stop workflow if running
                 self.fsm_system.stop_workflow(fsm_workflow_id)
                 # Remove workflow
-                if hasattr(self.fsm_system, 'remove_workflow'):
+                if hasattr(self.fsm_system, "remove_workflow"):
                     self.fsm_system.remove_workflow(fsm_workflow_id)
                 self.logger.info(f"✅ Cleaned up FSM workflow: {fsm_workflow_id}")
         except Exception as e:
             self.logger.error(f"❌ Failed to cleanup FSM workflow: {e}")
-    
+
     def export_integration_report(self, format: str = "json") -> Optional[str]:
         """Export integration system report."""
         try:
-            report_data = {
-                "integration_status": self.integration_status,
-                "health_status": self.get_integration_health(),
-                "compliance_workflows": self.list_compliance_workflows(),
-                "mappings": {
-                    "fsm_to_compliance": self.fsm_compliance_mapping,
-                    "compliance_to_fsm": self.compliance_fsm_mapping
-                },
-                "exported_at": datetime.now().isoformat()
-            }
-            
-            if format.lower() == "json":
-                return json.dumps(report_data, indent=2, default=str)
-            else:
-                return f"Report format '{format}' not supported"
-                
+            report_data = generate_report(self)
+            return export_report(report_data, format)
         except Exception as e:
             self.logger.error(f"❌ Failed to export integration report: {e}")
             return None
@@ -591,6 +675,7 @@ class FSMComplianceIntegration:
 # ============================================================================
 # INTEGRATION FACTORY FUNCTIONS
 # ============================================================================
+
 
 def create_fsm_compliance_integration() -> FSMComplianceIntegration:
     """Factory function to create FSM compliance integration."""
@@ -603,35 +688,8 @@ def get_integration_status() -> Dict[str, Any]:
     return integration.get_integration_health()
 
 
-# ============================================================================
-# BACKWARDS COMPATIBILITY
-# ============================================================================
-
-# Maintain backwards compatibility
-FSMComplianceBridge = FSMComplianceIntegration
-ComplianceFSMIntegration = FSMComplianceIntegration
-
-# Export all components
 __all__ = [
     "FSMComplianceIntegration",
-    "FSMComplianceBridge",
-    "ComplianceFSMIntegration",
     "create_fsm_compliance_integration",
-    "get_integration_status"
+    "get_integration_status",
 ]
-
-
-if __name__ == "__main__":
-    # Test integration
-    integration = FSMComplianceIntegration()
-    
-    # Get health status
-    health = integration.get_integration_health()
-    print(f"Integration Health: {health['overall_health']}")
-    
-    # Export report
-    report = integration.export_integration_report()
-    if report:
-        print("✅ Integration report exported successfully")
-    else:
-        print("❌ Failed to export integration report")

--- a/src/core/fsm/fsm_compliance_validation_test.py
+++ b/src/core/fsm/fsm_compliance_validation_test.py
@@ -18,8 +18,9 @@ from datetime import datetime
 
 # Import FSM compliance integration system
 from fsm_compliance_integration import (
-    FSMComplianceIntegration, create_fsm_compliance_integration, get_integration_status,
-    FSMComplianceBridge, ComplianceFSMIntegration
+    FSMComplianceIntegration,
+    create_fsm_compliance_integration,
+    get_integration_status,
 )
 
 # Import FSM system for testing
@@ -34,14 +35,17 @@ from fsm_core import (
     TransitionHandler,
 )
 
+from definitions import get_default_definitions
+
 
 class MockFSMStateHandler(StateHandler):
     """Mock state handler for FSM testing."""
+
     def __init__(self, should_succeed: bool = True):
         self.should_succeed = should_succeed
         self.execution_count = 0
         self.last_context = None
-    
+
     def execute(self, context):
         self.execution_count += 1
         self.last_context = context
@@ -50,7 +54,7 @@ class MockFSMStateHandler(StateHandler):
 
 class FSMComplianceIntegrationTest(unittest.TestCase):
     """Comprehensive tests for FSMComplianceIntegration."""
-    
+
     def setUp(self):
         """Set up test environment."""
         self.integration = FSMComplianceIntegration()
@@ -58,64 +62,21 @@ class FSMComplianceIntegrationTest(unittest.TestCase):
         self.agent_id = "Agent-1"
         self.workflow_name = "FSM Compliance Integration Test"
         self.workflow_priority = WorkflowPriority.NORMAL
-        
-        # Test FSM components
-        self.state_start = StateDefinition(
-            name="start",
-            description="Starting state",
-            entry_actions=[],
-            exit_actions=[],
-            timeout_seconds=None,
-            retry_count=0,
-            retry_delay=0.0,
-            required_resources=[],
-            dependencies=[],
-            metadata={}
-        )
-        self.state_process = StateDefinition(
-            name="process",
-            description="Processing state",
-            entry_actions=[],
-            exit_actions=[],
-            timeout_seconds=None,
-            retry_count=0,
-            retry_delay=0.0,
-            required_resources=[],
-            dependencies=[],
-            metadata={}
-        )
-        self.state_end = StateDefinition(
-            name="end",
-            description="Ending state",
-            entry_actions=[],
-            exit_actions=[],
-            timeout_seconds=None,
-            retry_count=0,
-            retry_delay=0.0,
-            required_resources=[],
-            dependencies=[],
-            metadata={}
-        )
-        
-        self.transition_start_process = TransitionDefinition(
-            from_state="start", to_state="process", transition_type=TransitionType.AUTOMATIC,
-            condition=None, priority=1, timeout_seconds=None, actions=[], metadata={}
-        )
-        self.transition_process_end = TransitionDefinition(
-            from_state="process", to_state="end", transition_type=TransitionType.AUTOMATIC,
-            condition=None, priority=1, timeout_seconds=None, actions=[], metadata={}
-        )
-    
+
+        states, transitions = get_default_definitions()
+        self.state_start, self.state_process, self.state_end = states
+        self.transition_start_process, self.transition_process_end = transitions
+
     def tearDown(self):
         """Clean up test environment."""
         # Clean up any created workflows
-        if hasattr(self.integration, 'fsm_system') and self.integration.fsm_system:
+        if hasattr(self.integration, "fsm_system") and self.integration.fsm_system:
             for workflow_id in list(self.integration.fsm_system.workflows.keys()):
                 try:
                     self.integration.fsm_system.stop_workflow(workflow_id)
                 except:
                     pass
-    
+
     def test_system_initialization(self):
         """Test FSM compliance integration initialization."""
         # Check integration status
@@ -123,103 +84,115 @@ class FSMComplianceIntegrationTest(unittest.TestCase):
         self.assertIn("fsm_system", self.integration.integration_status)
         self.assertIn("compliance_system", self.integration.integration_status)
         self.assertIn("integration_active", self.integration.integration_status)
-        
+
         # Check data structures
         self.assertIsInstance(self.integration.compliance_workflows, dict)
         self.assertIsInstance(self.integration.fsm_compliance_mapping, dict)
         self.assertIsInstance(self.integration.compliance_fsm_mapping, dict)
-        
+
         # Check system connections
         self.assertIsNotNone(self.integration.fsm_system)
         self.assertIsNotNone(self.integration.compliance_system)
-    
+
     def test_compliance_workflow_creation(self):
         """Test creating a compliance workflow."""
         # Create compliance workflow
         workflow_id = self.integration.create_compliance_workflow(
-            self.task_id, self.agent_id, self.workflow_name,
+            self.task_id,
+            self.agent_id,
+            self.workflow_name,
             [self.state_start, self.state_process, self.state_end],
             [self.transition_start_process, self.transition_process_end],
-            self.workflow_priority
+            self.workflow_priority,
         )
-        
+
         # Verify workflow created
         self.assertIsNotNone(workflow_id)
         self.assertIn(workflow_id, self.integration.compliance_workflows)
-        
+
         # Verify integration metadata
         workflow_data = self.integration.compliance_workflows[workflow_id]
         self.assertEqual(workflow_data["task_id"], self.task_id)
         self.assertEqual(workflow_data["agent_id"], self.agent_id)
         self.assertEqual(workflow_data["workflow_name"], self.workflow_name)
         self.assertEqual(workflow_data["status"], "integrated")
-        
+
         # Verify mappings - check both directions
         self.assertIn(workflow_id, self.integration.fsm_compliance_mapping)
         compliance_task_id = self.integration.fsm_compliance_mapping[workflow_id]
         self.assertIn(compliance_task_id, self.integration.compliance_fsm_mapping)
-        self.assertEqual(self.integration.compliance_fsm_mapping[compliance_task_id], workflow_id)
-    
+        self.assertEqual(
+            self.integration.compliance_fsm_mapping[compliance_task_id], workflow_id
+        )
+
     def test_compliance_workflow_start(self):
         """Test starting a compliance workflow."""
         # Create workflow first
         workflow_id = self.integration.create_compliance_workflow(
-            self.task_id, self.agent_id, self.workflow_name,
+            self.task_id,
+            self.agent_id,
+            self.workflow_name,
             [self.state_start, self.state_process, self.state_end],
             [self.transition_start_process, self.transition_process_end],
-            self.workflow_priority
+            self.workflow_priority,
         )
-        
+
         # Start workflow
         result = self.integration.start_compliance_workflow(workflow_id)
         self.assertTrue(result)
-        
+
         # Verify workflow status updated
         workflow_data = self.integration.compliance_workflows[workflow_id]
         self.assertEqual(workflow_data["status"], "running")
         self.assertIn("started_at", workflow_data)
-    
+
     def test_compliance_progress_tracking(self):
         """Test compliance progress tracking."""
         # Create workflow first
         workflow_id = self.integration.create_compliance_workflow(
-            self.task_id, self.agent_id, self.workflow_name,
+            self.task_id,
+            self.agent_id,
+            self.workflow_name,
             [self.state_start, self.state_process, self.state_end],
             [self.transition_start_process, self.transition_process_end],
-            self.workflow_priority
+            self.workflow_priority,
         )
-        
+
         # Update progress
         result = self.integration.update_compliance_progress(
-            workflow_id, 50.0, "PROCESSING",
+            workflow_id,
+            50.0,
+            "PROCESSING",
             deliverables={"fsm_workflow": "ACTIVE", "validation": "IN_PROGRESS"},
             code_changes=["Updated workflow state"],
-            devlog_entries=["Progress update: 50% complete"]
+            devlog_entries=["Progress update: 50% complete"],
         )
-        
+
         self.assertTrue(result)
-        
+
         # Verify progress updated
         workflow_data = self.integration.compliance_workflows[workflow_id]
         self.assertEqual(workflow_data["current_progress"], 50.0)
         self.assertEqual(workflow_data["current_phase"], "PROCESSING")
         self.assertIn("last_progress_update", workflow_data)
-    
+
     def test_compliance_workflow_validation(self):
         """Test compliance workflow validation."""
         # Create and start workflow
         workflow_id = self.integration.create_compliance_workflow(
-            self.task_id, self.agent_id, self.workflow_name,
+            self.task_id,
+            self.agent_id,
+            self.workflow_name,
             [self.state_start, self.state_process, self.state_end],
             [self.transition_start_process, self.transition_process_end],
-            self.workflow_priority
+            self.workflow_priority,
         )
-        
+
         self.integration.start_compliance_workflow(workflow_id)
-        
+
         # Validate workflow
         validation_results = self.integration.validate_compliance_workflow(workflow_id)
-        
+
         # Verify validation results
         self.assertIsNotNone(validation_results)
         self.assertIn("workflow_id", validation_results)
@@ -227,32 +200,34 @@ class FSMComplianceIntegrationTest(unittest.TestCase):
         self.assertIn("agent_id", validation_results)
         self.assertIn("checks", validation_results)
         self.assertIn("overall_valid", validation_results)
-        
+
         # Check FSM workflow validation
         fsm_check = validation_results["checks"].get("fsm_workflow")
         self.assertIsNotNone(fsm_check)
         self.assertEqual(fsm_check["status"], "VALID")
-        
+
         # Check compliance tracking validation
         compliance_check = validation_results["checks"].get("compliance_tracking")
         self.assertIsNotNone(compliance_check)
         self.assertEqual(compliance_check["status"], "VALID")
-    
+
     def test_workflow_status_retrieval(self):
         """Test retrieving comprehensive workflow status."""
         # Create and start workflow
         workflow_id = self.integration.create_compliance_workflow(
-            self.task_id, self.agent_id, self.workflow_name,
+            self.task_id,
+            self.agent_id,
+            self.workflow_name,
             [self.state_start, self.state_process, self.state_end],
             [self.transition_start_process, self.transition_process_end],
-            self.workflow_priority
+            self.workflow_priority,
         )
-        
+
         self.integration.start_compliance_workflow(workflow_id)
-        
+
         # Get workflow status
         status = self.integration.get_compliance_workflow_status(workflow_id)
-        
+
         # Verify status structure
         self.assertIsNotNone(status)
         self.assertEqual(status["fsm_workflow_id"], workflow_id)
@@ -260,17 +235,17 @@ class FSMComplianceIntegrationTest(unittest.TestCase):
         self.assertEqual(status["agent_id"], self.agent_id)
         self.assertEqual(status["workflow_name"], self.workflow_name)
         self.assertEqual(status["integration_status"], "running")
-        
+
         # Verify FSM status
         self.assertIsNotNone(status["fsm_status"])
         self.assertIn("current_state", status["fsm_status"])
         self.assertIn("status", status["fsm_status"])
-        
+
         # Verify compliance status
         self.assertIsNotNone(status["compliance_status"])
         self.assertIn("progress_percentage", status["compliance_status"])
         self.assertIn("current_phase", status["compliance_status"])
-    
+
     def test_workflow_listing(self):
         """Test listing compliance workflows."""
         # Create multiple workflows with proper state setup
@@ -285,7 +260,7 @@ class FSMComplianceIntegrationTest(unittest.TestCase):
             retry_delay=0.0,
             required_resources=[],
             dependencies=[],
-            metadata={}
+            metadata={},
         )
         end_state1 = StateDefinition(
             name="end1",
@@ -297,20 +272,28 @@ class FSMComplianceIntegrationTest(unittest.TestCase):
             retry_delay=0.0,
             required_resources=[],
             dependencies=[],
-            metadata={}
+            metadata={},
         )
         transition1 = TransitionDefinition(
-            from_state="start1", to_state="end1", transition_type=TransitionType.AUTOMATIC,
-            condition=None, priority=1, timeout_seconds=None, actions=[], metadata={}
+            from_state="start1",
+            to_state="end1",
+            transition_type=TransitionType.AUTOMATIC,
+            condition=None,
+            priority=1,
+            timeout_seconds=None,
+            actions=[],
+            metadata={},
         )
-        
+
         workflow1_id = self.integration.create_compliance_workflow(
-            "TASK_1", "Agent-1", "Workflow 1",
+            "TASK_1",
+            "Agent-1",
+            "Workflow 1",
             [start_state1, end_state1],
             [transition1],
-            WorkflowPriority.HIGH
+            WorkflowPriority.HIGH,
         )
-        
+
         # Second workflow
         start_state2 = StateDefinition(
             name="start2",
@@ -322,7 +305,7 @@ class FSMComplianceIntegrationTest(unittest.TestCase):
             retry_delay=0.0,
             required_resources=[],
             dependencies=[],
-            metadata={}
+            metadata={},
         )
         end_state2 = StateDefinition(
             name="end2",
@@ -334,171 +317,183 @@ class FSMComplianceIntegrationTest(unittest.TestCase):
             retry_delay=0.0,
             required_resources=[],
             dependencies=[],
-            metadata={}
+            metadata={},
         )
         transition2 = TransitionDefinition(
-            from_state="start2", to_state="end2", transition_type=TransitionType.AUTOMATIC,
-            condition=None, priority=1, timeout_seconds=None, actions=[], metadata={}
+            from_state="start2",
+            to_state="end2",
+            transition_type=TransitionType.AUTOMATIC,
+            condition=None,
+            priority=1,
+            timeout_seconds=None,
+            actions=[],
+            metadata={},
         )
-        
+
         workflow2_id = self.integration.create_compliance_workflow(
-            "TASK_2", "Agent-2", "Workflow 2",
+            "TASK_2",
+            "Agent-2",
+            "Workflow 2",
             [start_state2, end_state2],
             [transition2],
-            WorkflowPriority.NORMAL
+            WorkflowPriority.NORMAL,
         )
-        
+
         # List all workflows
         all_workflows = self.integration.list_compliance_workflows()
         self.assertEqual(len(all_workflows), 2)
-        
+
         # List workflows by status
         integrated_workflows = self.integration.list_compliance_workflows("integrated")
         self.assertEqual(len(integrated_workflows), 2)
-        
+
         # Verify workflow data
-        workflow1_data = next(w for w in all_workflows if w["fsm_workflow_id"] == workflow1_id)
+        workflow1_data = next(
+            w for w in all_workflows if w["fsm_workflow_id"] == workflow1_id
+        )
         self.assertEqual(workflow1_data["task_id"], "TASK_1")
         self.assertEqual(workflow1_data["agent_id"], "Agent-1")
         self.assertEqual(workflow1_data["priority"], WorkflowPriority.HIGH.value)
-    
+
     def test_integration_health_monitoring(self):
         """Test integration health monitoring."""
         # Get integration health
         health = self.integration.get_integration_health()
-        
+
         # Verify health structure
         self.assertIn("overall_health", health)
         self.assertIn("fsm_system", health)
         self.assertIn("compliance_system", health)
         self.assertIn("integration", health)
         self.assertIn("last_health_check", health)
-        
+
         # Verify FSM system health
         fsm_health = health["fsm_system"]
         self.assertIn("status", fsm_health)
         self.assertIn("connected", fsm_health)
         self.assertIn("running", fsm_health)
-        
+
         # Verify compliance system health
         compliance_health = health["compliance_system"]
         self.assertIn("status", compliance_health)
         self.assertIn("connected", compliance_health)
-        
+
         # Verify integration health
         integration_health = health["integration"]
         self.assertIn("active", integration_health)
         self.assertIn("total_workflows", integration_health)
         self.assertIn("running_workflows", integration_health)
-    
+
     def test_integration_report_export(self):
         """Test integration report export functionality."""
         # Create a workflow first
         workflow_id = self.integration.create_compliance_workflow(
-            self.task_id, self.agent_id, self.workflow_name,
+            self.task_id,
+            self.agent_id,
+            self.workflow_name,
             [self.state_start, self.state_process, self.state_end],
             [self.transition_start_process, self.transition_process_end],
-            self.workflow_priority
+            self.workflow_priority,
         )
-        
+
         # Export report
         report = self.integration.export_integration_report()
         self.assertIsNotNone(report)
-        
+
         # Parse report
         report_data = json.loads(report)
-        
+
         # Verify report structure
         self.assertIn("integration_status", report_data)
         self.assertIn("health_status", report_data)
         self.assertIn("compliance_workflows", report_data)
         self.assertIn("mappings", report_data)
         self.assertIn("exported_at", report_data)
-        
+
         # Verify workflows in report
         workflows = report_data["compliance_workflows"]
         self.assertGreater(len(workflows), 0)
-        
+
         # Verify mappings in report
         mappings = report_data["mappings"]
         self.assertIn("fsm_to_compliance", mappings)
         self.assertIn("compliance_to_fsm", mappings)
-    
+
     def test_factory_functions(self):
         """Test factory functions."""
         # Test create function
         integration = create_fsm_compliance_integration()
         self.assertIsInstance(integration, FSMComplianceIntegration)
-        
+
         # Test status function
         status = get_integration_status()
         self.assertIsInstance(status, dict)
         self.assertIn("overall_health", status)
-    
-    def test_backwards_compatibility(self):
-        """Test backwards compatibility aliases."""
-        # Test alias imports
-        from fsm_compliance_integration import FSMComplianceBridge, ComplianceFSMIntegration
-        
-        # Verify aliases work
-        bridge = FSMComplianceBridge()
-        self.assertIsInstance(bridge, FSMComplianceIntegration)
-        
-        integration = ComplianceFSMIntegration()
-        self.assertIsInstance(integration, FSMComplianceIntegration)
-    
+
     def test_error_handling(self):
         """Test error handling and recovery."""
         # Test creating workflow with invalid integration
-        with patch.object(self.integration, 'integration_status', {"integration_active": False}):
+        with patch.object(
+            self.integration, "integration_status", {"integration_active": False}
+        ):
             workflow_id = self.integration.create_compliance_workflow(
-                self.task_id, self.agent_id, self.workflow_name,
-                [self.state_start], [], self.workflow_priority
+                self.task_id,
+                self.agent_id,
+                self.workflow_name,
+                [self.state_start],
+                [],
+                self.workflow_priority,
             )
             self.assertIsNone(workflow_id)
-        
+
         # Test starting non-existent workflow
         result = self.integration.start_compliance_workflow("nonexistent")
         self.assertFalse(result)
-        
+
         # Test updating progress for non-existent workflow
-        result = self.integration.update_compliance_progress("nonexistent", 50.0, "TESTING")
+        result = self.integration.update_compliance_progress(
+            "nonexistent", 50.0, "TESTING"
+        )
         self.assertFalse(result)
-        
+
         # Test validating non-existent workflow
         validation = self.integration.validate_compliance_workflow("nonexistent")
         self.assertFalse(validation.get("overall_valid", False))
         self.assertIn("error", validation)
-    
+
     def test_workflow_lifecycle(self):
         """Test complete workflow lifecycle."""
         # Create workflow
         workflow_id = self.integration.create_compliance_workflow(
-            self.task_id, self.agent_id, self.workflow_name,
+            self.task_id,
+            self.agent_id,
+            self.workflow_name,
             [self.state_start, self.state_process, self.state_end],
             [self.transition_start_process, self.transition_process_end],
-            self.workflow_priority
+            self.workflow_priority,
         )
-        
+
         # Verify initial state
         status = self.integration.get_compliance_workflow_status(workflow_id)
         self.assertEqual(status["integration_status"], "integrated")
-        
+
         # Start workflow
         self.integration.start_compliance_workflow(workflow_id)
         status = self.integration.get_compliance_workflow_status(workflow_id)
         self.assertEqual(status["integration_status"], "running")
-        
+
         # Update progress
-        self.integration.update_compliance_progress(workflow_id, 75.0, "NEAR_COMPLETION")
+        self.integration.update_compliance_progress(
+            workflow_id, 75.0, "NEAR_COMPLETION"
+        )
         status = self.integration.get_compliance_workflow_status(workflow_id)
         self.assertEqual(status["current_progress"], 75.0)
         self.assertEqual(status["current_phase"], "NEAR_COMPLETION")
-        
+
         # Validate workflow
         validation = self.integration.validate_compliance_workflow(workflow_id)
         self.assertTrue(validation["overall_valid"])
-        
+
         # Final status check
         final_status = self.integration.get_compliance_workflow_status(workflow_id)
         self.assertIn("current_progress", final_status)
@@ -507,25 +502,25 @@ class FSMComplianceIntegrationTest(unittest.TestCase):
 
 class FSMComplianceIntegrationPerformanceTest(unittest.TestCase):
     """Performance tests for FSM compliance integration."""
-    
+
     def setUp(self):
         """Set up performance test environment."""
         self.integration = FSMComplianceIntegration()
-    
+
     def tearDown(self):
         """Clean up performance test environment."""
         # Clean up workflows
-        if hasattr(self.integration, 'fsm_system') and self.integration.fsm_system:
+        if hasattr(self.integration, "fsm_system") and self.integration.fsm_system:
             for workflow_id in list(self.integration.fsm_system.workflows.keys()):
                 try:
                     self.integration.fsm_system.stop_workflow(workflow_id)
                 except:
                     pass
-    
+
     def test_bulk_workflow_creation(self):
         """Test creating many workflows quickly."""
         start_time = time.time()
-        
+
         # Create 10 workflows
         workflow_ids = []
         for i in range(10):
@@ -539,27 +534,29 @@ class FSMComplianceIntegrationPerformanceTest(unittest.TestCase):
                 retry_delay=0.0,
                 required_resources=[],
                 dependencies=[],
-                metadata={}
+                metadata={},
             )
             workflow_id = self.integration.create_compliance_workflow(
-                f"TASK_{i}", f"Agent_{i}", f"Workflow_{i}",
+                f"TASK_{i}",
+                f"Agent_{i}",
+                f"Workflow_{i}",
                 [state],
                 [],
-                WorkflowPriority.NORMAL
+                WorkflowPriority.NORMAL,
             )
             workflow_ids.append(workflow_id)
-        
+
         creation_time = time.time() - start_time
-        
+
         # Should complete in reasonable time
         self.assertLess(creation_time, 2.0)
         self.assertEqual(len(workflow_ids), 10)
-        
+
         # Verify all workflows created
         for workflow_id in workflow_ids:
             self.assertIsNotNone(workflow_id)
             self.assertIn(workflow_id, self.integration.compliance_workflows)
-    
+
     def test_concurrent_operations(self):
         """Test concurrent workflow operations."""
         # Create workflows
@@ -575,36 +572,40 @@ class FSMComplianceIntegrationPerformanceTest(unittest.TestCase):
                 retry_delay=0.0,
                 required_resources=[],
                 dependencies=[],
-                metadata={}
+                metadata={},
             )
             workflow_id = self.integration.create_compliance_workflow(
-                f"TASK_{i}", f"Agent_{i}", f"Workflow_{i}",
+                f"TASK_{i}",
+                f"Agent_{i}",
+                f"Workflow_{i}",
                 [state],
                 [],
-                WorkflowPriority.NORMAL
+                WorkflowPriority.NORMAL,
             )
             workflow_ids.append(workflow_id)
-        
+
         # Perform concurrent operations
         start_time = time.time()
-        
+
         # Start all workflows
         for workflow_id in workflow_ids:
             self.integration.start_compliance_workflow(workflow_id)
-        
+
         # Update progress for all workflows
         for i, workflow_id in enumerate(workflow_ids):
-            self.integration.update_compliance_progress(workflow_id, 50.0 + i, f"PHASE_{i}")
-        
+            self.integration.update_compliance_progress(
+                workflow_id, 50.0 + i, f"PHASE_{i}"
+            )
+
         # Get status for all workflows
         for workflow_id in workflow_ids:
             self.integration.get_compliance_workflow_status(workflow_id)
-        
+
         operation_time = time.time() - start_time
-        
+
         # Should complete in reasonable time
         self.assertLess(operation_time, 1.0)
-        
+
         # Verify all operations completed
         for workflow_id in workflow_ids:
             status = self.integration.get_compliance_workflow_status(workflow_id)

--- a/src/core/fsm/reporting.py
+++ b/src/core/fsm/reporting.py
@@ -1,0 +1,29 @@
+"""Reporting helpers for FSM compliance integration."""
+from __future__ import annotations
+from datetime import datetime
+from typing import Any, Dict
+import json
+
+
+def generate_report(integration) -> Dict[str, Any]:
+    """Build a dictionary report from an FSMComplianceIntegration instance."""
+    return {
+        "integration_status": integration.integration_status,
+        "health_status": integration.get_integration_health(),
+        "compliance_workflows": integration.list_compliance_workflows(),
+        "mappings": {
+            "fsm_to_compliance": integration.fsm_compliance_mapping,
+            "compliance_to_fsm": integration.compliance_fsm_mapping,
+        },
+        "exported_at": datetime.now().isoformat(),
+    }
+
+
+def export_report(report_data: Dict[str, Any], fmt: str = "json") -> str:
+    """Serialize a report to the requested format."""
+    if fmt.lower() != "json":
+        raise ValueError(f"Report format '{fmt}' not supported")
+    return json.dumps(report_data, indent=2, default=str)
+
+
+__all__ = ["generate_report", "export_report"]

--- a/src/core/fsm/validation.py
+++ b/src/core/fsm/validation.py
@@ -1,0 +1,22 @@
+"""Compliance validation utilities for FSM workflows."""
+from typing import List
+from .fsm_core import StateDefinition, TransitionDefinition
+
+
+def validate_workflow(
+    states: List[StateDefinition], transitions: List[TransitionDefinition]
+) -> bool:
+    """Ensure transitions reference valid states."""
+    state_names = {state.name for state in states}
+    if not state_names:
+        return False
+    for transition in transitions:
+        if (
+            transition.from_state not in state_names
+            or transition.to_state not in state_names
+        ):
+            return False
+    return True
+
+
+__all__ = ["validate_workflow"]


### PR DESCRIPTION
## Summary
- add shared FSM constants and definition helpers
- extract workflow validation and reporting helpers
- streamline compliance integration and prune legacy aliases

## Testing
- `PYTHONPATH=$PWD pre-commit run --files src/core/fsm/constants.py src/core/fsm/definitions.py src/core/fsm/validation.py src/core/fsm/reporting.py src/core/fsm/fsm_compliance_integration.py src/core/fsm/fsm_compliance_validation_test.py` (failed: ModuleNotFoundError: No module named 'src.core.performance.performance_types')
- `PYTHONPATH=$PWD pytest` (failed: No module named 'src.core.performance.performance_types')

------
https://chatgpt.com/codex/tasks/task_e_68b08be643b88329a4ff5983f3370cfa