### PR TITLE
refactor: modularize status management

### DIFF
--- a/src/core/managers/constants.py
+++ b/src/core/managers/constants.py
@@ -1,0 +1,6 @@
+"""Shared configuration constants for manager modules."""
+
+DEFAULT_HEALTH_CHECK_INTERVAL = 30
+DEFAULT_MAX_STATUS_HISTORY = 1000
+DEFAULT_AUTO_RESOLVE_TIMEOUT = 3600
+STATUS_CONFIG_PATH = "config/status_manager.json"

--- a/src/core/managers/status_registry.py
+++ b/src/core/managers/status_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
+import uuid
 from dataclasses import asdict
 from datetime import datetime
 from typing import Dict, List, Optional, Callable, Any

--- a/src/core/managers/status_tracker.py
+++ b/src/core/managers/status_tracker.py
@@ -1,0 +1,50 @@
+"""Status tracking utilities for manager system."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from .status_entities import StatusItem, StatusMetrics
+from .status_registry import StatusRegistry
+from .status_types import StatusLevel
+
+
+class StatusTracker:
+    """Track status items and component health."""
+
+    def __init__(self, max_history: int) -> None:
+        self.registry = StatusRegistry(max_history)
+
+    def set_event_callback(
+        self, callback: Callable[[str, Dict[str, Any]], None]
+    ) -> None:
+        self.registry.set_event_callback(callback)
+
+    def add_status(
+        self,
+        component: str,
+        status: str,
+        level: StatusLevel,
+        message: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        return self.registry.add_status(component, status, level, message, metadata)
+
+    def get_status(
+        self, component: Optional[str] = None
+    ) -> Union[StatusItem, List[StatusItem], None]:
+        return self.registry.get_status(component)
+
+    def resolve_status(
+        self, status_id: str, resolution_message: str = "Resolved"
+    ) -> bool:
+        return self.registry.resolve_status(status_id, resolution_message)
+
+    def get_active_alerts(self) -> List[StatusItem]:
+        return self.registry.get_active_alerts()
+
+    def get_status_summary(self, uptime_seconds: float) -> StatusMetrics:
+        return self.registry.get_summary(uptime_seconds)
+
+    def clear(self) -> None:
+        self.registry.clear()

--- a/src/core/managers/status_updater.py
+++ b/src/core/managers/status_updater.py
@@ -1,0 +1,47 @@
+"""Status update logic and health monitoring."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Callable, Dict, Optional
+
+from .status_entities import ComponentHealth
+from .status_types import HealthStatus
+from .health_monitor import HealthMonitor
+
+
+class StatusUpdater:
+    """Manage health checks and component health state."""
+
+    def __init__(self, interval: int) -> None:
+        self.health_monitor = HealthMonitor(interval)
+        self.component_health: Dict[str, ComponentHealth] = {}
+        self.health_monitor.setup_default_checks()
+
+    def register_health_check(
+        self, name: str, check: Callable[[], HealthStatus]
+    ) -> None:
+        self.health_monitor.register_health_check(name, check)
+
+    def run_health_checks(self) -> Dict[str, HealthStatus]:
+        results = self.health_monitor.run_checks()
+        for name, status in results.items():
+            self.component_health[name] = ComponentHealth(
+                component_id=name,
+                status=status,
+                last_check=datetime.now().isoformat(),
+            )
+        return results
+
+    def get_health_status(self, component_id: str) -> Optional[ComponentHealth]:
+        return self.component_health.get(component_id)
+
+    def start(self, interval: int) -> None:
+        self.health_monitor.interval = interval
+        self.health_monitor.start()
+
+    def stop(self) -> None:
+        self.health_monitor.stop()
+
+    def clear(self) -> None:
+        self.component_health.clear()


### PR DESCRIPTION
## Summary
- extract shared manager defaults into constants
- split status tracking and health updates into dedicated modules
- simplify StatusManager to delegate to tracker and updater

## Testing
- `pre-commit run --files src/core/managers/constants.py src/core/managers/status_tracker.py src/core/managers/status_updater.py src/core/managers/status_manager.py src/core/managers/status_registry.py` *(fails: No module named 'src.core.performance.performance_types')*
- `pytest` *(fails: No module named 'src.core.performance.performance_types')*


------
https://chatgpt.com/codex/tasks/task_e_68b08be6a0ac8329bc4961599e40184a