### PR TITLE
refactor: modularize streaming service

### DIFF
--- a/src/services/multimedia/media_processing.py
+++ b/src/services/multimedia/media_processing.py
@@ -1,0 +1,28 @@
+"""Media processing utilities for streaming."""
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def get_streaming_frame(stream_name: str, config: Dict[str, Any]) -> Any:
+    """Retrieve a frame from the configured source.
+
+    In the current implementation a placeholder value is returned to
+    simulate frame acquisition.
+    """
+    try:
+        return "frame_placeholder"
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Error getting frame for %s: %s", stream_name, exc)
+        return None
+
+
+def process_frame_for_streaming(frame: Any, quality_preset: Dict[str, Any]) -> Any:
+    """Process a raw frame based on the selected quality preset."""
+    try:
+        return frame
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Error processing frame: %s", exc)
+        return frame

--- a/src/services/multimedia/protocol_handler.py
+++ b/src/services/multimedia/protocol_handler.py
@@ -1,0 +1,38 @@
+"""Streaming protocol utilities for platform connections and frame delivery."""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def initialize_platform_connection(platform: str, stream_name: str) -> bool:
+    """Initialize connection to a streaming platform.
+
+    This function currently simulates a successful connection to the
+    requested platform and logs the interaction.
+    """
+    try:
+        logger.info(
+            "%s connection initialized for stream %s", platform.title(), stream_name
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Error initializing platform %s: %s", platform, exc)
+        return False
+
+
+def send_frame_to_platform(frame: Any, platform: str, stream_name: str) -> bool:
+    """Send a processed frame to a specific platform.
+
+    Args:
+        frame: Processed frame to transmit.
+        platform: Target platform name.
+        stream_name: Name of the stream.
+    """
+    try:
+        logger.debug("Frame sent to %s for stream %s", platform, stream_name)
+        return True
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Error sending frame to %s: %s", platform, exc)
+        return False

--- a/src/services/multimedia/streaming_api.py
+++ b/src/services/multimedia/streaming_api.py
@@ -1,0 +1,45 @@
+"""FastAPI endpoints for controlling streaming services."""
+
+from typing import Dict, Any
+
+try:  # pragma: no cover - optional dependency
+    from fastapi import APIRouter, HTTPException
+except Exception:  # pragma: no cover - optional dependency
+    APIRouter = None  # type: ignore
+    HTTPException = Exception
+
+from .streaming_service import StreamingService
+
+router = APIRouter() if APIRouter else None
+_service = StreamingService()
+
+if router:
+
+    @router.post("/stream/start")
+    def start_stream(config: Dict[str, Any]) -> Dict[str, Any]:
+        """Start a new live stream."""
+        if not _service.start_live_stream(config["name"], config):
+            raise HTTPException(status_code=400, detail="Failed to start stream")
+        return {"status": "started"}
+
+    @router.post("/stream/stop/{name}")
+    def stop_stream(name: str) -> Dict[str, Any]:
+        """Stop an existing live stream."""
+        if not _service.stop_live_stream(name):
+            raise HTTPException(status_code=404, detail="Stream not found")
+        return {"status": "stopped"}
+
+    @router.get("/stream/status/{name}")
+    def stream_status(name: str) -> Dict[str, Any]:
+        """Retrieve streaming session status."""
+        status = _service.get_streaming_status(name)
+        if "error" in status:
+            raise HTTPException(status_code=404, detail=status["error"])
+        return status
+
+    @router.patch("/stream/{name}/quality/{quality}")
+    def update_quality(name: str, quality: str) -> Dict[str, Any]:
+        """Update quality preset of a live stream."""
+        if not _service.update_stream_quality(name, quality):
+            raise HTTPException(status_code=400, detail="Failed to update quality")
+        return {"status": "updated"}

--- a/src/services/multimedia/streaming_config.py
+++ b/src/services/multimedia/streaming_config.py
@@ -1,0 +1,20 @@
+"""Configuration and constants for streaming services."""
+
+from typing import Dict, Any
+
+# Default streaming configuration
+DEFAULT_STREAMING_CONFIG: Dict[str, Any] = {
+    "max_streams": 5,
+    "default_quality": "720p",
+    "buffer_size": 1000,
+    "auto_restart": True,
+    "quality_presets": {
+        "1080p": {"width": 1920, "height": 1080, "bitrate": 5000},
+        "720p": {"width": 1280, "height": 720, "bitrate": 2500},
+        "480p": {"width": 854, "height": 480, "bitrate": 1000},
+    },
+}
+
+# Supported platforms and schedule types
+VALID_PLATFORMS = ["youtube", "twitch", "facebook", "instagram", "tiktok", "custom"]
+VALID_SCHEDULE_TYPES = ["once", "daily", "weekly", "monthly", "custom"]


### PR DESCRIPTION
## Summary
- split protocol handling, media processing and API endpoints into their own modules
- centralize streaming configuration and constants
- clean up imports and document functions

## Testing
- `pre-commit run --files src/services/multimedia/streaming_service.py src/services/multimedia/media_processing.py src/services/multimedia/protocol_handler.py src/services/multimedia/streaming_config.py src/services/multimedia/streaming_api.py`
- `PYTHONPATH=. pytest src/services/multimedia/tests/test_multimedia_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68b08bf779dc8329a7009bcca1b7eb3c