### PR TITLE
refactor: modularize repository utilities

### DIFF
--- a/config/repo_config.py
+++ b/config/repo_config.py
@@ -1,0 +1,27 @@
+"""Repository configuration module.
+
+Provides a single source of truth (SSOT) for repository related settings.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+BASE_PATH = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class RepoConfig:
+    """Configuration for repository operations."""
+
+    root_path: Path = BASE_PATH
+    remote: str = "origin"
+
+
+def get_repo_config() -> RepoConfig:
+    """Return default repository configuration.
+
+    This function acts as a SSOT so that all repository modules share the
+    same configuration instance.
+    """
+    return RepoConfig()

--- a/src/core/repository/__init__.py
+++ b/src/core/repository/__init__.py
@@ -20,6 +20,10 @@ from ..managers.repository_system_manager import (
     TechnologyType
 )
 
+from .access import is_repository, list_files
+from .sync import fetch, get_status
+from .audit import audit_repository
+
 __version__ = "2.0.0"
 __author__ = "V2 SWARM CAPTAIN"
 __license__ = "MIT"
@@ -31,5 +35,10 @@ __all__ = [
     "AnalysisResult",
     "DiscoveryConfig",
     "DiscoveryStatus",
-    "TechnologyType"
+    "TechnologyType",
+    "is_repository",
+    "list_files",
+    "fetch",
+    "get_status",
+    "audit_repository"
 ]

--- a/src/core/repository/access.py
+++ b/src/core/repository/access.py
@@ -1,0 +1,26 @@
+"""Repository access utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from config.repo_config import RepoConfig, get_repo_config
+
+
+def is_repository(path: Path) -> bool:
+    """Return True if *path* points to a git repository."""
+    return (path / ".git").exists()
+
+
+def list_files(config: RepoConfig | None = None) -> List[Path]:
+    """List all files in the repository defined by *config*.
+
+    Parameters
+    ----------
+    config:
+        Repository configuration. If not provided, the default configuration
+        is used.
+    """
+    cfg = config or get_repo_config()
+    root = cfg.root_path
+    return [p for p in root.rglob("*") if p.is_file() and ".git" not in p.parts]

--- a/src/core/repository/audit.py
+++ b/src/core/repository/audit.py
@@ -1,0 +1,31 @@
+"""Repository auditing utilities."""
+from __future__ import annotations
+
+import subprocess
+from typing import Dict, List
+
+from config.repo_config import RepoConfig, get_repo_config
+
+
+def audit_repository(config: RepoConfig | None = None) -> Dict[str, List[str]]:
+    """Audit repository for local changes.
+
+    Returns a dictionary with lists of modified and untracked files.
+    """
+    cfg = config or get_repo_config()
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=cfg.root_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    modified: List[str] = []
+    untracked: List[str] = []
+    for line in result.stdout.splitlines():
+        status, file = line[:2], line[3:]
+        if status == "??":
+            untracked.append(file)
+        elif file:
+            modified.append(file)
+    return {"modified": modified, "untracked": untracked}

--- a/src/core/repository/sync.py
+++ b/src/core/repository/sync.py
@@ -1,0 +1,32 @@
+"""Repository synchronization utilities."""
+from __future__ import annotations
+
+import subprocess
+from typing import Optional
+
+from config.repo_config import RepoConfig, get_repo_config
+
+
+def fetch(config: RepoConfig | None = None) -> subprocess.CompletedProcess[str]:
+    """Fetch updates from the remote without merging."""
+    cfg = config or get_repo_config()
+    return subprocess.run(
+        ["git", "fetch", cfg.remote],
+        cwd=cfg.root_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def get_status(config: RepoConfig | None = None) -> str:
+    """Return short repository status."""
+    cfg = config or get_repo_config()
+    result = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=cfg.root_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()

--- a/tests/unit/test_repository_utils.py
+++ b/tests/unit/test_repository_utils.py
@@ -1,0 +1,28 @@
+"""Tests for repository utility modules."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from config.repo_config import get_repo_config
+from src.core.repository import access, audit, sync
+
+
+def test_is_repository() -> None:
+    cfg = get_repo_config()
+    assert access.is_repository(cfg.root_path)
+
+
+def test_list_files_excludes_git_dir() -> None:
+    cfg = get_repo_config()
+    files = access.list_files(cfg)
+    assert all(".git" not in p.parts for p in files)
+
+
+def test_sync_get_status() -> None:
+    status = sync.get_status()
+    assert isinstance(status, str)
+
+
+def test_audit_repository_returns_dict() -> None:
+    result = audit.audit_repository()
+    assert set(result.keys()) == {"modified", "untracked"}


### PR DESCRIPTION
## Summary
- centralize repo paths and remote settings in `repo_config`
- add dedicated modules for repository access, sync, and auditing
- expose new utilities and ensure type hints/docstrings

## Testing
- `pytest tests/unit/test_repository_utils.py -q` *(fails: No module named 'src.core.performance.performance_types')*


------
https://chatgpt.com/codex/tasks/task_e_68b08bf8b81083299a2d49562726a41a