### PR TITLE
docs: document backup policy and ignore backup dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ $RECYCLE.BIN/
 *.msp
 *.lnk
 
+# Backup directories
+*_backup_*/
+
 # Linux
 *~
 .fuse_hidden*

--- a/README.md
+++ b/README.md
@@ -297,3 +297,10 @@ logger = get_logger(__name__)
 ```
 
 This centralizes configuration and removes the need for module-level `logging.basicConfig` calls.
+
+## Backup Policy
+
+Temporary backup directories (e.g., names matching `*_backup_*`) may be
+created for short-term local use during development. These directories are
+ignored by Git and should never be committed to the repository. Remove or move
+backups outside the project before submitting changes to keep history clean.


### PR DESCRIPTION
## Summary
- ignore backup directories matching `*_backup_*`
- document backup policy to keep repo clean

## Testing
- `pre-commit run --files .gitignore README.md`
- `pytest` *(fails: ModuleNotFoundError: coverage and multiple collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b194e0ad788329924a90312ef5959e