### PR TITLE
Refactor orchestrator into modular components

### DIFF
--- a/src/core/manager_orchestrator.py
+++ b/src/core/manager_orchestrator.py
@@ -1,92 +1,42 @@
 #!/usr/bin/env python3
-"""
-Manager Orchestrator - V2 Core Manager Coordination System
-=========================================================
+"""Manager Orchestrator - delegates registry, lifecycle and integration."""
 
-Coordinates all consolidated managers and provides unified interface.
-Eliminates duplication by orchestrating 42 manager files into 8 specialized managers.
-
-Follows V2 standards: 400 LOC, OOP design, SRP.
-
-Author: V2 SWARM CAPTAIN
-License: MIT
-"""
-
-import logging
 import json
-import time
-import threading
+import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Type, Union
-from dataclasses import dataclass, asdict
-from datetime import datetime, timedelta
-from collections import defaultdict
+from typing import Any, Dict, Optional
 
-from src.utils.stability_improvements import stability_manager, safe_import
-from .base_manager import BaseManager, ManagerStatus, ManagerPriority, ManagerMetrics
+from .base_manager import BaseManager
+from .orchestrator import (
+    ManagerRegistry,
+    LifecycleManager,
+    IntegrationManager,
+)
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class ManagerInfo:
-    """Information about a registered manager"""
-    manager_name: str
-    manager_class: Type[BaseManager]
-    instance: Optional[BaseManager]
-    status: ManagerStatus
-    priority: ManagerPriority
-    dependencies: List[str]
-    config_path: Optional[str]
-    last_health_check: datetime
-    health_status: Dict[str, Any]
-
-
 class ManagerOrchestrator:
-    """
-    Manager Orchestrator - Single responsibility: Coordinate all managers
-    
-    This class eliminates duplication by orchestrating 42 manager files into:
-    - 1 BaseManager (common functionality)
-    - 8 specialized managers (inheriting from BaseManager)
-    - 1 ManagerOrchestrator (coordination)
-    
-    Expected reduction: 42 files → 10 files (76% reduction)
-    """
+    """Coordinate managers via dedicated registry and lifecycle helpers."""
 
     def __init__(self, config_path: str = "config/manager_orchestrator.json"):
-        """Initialize the manager orchestrator"""
         self.config_path = Path(config_path)
         self.config = self._load_config()
-        
-        # Manager registry
-        self.managers: Dict[str, ManagerInfo] = {}
-        self.manager_instances: Dict[str, BaseManager] = {}
-        
-        # Dependencies and ordering
-        self.dependency_graph: Dict[str, List[str]] = {}
-        self.startup_order: List[str] = []
-        
-        # Health monitoring
-        self.health_check_interval = self.config.get("health_check_interval", 300)  # 5 minutes
-        self.last_health_check = datetime.now()
-        self.health_thread = None
-        self.shutdown_event = threading.Event()
-        
-        # Performance tracking
-        self.start_time = datetime.now()
-        self.total_operations = 0
-        self.failed_operations = 0
-        
-        # Initialize orchestrator
-        self._register_default_managers()
-        self._build_dependency_graph()
-        self._calculate_startup_order()
-        
+
+        self.registry = ManagerRegistry()
+        self.registry.register_default_managers()
+        self.registry.build_dependency_graph()
+        self.registry.calculate_startup_order()
+
+        self.lifecycle = LifecycleManager(self.registry, self.config)
+        self.integration = IntegrationManager(self.registry, self.lifecycle)
+
         logger.info("ManagerOrchestrator initialized successfully")
 
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
     def _load_config(self) -> Dict[str, Any]:
-        """Load orchestrator configuration"""
         default_config = {
             "health_check_interval": 300,
             "max_startup_time": 60,
@@ -98,507 +48,72 @@ class ManagerOrchestrator:
             "enable_metrics": True,
             "enable_events": True,
         }
-        
         if not self.config_path.exists():
             return default_config
-        
         try:
-            with open(self.config_path, 'r') as f:
+            with open(self.config_path, "r") as f:
                 config = json.load(f)
                 default_config.update(config)
-                logger.info(f"Configuration loaded from {self.config_path}")
-        except Exception as e:
-            logger.error(f"Failed to load config: {e}")
-        
+                logger.info("Configuration loaded from %s", self.config_path)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to load config: %s", exc)
         return default_config
 
-    def _register_default_managers(self) -> None:
-        """Register the 8 specialized managers that replace 42 duplicate files"""
-        
-        # Core System Managers (replaces 15+ core manager files)
-        self._register_manager(
-            "system_manager",
-            "SystemManager",
-            priority=ManagerPriority.CRITICAL,
-            dependencies=[],
-            config_path="config/system_manager.json"
-        )
-        
-        # Configuration Manager (replaces 6+ config manager files)
-        self._register_manager(
-            "config_manager", 
-            "ConfigManager",
-            priority=ManagerPriority.HIGH,
-            dependencies=["system_manager"],
-            config_path="config/config_manager.json"
-        )
-        
-        # Status Manager (replaces 5+ status manager files)
-        self._register_manager(
-            "status_manager",
-            "StatusManager", 
-            priority=ManagerPriority.HIGH,
-            dependencies=["system_manager"],
-            config_path="config/status_manager.json"
-        )
-        
-        # Task Manager (replaces 4+ task manager files)
-        self._register_manager(
-            "task_manager",
-            "TaskManager",
-            priority=ManagerPriority.HIGH,
-            dependencies=["system_manager", "status_manager"],
-            config_path="config/task_manager.json"
-        )
-        
-        # Data Manager (replaces 4+ data manager files)
-        self._register_manager(
-            "data_manager",
-            "DataManager",
-            priority=ManagerPriority.MEDIUM,
-            dependencies=["system_manager", "config_manager"],
-            config_path="config/data_manager.json"
-        )
-        
-        # Communication Manager (replaces 3+ communication manager files)
-        self._register_manager(
-            "communication_manager",
-            "CommunicationManager",
-            priority=ManagerPriority.MEDIUM,
-            dependencies=["system_manager", "config_manager"],
-            config_path="config/communication_manager.json"
-        )
-        
-        # Health Manager (replaces 3+ health manager files)
-        self._register_manager(
-            "health_manager",
-            "HealthManager",
-            priority=ManagerPriority.MEDIUM,
-            dependencies=["system_manager", "status_manager"],
-            config_path="config/health_manager.json"
-        )
-        
-        # Performance Manager (replaces 2+ performance manager files)
-        self._register_manager(
-            "performance_manager",
-            "PerformanceManager",
-            priority=ManagerPriority.LOW,
-            dependencies=["system_manager", "health_manager"],
-            config_path="config/performance_manager.json"
-        )
-        
-        logger.info(f"Registered {len(self.managers)} specialized managers")
-
-    def _register_manager(
-        self,
-        manager_name: str,
-        manager_class_name: str,
-                    priority: ManagerPriority = ManagerPriority.NORMAL,
-        dependencies: List[str] = None,
-        config_path: Optional[str] = None
-    ) -> None:
-        """Register a manager with the orchestrator"""
-        if dependencies is None:
-            dependencies = []
-        
-        # For now, we'll use placeholder classes until we create the specialized managers
-        # In the actual implementation, these would be imported from their respective modules
-        class PlaceholderManager(BaseManager):
-            def _validate_data(self, data: Any) -> bool:
-                return True
-        
-        manager_info = ManagerInfo(
-            manager_name=manager_name,
-            manager_class=PlaceholderManager,
-            instance=None,
-            status=ManagerStatus.INACTIVE,
-            priority=priority,
-            dependencies=dependencies,
-            config_path=config_path,
-            last_health_check=datetime.now(),
-            health_status={}
-        )
-        
-        self.managers[manager_name] = manager_info
-        logger.debug(f"Registered manager: {manager_name}")
-
-    def _build_dependency_graph(self) -> None:
-        """Build dependency graph for startup ordering"""
-        self.dependency_graph = {}
-        
-        for manager_name, manager_info in self.managers.items():
-            self.dependency_graph[manager_name] = manager_info.dependencies.copy()
-        
-        logger.debug("Dependency graph built")
-
-    def _calculate_startup_order(self) -> None:
-        """Calculate startup order based on dependencies"""
-        visited = set()
-        temp_visited = set()
-        order = []
-        
-        def dfs(node: str) -> None:
-            if node in temp_visited:
-                raise ValueError(f"Circular dependency detected: {node}")
-            if node in visited:
-                return
-            
-            temp_visited.add(node)
-            
-            for dependency in self.dependency_graph.get(node, []):
-                if dependency not in self.managers:
-                    logger.warning(f"Manager {node} depends on unknown manager: {dependency}")
-                else:
-                    dfs(dependency)
-            
-            temp_visited.remove(node)
-            visited.add(node)
-            order.append(node)
-        
-        # Process managers in priority order
-        priority_order = sorted(
-            self.managers.keys(),
-            key=lambda x: self.managers[x].priority.value,
-            reverse=True
-        )
-        
-        for manager_name in priority_order:
-            if manager_name not in visited:
-                dfs(manager_name)
-        
-        self.startup_order = order
-        logger.info(f"Startup order calculated: {self.startup_order}")
-
+    # ------------------------------------------------------------------
+    # Lifecycle delegation
+    # ------------------------------------------------------------------
     def start_all_managers(self) -> bool:
-        """Start all managers in dependency order"""
-        logger.info("Starting all managers...")
-        
-        startup_results = {}
-        failed_managers = []
-        
-        for manager_name in self.startup_order:
-            try:
-                logger.info(f"Starting manager: {manager_name}")
-                
-                # Create manager instance
-                manager_info = self.managers[manager_name]
-                manager_instance = manager_info.manager_class(
-                    manager_name=manager_name,
-                    config_path=manager_info.config_path,
-                    enable_metrics=self.config.get("enable_metrics", True),
-                    enable_events=self.config.get("enable_events", True)
-                )
-                
-                # Start manager
-                if manager_instance.start():
-                    manager_info.instance = manager_instance
-                    manager_info.status = ManagerStatus.ACTIVE
-                    self.manager_instances[manager_name] = manager_instance
-                    startup_results[manager_name] = True
-                    logger.info(f"✅ Manager {manager_name} started successfully")
-                else:
-                    startup_results[manager_name] = False
-                    failed_managers.append(manager_name)
-                    logger.error(f"❌ Manager {manager_name} failed to start")
-                
-            except Exception as e:
-                startup_results[manager_name] = False
-                failed_managers.append(manager_name)
-                logger.error(f"❌ Failed to start manager {manager_name}: {e}")
-        
-        # Report results
-        successful = sum(startup_results.values())
-        total = len(startup_results)
-        
-        logger.info(f"Manager startup complete: {successful}/{total} successful")
-        
-        if failed_managers:
-            logger.error(f"Failed managers: {failed_managers}")
-            return False
-        
-        # Start health monitoring
-        self._start_health_monitoring()
-        
-        return True
+        return self.lifecycle.start_all_managers()
 
     def stop_all_managers(self) -> None:
-        """Stop all managers in reverse dependency order"""
-        logger.info("Stopping all managers...")
-        
-        # Stop health monitoring
-        self._stop_health_monitoring()
-        
-        # Stop managers in reverse order
-        for manager_name in reversed(self.startup_order):
-            if manager_name in self.manager_instances:
-                try:
-                    manager_instance = self.manager_instances[manager_name]
-                    manager_instance.stop()
-                    self.managers[manager_name].status = ManagerStatus.SHUTDOWN
-                    logger.info(f"✅ Manager {manager_name} stopped")
-                except Exception as e:
-                    logger.error(f"❌ Failed to stop manager {manager_name}: {e}")
-        
-        logger.info("All managers stopped")
+        self.lifecycle.stop_all_managers()
 
     def restart_manager(self, manager_name: str) -> bool:
-        """Restart a specific manager"""
-        if manager_name not in self.manager_instances:
-            logger.error(f"Manager {manager_name} not found")
-            return False
-        
-        try:
-            logger.info(f"Restarting manager: {manager_name}")
-            
-            # Stop manager
-            manager_instance = self.manager_instances[manager_name]
-            manager_instance.stop()
-            
-            # Start manager
-            if manager_instance.start():
-                self.managers[manager_name].status = ManagerStatus.ACTIVE
-                logger.info(f"✅ Manager {manager_name} restarted successfully")
-                return True
-            else:
-                logger.error(f"❌ Manager {manager_name} failed to restart")
-                return False
-                
-        except Exception as e:
-            logger.error(f"❌ Failed to restart manager {manager_name}: {e}")
-            return False
-
-    def get_manager(self, manager_name: str) -> Optional[BaseManager]:
-        """Get a specific manager instance"""
-        return self.manager_instances.get(manager_name)
-
-    def get_manager_status(self, manager_name: str) -> Optional[Dict[str, Any]]:
-        """Get status of a specific manager"""
-        if manager_name not in self.managers:
-            return None
-        
-        manager_info = self.managers[manager_name]
-        manager_instance = self.manager_instances.get(manager_name)
-        
-        status = {
-            "manager_name": manager_name,
-            "status": manager_info.status.value,
-            "priority": manager_info.priority.value,
-            "dependencies": manager_info.dependencies,
-            "last_health_check": manager_info.last_health_check.isoformat(),
-            "health_status": manager_info.health_status
-        }
-        
-        if manager_instance:
-            status.update({
-                "instance_info": manager_instance.get_info(),
-                "health_check": manager_instance.health_check()
-            })
-        
-        return status
-
-    def get_all_manager_statuses(self) -> Dict[str, Dict[str, Any]]:
-        """Get status of all managers"""
-        return {
-            manager_name: self.get_manager_status(manager_name)
-            for manager_name in self.managers.keys()
-        }
-
-    def _start_health_monitoring(self) -> None:
-        """Start health monitoring thread"""
-        if self.health_thread and self.health_thread.is_alive():
-            return
-        
-        self.health_thread = threading.Thread(
-            target=self._health_monitoring_loop,
-            daemon=True
-        )
-        self.health_thread.start()
-        logger.info("Health monitoring started")
-
-    def _stop_health_monitoring(self) -> None:
-        """Stop health monitoring thread"""
-        self.shutdown_event.set()
-        if self.health_thread and self.health_thread.is_alive():
-            self.health_thread.join(timeout=5)
-        logger.info("Health monitoring stopped")
-
-    def _health_monitoring_loop(self) -> None:
-        """Health monitoring loop"""
-        while not self.shutdown_event.is_set():
-            try:
-                self._perform_health_checks()
-                time.sleep(self.health_check_interval)
-            except Exception as e:
-                logger.error(f"Health monitoring error: {e}")
-                time.sleep(60)  # Wait before retrying
-
-    def _perform_health_checks(self) -> None:
-        """Perform health checks on all managers"""
-        logger.debug("Performing health checks...")
-        
-        for manager_name in self.managers.keys():
-            if manager_name in self.manager_instances:
-                try:
-                    manager_instance = self.manager_instances[manager_name]
-                    health_status = manager_instance.health_check()
-                    
-                    # Update manager info
-                    self.managers[manager_name].last_health_check = datetime.now()
-                    self.managers[manager_name].health_status = health_status
-                    
-                    # Check if manager is healthy
-                    if not health_status.get("is_healthy", False):
-                        logger.warning(f"Manager {manager_name} is unhealthy: {health_status}")
-                        
-                        # Auto-recovery if enabled
-                        if self.config.get("enable_auto_recovery", True):
-                            self._attempt_auto_recovery(manager_name)
-                    
-                except Exception as e:
-                    logger.error(f"Health check failed for {manager_name}: {e}")
-                    self.managers[manager_name].health_status = {"error": str(e)}
-
-    def _attempt_auto_recovery(self, manager_name: str) -> None:
-        """Attempt to automatically recover a failed manager"""
-        max_attempts = self.config.get("max_retry_attempts", 3)
-        retry_delay = self.config.get("retry_delay", 5)
-        
-        logger.info(f"Attempting auto-recovery for {manager_name}")
-        
-        for attempt in range(max_attempts):
-            try:
-                if self.restart_manager(manager_name):
-                    logger.info(f"✅ Auto-recovery successful for {manager_name}")
-                    return
-                else:
-                    logger.warning(f"Auto-recovery attempt {attempt + 1} failed for {manager_name}")
-                    
-            except Exception as e:
-                logger.error(f"Auto-recovery attempt {attempt + 1} error for {manager_name}: {e}")
-            
-            if attempt < max_attempts - 1:
-                time.sleep(retry_delay)
-        
-        logger.error(f"❌ Auto-recovery failed for {manager_name} after {max_attempts} attempts")
-
-    def get_orchestrator_metrics(self) -> Dict[str, Any]:
-        """Get orchestrator performance metrics"""
-        return {
-            "orchestrator_name": "ManagerOrchestrator",
-            "start_time": self.start_time.isoformat(),
-            "uptime": (datetime.now() - self.start_time).total_seconds(),
-            "total_managers": len(self.managers),
-            "active_managers": len([m for m in self.managers.values() if m.status == ManagerStatus.ACTIVE]),
-            "failed_managers": len([m for m in self.managers.values() if m.status == ManagerStatus.ERROR]),
-            "total_operations": self.total_operations,
-            "failed_operations": self.failed_operations,
-            "success_rate": (self.total_operations - self.failed_operations) / self.total_operations if self.total_operations > 0 else 0,
-            "last_health_check": self.last_health_check.isoformat(),
-            "health_check_interval": self.health_check_interval,
-            "startup_order": self.startup_order,
-            "dependency_graph": self.dependency_graph
-        }
-
-    def get_consolidation_summary(self) -> Dict[str, Any]:
-        """Get summary of manager consolidation benefits"""
-        return {
-            "consolidation_benefits": {
-                "files_before": 42,
-                "files_after": 10,
-                "reduction_percentage": 76,
-                "duplication_eliminated": "80%",
-                "maintenance_effort_reduction": "50-60%",
-                "code_consolidation": "70%"
-            },
-            "manager_categories": {
-                "core_system": ["system_manager", "config_manager", "status_manager"],
-                "task_management": ["task_manager"],
-                "data_management": ["data_manager"],
-                "communication": ["communication_manager"],
-                "health_monitoring": ["health_manager", "performance_manager"]
-            },
-            "replaced_files": {
-                "system_manager": [
-                    "agent_manager.py", "core_manager.py", "repository/system_manager.py",
-                    "workspace_manager.py", "persistent_storage_manager.py"
-                ],
-                "config_manager": [
-                    "config_manager.py", "config_manager_core.py", "config_manager_loader.py",
-                    "config_manager_validator.py", "config_manager_config.py"
-                ],
-                "status_manager": [
-                    "status_manager.py", "status_manager_core.py", "status_manager_tracker.py",
-                    "status_manager_reporter.py", "status_manager_config.py"
-                ],
-                "task_manager": [
-                    "task_manager.py", "autonomous_development/tasks/manager.py",
-                    "task_management/task_scheduler_manager.py", "autonomous_development/workflow/manager.py"
-                ],
-                "data_manager": [
-                    "services/testing/data_manager.py", "services/financial/sentiment/data_manager.py",
-                    "services/financial/analytics/data_manager.py"
-                ],
-                "communication_manager": [
-                    "services/communication/channel_manager.py", "core/communication/communication_manager.py",
-                    "services/api_manager.py"
-                ],
-                "health_manager": [
-                    "core/health_alert_manager.py", "core/health_threshold_manager.py",
-                    "core/health/monitoring/health_notification_manager.py"
-                ],
-                "performance_manager": [
-                    "core/performance/alerts/manager.py", "core/connection_pool_manager.py"
-                ]
-            }
-        }
+        return self.lifecycle.restart_manager(manager_name)
 
     def cleanup(self) -> None:
-        """Clean up orchestrator resources"""
-        logger.info("Cleaning up orchestrator resources...")
-        
-        # Clean up managers
-        for manager_name in self.manager_instances:
-            try:
-                manager_instance = self.manager_instances[manager_name]
-                manager_instance.cleanup()
-            except Exception as e:
-                logger.error(f"Cleanup error for {manager_name}: {e}")
-        
-        # Save configuration
-        try:
-            self.config_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.config_path, 'w') as f:
-                json.dump(self.config, f, indent=2, default=str)
-        except Exception as e:
-            logger.error(f"Failed to save configuration: {e}")
-        
-        logger.info("Orchestrator cleanup completed")
+        self.lifecycle.cleanup(self.config_path, self.config)
 
+    # ------------------------------------------------------------------
+    # Integration utilities
+    # ------------------------------------------------------------------
+    def get_manager(self, manager_name: str) -> Optional[BaseManager]:
+        return self.integration.get_manager(manager_name)
+
+    def get_manager_status(self, manager_name: str) -> Optional[Dict[str, Any]]:
+        return self.integration.get_manager_status(manager_name)
+
+    def get_all_manager_statuses(self) -> Dict[str, Dict[str, Any]]:
+        return self.integration.get_all_manager_statuses()
+
+    def get_orchestrator_metrics(self) -> Dict[str, Any]:
+        return self.integration.get_orchestrator_metrics()
+
+    def get_consolidation_summary(self) -> Dict[str, Any]:
+        return self.integration.get_consolidation_summary()
+
+    # ------------------------------------------------------------------
+    # Context manager & magic methods
+    # ------------------------------------------------------------------
     def __enter__(self):
-        """Context manager entry"""
         self.start_all_managers()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit"""
         self.stop_all_managers()
         self.cleanup()
 
     def __getitem__(self, manager_name: str) -> BaseManager:
-        """Get manager by name"""
         manager = self.get_manager(manager_name)
         if not manager:
             raise KeyError(f"Manager not found: {manager_name}")
         return manager
 
     def __contains__(self, manager_name: str) -> bool:
-        """Check if manager exists"""
-        return manager_name in self.managers
+        return manager_name in self.registry.managers
 
     def __len__(self) -> int:
-        """Get number of managers"""
-        return len(self.managers)
+        return len(self.registry.managers)
 
     def __iter__(self):
-        """Iterate over manager names"""
-        return iter(self.managers.keys())
+        return iter(self.registry.managers.keys())

--- a/src/core/orchestrator/__init__.py
+++ b/src/core/orchestrator/__init__.py
@@ -1,0 +1,12 @@
+"""Orchestrator submodule providing registry, lifecycle and integration utilities."""
+
+from .registry import ManagerRegistry, ManagerInfo
+from .lifecycle import LifecycleManager
+from .integration import IntegrationManager
+
+__all__ = [
+    "ManagerRegistry",
+    "ManagerInfo",
+    "LifecycleManager",
+    "IntegrationManager",
+]

--- a/src/core/orchestrator/integration.py
+++ b/src/core/orchestrator/integration.py
@@ -1,0 +1,142 @@
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from ..base_manager import BaseManager, ManagerStatus
+from .registry import ManagerRegistry
+from .lifecycle import LifecycleManager
+
+logger = logging.getLogger(__name__)
+
+
+class IntegrationManager:
+    """Provide integration utilities and information access."""
+
+    def __init__(self, registry: ManagerRegistry, lifecycle: LifecycleManager) -> None:
+        self.registry = registry
+        self.lifecycle = lifecycle
+        self.start_time = datetime.now()
+        self.total_operations = 0
+        self.failed_operations = 0
+
+    # ------------------------------------------------------------------
+    # Manager lookup helpers
+    # ------------------------------------------------------------------
+    def get_manager(self, manager_name: str) -> Optional[BaseManager]:
+        return self.registry.manager_instances.get(manager_name)
+
+    def get_manager_status(self, manager_name: str) -> Optional[Dict[str, Any]]:
+        if manager_name not in self.registry.managers:
+            return None
+        info = self.registry.managers[manager_name]
+        inst = self.registry.manager_instances.get(manager_name)
+        status: Dict[str, Any] = {
+            "manager_name": manager_name,
+            "status": info.status.value,
+            "priority": info.priority.value,
+            "dependencies": info.dependencies,
+            "last_health_check": info.last_health_check.isoformat(),
+            "health_status": info.health_status,
+        }
+        if inst:
+            status.update({
+                "instance_info": inst.get_info(),
+                "health_check": inst.health_check(),
+            })
+        return status
+
+    def get_all_manager_statuses(self) -> Dict[str, Dict[str, Any]]:
+        return {name: self.get_manager_status(name) for name in self.registry.managers}
+
+    # ------------------------------------------------------------------
+    # Metrics and summaries
+    # ------------------------------------------------------------------
+    def get_orchestrator_metrics(self) -> Dict[str, Any]:
+        total_ops = self.total_operations
+        failed_ops = self.failed_operations
+        return {
+            "orchestrator_name": "ManagerOrchestrator",
+            "start_time": self.start_time.isoformat(),
+            "uptime": (datetime.now() - self.start_time).total_seconds(),
+            "total_managers": len(self.registry.managers),
+            "active_managers": len(
+                [m for m in self.registry.managers.values() if m.status == ManagerStatus.ACTIVE]
+            ),
+            "failed_managers": len(
+                [m for m in self.registry.managers.values() if m.status == ManagerStatus.ERROR]
+            ),
+            "total_operations": total_ops,
+            "failed_operations": failed_ops,
+            "success_rate": (total_ops - failed_ops) / total_ops if total_ops > 0 else 0,
+            "last_health_check": self.lifecycle.last_health_check.isoformat(),
+            "health_check_interval": self.lifecycle.health_check_interval,
+            "startup_order": self.registry.startup_order,
+            "dependency_graph": self.registry.dependency_graph,
+        }
+
+    def get_consolidation_summary(self) -> Dict[str, Any]:
+        return {
+            "consolidation_benefits": {
+                "files_before": 42,
+                "files_after": 10,
+                "reduction_percentage": 76,
+                "duplication_eliminated": "80%",
+                "maintenance_effort_reduction": "50-60%",
+                "code_consolidation": "70%",
+            },
+            "manager_categories": {
+                "core_system": ["system_manager", "config_manager", "status_manager"],
+                "task_management": ["task_manager"],
+                "data_management": ["data_manager"],
+                "communication": ["communication_manager"],
+                "health_monitoring": ["health_manager", "performance_manager"],
+            },
+            "replaced_files": {
+                "system_manager": [
+                    "agent_manager.py",
+                    "core_manager.py",
+                    "repository/system_manager.py",
+                    "workspace_manager.py",
+                    "persistent_storage_manager.py",
+                ],
+                "config_manager": [
+                    "config_manager.py",
+                    "config_manager_core.py",
+                    "config_manager_loader.py",
+                    "config_manager_validator.py",
+                    "config_manager_config.py",
+                ],
+                "status_manager": [
+                    "status_manager.py",
+                    "status_manager_core.py",
+                    "status_manager_tracker.py",
+                    "status_manager_reporter.py",
+                    "status_manager_config.py",
+                ],
+                "task_manager": [
+                    "task_manager.py",
+                    "autonomous_development/tasks/manager.py",
+                    "task_management/task_scheduler_manager.py",
+                    "autonomous_development/workflow/manager.py",
+                ],
+                "data_manager": [
+                    "services/testing/data_manager.py",
+                    "services/financial/sentiment/data_manager.py",
+                    "services/financial/analytics/data_manager.py",
+                ],
+                "communication_manager": [
+                    "services/communication/channel_manager.py",
+                    "core/communication/communication_manager.py",
+                    "services/api_manager.py",
+                ],
+                "health_manager": [
+                    "core/health_alert_manager.py",
+                    "core/health_threshold_manager.py",
+                    "core/health/monitoring/health_notification_manager.py",
+                ],
+                "performance_manager": [
+                    "core/performance/alerts/manager.py",
+                    "core/connection_pool_manager.py",
+                ],
+            },
+        }

--- a/src/core/orchestrator/lifecycle.py
+++ b/src/core/orchestrator/lifecycle.py
@@ -1,0 +1,165 @@
+import logging
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ..base_manager import BaseManager, ManagerStatus
+from .registry import ManagerRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class LifecycleManager:
+    """Handle starting, stopping and monitoring manager lifecycles."""
+
+    def __init__(self, registry: ManagerRegistry, config: Dict[str, Any]) -> None:
+        self.registry = registry
+        self.config = config
+        self.health_check_interval = config.get("health_check_interval", 300)
+        self.last_health_check = datetime.now()
+        self.health_thread: Optional[threading.Thread] = None
+        self.shutdown_event = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Startup and shutdown
+    # ------------------------------------------------------------------
+    def start_all_managers(self) -> bool:
+        logger.info("Starting all managers...")
+        startup_results: Dict[str, bool] = {}
+        failed: list[str] = []
+        for name in self.registry.startup_order:
+            info = self.registry.managers[name]
+            try:
+                manager_instance = info.manager_class(
+                    manager_name=name,
+                    config_path=info.config_path,
+                    enable_metrics=self.config.get("enable_metrics", True),
+                    enable_events=self.config.get("enable_events", True),
+                )
+                if manager_instance.start():
+                    info.instance = manager_instance
+                    info.status = ManagerStatus.ACTIVE
+                    self.registry.manager_instances[name] = manager_instance
+                    startup_results[name] = True
+                    logger.info("✅ Manager %s started successfully", name)
+                else:
+                    startup_results[name] = False
+                    failed.append(name)
+                    logger.error("❌ Manager %s failed to start", name)
+            except Exception as exc:  # pragma: no cover - defensive
+                startup_results[name] = False
+                failed.append(name)
+                logger.error("❌ Failed to start manager %s: %s", name, exc)
+        if failed:
+            logger.error("Failed managers: %s", failed)
+            return False
+        self._start_health_monitoring()
+        return True
+
+    def stop_all_managers(self) -> None:
+        logger.info("Stopping all managers...")
+        self._stop_health_monitoring()
+        for name in reversed(self.registry.startup_order):
+            inst = self.registry.manager_instances.get(name)
+            if not inst:
+                continue
+            try:
+                inst.stop()
+                self.registry.managers[name].status = ManagerStatus.SHUTDOWN
+                logger.info("✅ Manager %s stopped", name)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("❌ Failed to stop manager %s: %s", name, exc)
+        logger.info("All managers stopped")
+
+    def restart_manager(self, manager_name: str) -> bool:
+        if manager_name not in self.registry.manager_instances:
+            logger.error("Manager %s not found", manager_name)
+            return False
+        inst = self.registry.manager_instances[manager_name]
+        try:
+            inst.stop()
+            if inst.start():
+                self.registry.managers[manager_name].status = ManagerStatus.ACTIVE
+                logger.info("✅ Manager %s restarted successfully", manager_name)
+                return True
+            logger.error("❌ Manager %s failed to restart", manager_name)
+            return False
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("❌ Failed to restart manager %s: %s", manager_name, exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # Health monitoring
+    # ------------------------------------------------------------------
+    def _start_health_monitoring(self) -> None:
+        if self.health_thread and self.health_thread.is_alive():
+            return
+        self.health_thread = threading.Thread(target=self._health_monitoring_loop, daemon=True)
+        self.health_thread.start()
+        logger.info("Health monitoring started")
+
+    def _stop_health_monitoring(self) -> None:
+        self.shutdown_event.set()
+        if self.health_thread and self.health_thread.is_alive():
+            self.health_thread.join(timeout=5)
+        logger.info("Health monitoring stopped")
+
+    def _health_monitoring_loop(self) -> None:
+        while not self.shutdown_event.is_set():
+            try:
+                self._perform_health_checks()
+                time.sleep(self.health_check_interval)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Health monitoring error: %s", exc)
+                time.sleep(60)
+
+    def _perform_health_checks(self) -> None:
+        for name, info in self.registry.managers.items():
+            inst = self.registry.manager_instances.get(name)
+            if not inst:
+                continue
+            try:
+                status = inst.health_check()
+                info.last_health_check = datetime.now()
+                info.health_status = status
+                if not status.get("is_healthy", False):
+                    logger.warning("Manager %s is unhealthy: %s", name, status)
+                    if self.config.get("enable_auto_recovery", True):
+                        self._attempt_auto_recovery(name)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Health check failed for %s: %s", name, exc)
+                info.health_status = {"error": str(exc)}
+        self.last_health_check = datetime.now()
+
+    def _attempt_auto_recovery(self, manager_name: str) -> None:
+        max_attempts = self.config.get("max_retry_attempts", 3)
+        delay = self.config.get("retry_delay", 5)
+        for attempt in range(max_attempts):
+            if self.restart_manager(manager_name):
+                logger.info("✅ Auto-recovery successful for %s", manager_name)
+                return
+            logger.warning("Auto-recovery attempt %s failed for %s", attempt + 1, manager_name)
+            time.sleep(delay)
+        logger.error("❌ Auto-recovery failed for %s after %s attempts", manager_name, max_attempts)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+    def cleanup(self, config_path: Path, config: Dict[str, Any]) -> None:
+        logger.info("Cleaning up orchestrator resources...")
+        for name, inst in self.registry.manager_instances.items():
+            try:
+                inst.cleanup()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Cleanup error for %s: %s", name, exc)
+        try:
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(config_path, "w") as f:
+                import json
+
+                json.dump(config, f, indent=2, default=str)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to save configuration: %s", exc)
+        logger.info("Orchestrator cleanup completed")

--- a/src/core/orchestrator/registry.py
+++ b/src/core/orchestrator/registry.py
@@ -1,0 +1,169 @@
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Type
+
+from ..base_manager import BaseManager, ManagerStatus, ManagerPriority
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ManagerInfo:
+    """Information about a registered manager."""
+
+    manager_name: str
+    manager_class: Type[BaseManager]
+    instance: Optional[BaseManager]
+    status: ManagerStatus
+    priority: ManagerPriority
+    dependencies: List[str]
+    config_path: Optional[str]
+    last_health_check: datetime
+    health_status: Dict[str, Any]
+
+
+class ManagerRegistry:
+    """Maintain registration and ordering of managers."""
+
+    def __init__(self) -> None:
+        self.managers: Dict[str, ManagerInfo] = {}
+        self.manager_instances: Dict[str, BaseManager] = {}
+        self.dependency_graph: Dict[str, List[str]] = {}
+        self.startup_order: List[str] = []
+
+    # ------------------------------------------------------------------
+    # Registration utilities
+    # ------------------------------------------------------------------
+    def register_default_managers(self) -> None:
+        """Register the eight consolidated managers with placeholders."""
+        self.register_manager(
+            "system_manager",
+            "SystemManager",
+            priority=ManagerPriority.CRITICAL,
+            dependencies=[],
+            config_path="config/system_manager.json",
+        )
+        self.register_manager(
+            "config_manager",
+            "ConfigManager",
+            priority=ManagerPriority.HIGH,
+            dependencies=["system_manager"],
+            config_path="config/config_manager.json",
+        )
+        self.register_manager(
+            "status_manager",
+            "StatusManager",
+            priority=ManagerPriority.HIGH,
+            dependencies=["system_manager"],
+            config_path="config/status_manager.json",
+        )
+        self.register_manager(
+            "task_manager",
+            "TaskManager",
+            priority=ManagerPriority.HIGH,
+            dependencies=["system_manager", "status_manager"],
+            config_path="config/task_manager.json",
+        )
+        self.register_manager(
+            "data_manager",
+            "DataManager",
+            priority=ManagerPriority.MEDIUM,
+            dependencies=["system_manager", "config_manager"],
+            config_path="config/data_manager.json",
+        )
+        self.register_manager(
+            "communication_manager",
+            "CommunicationManager",
+            priority=ManagerPriority.MEDIUM,
+            dependencies=["system_manager", "config_manager"],
+            config_path="config/communication_manager.json",
+        )
+        self.register_manager(
+            "health_manager",
+            "HealthManager",
+            priority=ManagerPriority.MEDIUM,
+            dependencies=["system_manager", "status_manager"],
+            config_path="config/health_manager.json",
+        )
+        self.register_manager(
+            "performance_manager",
+            "PerformanceManager",
+            priority=ManagerPriority.LOW,
+            dependencies=["system_manager", "health_manager"],
+            config_path="config/performance_manager.json",
+        )
+        logger.info("Registered %s specialized managers", len(self.managers))
+
+    def register_manager(
+        self,
+        manager_name: str,
+        manager_class_name: str,
+        priority: ManagerPriority = ManagerPriority.NORMAL,
+        dependencies: Optional[List[str]] = None,
+        config_path: Optional[str] = None,
+    ) -> None:
+        """Register a manager using placeholder classes."""
+        if dependencies is None:
+            dependencies = []
+
+        class PlaceholderManager(BaseManager):
+            def _validate_data(self, data: Any) -> bool:  # pragma: no cover - simple stub
+                return True
+
+        info = ManagerInfo(
+            manager_name=manager_name,
+            manager_class=PlaceholderManager,
+            instance=None,
+            status=ManagerStatus.INACTIVE,
+            priority=priority,
+            dependencies=dependencies,
+            config_path=config_path,
+            last_health_check=datetime.now(),
+            health_status={},
+        )
+        self.managers[manager_name] = info
+        logger.debug("Registered manager: %s", manager_name)
+
+    # ------------------------------------------------------------------
+    # Dependency ordering
+    # ------------------------------------------------------------------
+    def build_dependency_graph(self) -> None:
+        self.dependency_graph = {
+            name: info.dependencies.copy() for name, info in self.managers.items()
+        }
+        logger.debug("Dependency graph built")
+
+    def calculate_startup_order(self) -> None:
+        visited = set()
+        temp_visited = set()
+        order: List[str] = []
+
+        def dfs(node: str) -> None:
+            if node in temp_visited:
+                raise ValueError(f"Circular dependency detected: {node}")
+            if node in visited:
+                return
+            temp_visited.add(node)
+            for dep in self.dependency_graph.get(node, []):
+                if dep not in self.managers:
+                    logger.warning(
+                        "Manager %s depends on unknown manager: %s", node, dep
+                    )
+                else:
+                    dfs(dep)
+            temp_visited.remove(node)
+            visited.add(node)
+            order.append(node)
+
+        priority_order = sorted(
+            self.managers.keys(),
+            key=lambda x: self.managers[x].priority.value,
+            reverse=True,
+        )
+        for name in priority_order:
+            if name not in visited:
+                dfs(name)
+        self.startup_order = order
+        logger.info("Startup order calculated: %s", self.startup_order)


### PR DESCRIPTION
## Summary
- Extract manager registry into dedicated module for registration and dependency ordering
- Move lifecycle hooks (start/stop/health monitoring) into a separate lifecycle manager
- Provide integration utilities for status queries and metrics
- Streamline ManagerOrchestrator to delegate to registry, lifecycle and integration helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil' and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a56d90d48329ab0ca9196ffab866