### PR TITLE
Refactor onboarding validation into modular components

### DIFF
--- a/src/core/validation/onboarding/__init__.py
+++ b/src/core/validation/onboarding/__init__.py
@@ -1,0 +1,2 @@
+"""Onboarding validation helpers package."""
+

--- a/src/core/validation/onboarding/reporting.py
+++ b/src/core/validation/onboarding/reporting.py
@@ -1,0 +1,33 @@
+"""Reporting helpers for onboarding validation."""
+from typing import Any
+
+from ..base_validator import (
+    BaseValidator,
+    ValidationResult,
+    ValidationSeverity,
+    ValidationStatus,
+)
+
+
+def generate_success_result(validator: BaseValidator, total_checks: int) -> ValidationResult:
+    """Create a success result when all checks pass."""
+    return validator._create_result(
+        rule_id="overall_onboarding_validation",
+        rule_name="Overall Onboarding Validation",
+        status=ValidationStatus.PASSED,
+        severity=ValidationSeverity.INFO,
+        message="Onboarding validation passed successfully",
+        details={"total_checks": total_checks},
+    )
+
+
+def generate_error_result(validator: BaseValidator, error: Exception) -> ValidationResult:
+    """Create a failure result when an exception occurs."""
+    return validator._create_result(
+        rule_id="onboarding_validation_error",
+        rule_name="Onboarding Validation Error",
+        status=ValidationStatus.FAILED,
+        severity=ValidationSeverity.CRITICAL,
+        message=f"Onboarding validation error: {str(error)}",
+        details={"error_type": type(error).__name__},
+    )

--- a/src/core/validation/onboarding/rules.py
+++ b/src/core/validation/onboarding/rules.py
@@ -1,0 +1,30 @@
+"""Rule definitions for onboarding validation."""
+
+ONBOARDING_STAGES = [
+    "registration",
+    "verification",
+    "profile_setup",
+    "training",
+    "activation",
+    "completion",
+]
+
+VERIFICATION_METHODS = [
+    "email",
+    "sms",
+    "phone",
+    "document",
+    "biometric",
+    "social",
+    "manual",
+]
+
+
+def is_valid_stage(stage: str) -> bool:
+    """Return True if *stage* is a valid onboarding stage."""
+    return stage.lower() in ONBOARDING_STAGES
+
+
+def is_valid_verification_method(method: str) -> bool:
+    """Return True if *method* is an allowed verification method."""
+    return method.lower() in VERIFICATION_METHODS

--- a/src/core/validation/onboarding/workflows.py
+++ b/src/core/validation/onboarding/workflows.py
@@ -1,0 +1,466 @@
+"""Onboarding workflow validation functions."""
+from typing import Any, Dict, List, Optional
+
+from ..base_validator import (
+    BaseValidator,
+    ValidationResult,
+    ValidationSeverity,
+    ValidationStatus,
+)
+from . import rules
+
+
+# --- Core validation helpers -------------------------------------------------
+
+def validate_onboarding_structure(validator: BaseValidator, onboarding_data: Dict[str, Any]) -> List[ValidationResult]:
+    """Validate onboarding data structure and format."""
+    results: List[ValidationResult] = []
+    if not isinstance(onboarding_data, dict):
+        result = validator._create_result(
+            rule_id="onboarding_type",
+            rule_name="Onboarding Type Validation",
+            status=ValidationStatus.FAILED,
+            severity=ValidationSeverity.ERROR,
+            message="Onboarding data must be a dictionary",
+            actual_value=type(onboarding_data).__name__,
+            expected_value="dict",
+        )
+        results.append(result)
+        return results
+
+    if len(onboarding_data) == 0:
+        result = validator._create_result(
+            rule_id="onboarding_empty",
+            rule_name="Onboarding Empty Check",
+            status=ValidationStatus.WARNING,
+            severity=ValidationSeverity.WARNING,
+            message="Onboarding data is empty",
+            actual_value=onboarding_data,
+            expected_value="non-empty onboarding data",
+        )
+        results.append(result)
+    return results
+
+
+def validate_onboarding_stage(validator: BaseValidator, stage: Any) -> Optional[ValidationResult]:
+    """Validate onboarding stage value."""
+    if not isinstance(stage, str):
+        return validator._create_result(
+            rule_id="stage_type",
+            rule_name="Stage Type Validation",
+            status=ValidationStatus.FAILED,
+            severity=ValidationSeverity.ERROR,
+            message="Onboarding stage must be a string",
+            field_path="stage",
+            actual_value=type(stage).__name__,
+            expected_value="str",
+        )
+    if stage.lower() not in validator.onboarding_stages:
+        return validator._create_result(
+            rule_id="stage_invalid",
+            rule_name="Stage Invalid Value",
+            status=ValidationStatus.FAILED,
+            severity=ValidationSeverity.ERROR,
+            message=f"Invalid onboarding stage: {stage}",
+            field_path="stage",
+            actual_value=stage,
+            expected_value=f"one of {validator.onboarding_stages}",
+        )
+    return None
+
+
+def validate_onboarding_flow(validator: BaseValidator, flow: Any) -> List[ValidationResult]:
+    """Validate onboarding flow data."""
+    results: List[ValidationResult] = []
+    if not isinstance(flow, dict):
+        result = validator._create_result(
+            rule_id="flow_type",
+            rule_name="Flow Type Validation",
+            status=ValidationStatus.FAILED,
+            severity=ValidationSeverity.ERROR,
+            message="Onboarding flow must be a dictionary",
+            field_path="flow",
+            actual_value=type(flow).__name__,
+            expected_value="dict",
+        )
+        results.append(result)
+        return results
+
+    if "stages" in flow:
+        stages = flow["stages"]
+        if isinstance(stages, list):
+            if len(stages) == 0:
+                result = validator._create_result(
+                    rule_id="flow_stages_empty",
+                    rule_name="Flow Stages Empty Check",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.ERROR,
+                    message="Onboarding flow must have at least one stage",
+                    field_path="flow.stages",
+                    actual_value=stages,
+                    expected_value="non-empty list of stages",
+                )
+                results.append(result)
+            else:
+                for i, stage in enumerate(stages):
+                    if not isinstance(stage, dict):
+                        result = validator._create_result(
+                            rule_id=f"flow_stage_{i}_type",
+                            rule_name=f"Flow Stage {i} Type Validation",
+                            status=ValidationStatus.FAILED,
+                            severity=ValidationSeverity.ERROR,
+                            message=f"Flow stage {i} must be a dictionary",
+                            field_path=f"flow.stages[{i}]",
+                            actual_value=type(stage).__name__,
+                            expected_value="dict",
+                        )
+                        results.append(result)
+                        continue
+                    stage_required_fields = ["name", "order", "required"]
+                    stage_field_results = validator._validate_required_fields(stage, stage_required_fields)
+                    for stage_result in stage_field_results:
+                        stage_result.field_path = f"flow.stages[{i}].{stage_result.field_path}"
+                    results.extend(stage_field_results)
+                    if "order" in stage:
+                        order = stage["order"]
+                        if isinstance(order, int):
+                            if order <= 0:
+                                result = validator._create_result(
+                                    rule_id=f"flow_stage_{i}_order",
+                                    rule_name=f"Flow Stage {i} Order Validation",
+                                    status=ValidationStatus.FAILED,
+                                    severity=ValidationSeverity.ERROR,
+                                    message=f"Flow stage {i} order must be greater than 0",
+                                    field_path=f"flow.stages[{i}].order",
+                                    actual_value=order,
+                                    expected_value="> 0",
+                                )
+                                results.append(result)
+    return results
+
+
+def validate_verification(validator: BaseValidator, verification: Any) -> List[ValidationResult]:
+    """Validate verification data."""
+    results: List[ValidationResult] = []
+    if not isinstance(verification, dict):
+        result = validator._create_result(
+            rule_id="verification_type",
+            rule_name="Verification Type Validation",
+            status=ValidationStatus.FAILED,
+            severity=ValidationSeverity.ERROR,
+            message="Verification data must be a dictionary",
+            field_path="verification",
+            actual_value=type(verification).__name__,
+            expected_value="dict",
+        )
+        results.append(result)
+        return results
+
+    if "method" in verification:
+        method = verification["method"]
+        if isinstance(method, str):
+            if method.lower() not in validator.verification_methods:
+                result = validator._create_result(
+                    rule_id="verification_method_invalid",
+                    rule_name="Verification Method Invalid Value",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.ERROR,
+                    message=f"Invalid verification method: {method}",
+                    field_path="verification.method",
+                    actual_value=method,
+                    expected_value=f"one of {validator.verification_methods}",
+                )
+                results.append(result)
+
+    if "status" in verification:
+        status = verification["status"]
+        valid_statuses = [
+            "pending",
+            "in_progress",
+            "completed",
+            "failed",
+            "expired",
+        ]
+        if isinstance(status, str):
+            if status.lower() not in valid_statuses:
+                result = validator._create_result(
+                    rule_id="verification_status_invalid",
+                    rule_name="Verification Status Invalid Value",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.ERROR,
+                    message=f"Invalid verification status: {status}",
+                    field_path="verification.status",
+                    actual_value=status,
+                    expected_value=f"one of {valid_statuses}",
+                )
+                results.append(result)
+
+    if "attempts" in verification:
+        attempts = verification["attempts"]
+        if isinstance(attempts, int):
+            if attempts < 0:
+                result = validator._create_result(
+                    rule_id="verification_attempts_invalid",
+                    rule_name="Verification Attempts Invalid Value",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.ERROR,
+                    message="Verification attempts cannot be negative",
+                    field_path="verification.attempts",
+                    actual_value=attempts,
+                    expected_value=">= 0",
+                )
+                results.append(result)
+    return results
+
+
+def validate_compliance(validator: BaseValidator, compliance: Any) -> List[ValidationResult]:
+    """Validate compliance data."""
+    results: List[ValidationResult] = []
+    if not isinstance(compliance, dict):
+        result = validator._create_result(
+            rule_id="compliance_type",
+            rule_name="Compliance Type Validation",
+            status=ValidationStatus.FAILED,
+            severity=ValidationSeverity.ERROR,
+            message="Compliance data must be a dictionary",
+            field_path="compliance",
+            actual_value=type(compliance).__name__,
+            expected_value="dict",
+        )
+        results.append(result)
+        return results
+
+    if "required_fields" in compliance:
+        required_fields = compliance["required_fields"]
+        if isinstance(required_fields, list):
+            if len(required_fields) == 0:
+                result = validator._create_result(
+                    rule_id="compliance_required_fields_empty",
+                    rule_name="Compliance Required Fields Empty Check",
+                    status=ValidationStatus.WARNING,
+                    severity=ValidationSeverity.WARNING,
+                    message="No required compliance fields specified",
+                    field_path="compliance.required_fields",
+                    actual_value=required_fields,
+                    expected_value="non-empty list of required fields",
+                )
+                results.append(result)
+            else:
+                for i, field in enumerate(required_fields):
+                    if not isinstance(field, str):
+                        result = validator._create_result(
+                            rule_id=f"compliance_field_{i}_type",
+                            rule_name=f"Compliance Field {i} Type Validation",
+                            status=ValidationStatus.FAILED,
+                            severity=ValidationSeverity.ERROR,
+                            message=f"Compliance field {i} must be a string",
+                            field_path=f"compliance.required_fields[{i}]",
+                            actual_value=type(field).__name__,
+                            expected_value="str",
+                        )
+                        results.append(result)
+
+    if "status" in compliance:
+        status = compliance["status"]
+        valid_statuses = [
+            "pending",
+            "in_review",
+            "approved",
+            "rejected",
+            "requires_action",
+        ]
+        if isinstance(status, str):
+            if status.lower() not in valid_statuses:
+                result = validator._create_result(
+                    rule_id="compliance_status_invalid",
+                    rule_name="Compliance Status Invalid Value",
+                    status=ValidationStatus.FAILED,
+                    severity=ValidationSeverity.ERROR,
+                    message=f"Invalid compliance status: {status}",
+                    field_path="compliance.status",
+                    actual_value=status,
+                    expected_value=f"one of {valid_statuses}",
+                )
+                results.append(result)
+    return results
+
+
+def validate_onboarding_progression(validator: BaseValidator, onboarding_data: Dict[str, Any]) -> List[ValidationResult]:
+    """Validate onboarding progression logic."""
+    results: List[ValidationResult] = []
+    if "stage" in onboarding_data and "status" in onboarding_data:
+        stage = onboarding_data["stage"]
+        status = onboarding_data["status"]
+        if isinstance(stage, str) and isinstance(status, str):
+            stage_lower = stage.lower()
+            status_lower = status.lower()
+            if stage_lower == "completion" and status_lower != "completed":
+                result = validator._create_result(
+                    rule_id="stage_completion_mismatch",
+                    rule_name="Stage Completion Mismatch",
+                    status=ValidationStatus.WARNING,
+                    severity=ValidationSeverity.WARNING,
+                    message="Completion stage should have 'completed' status",
+                    field_path="stage",
+                    actual_value=f"stage: {stage}, status: {status}",
+                    expected_value="status: completed for completion stage",
+                )
+                results.append(result)
+            if stage_lower in validator.onboarding_stages:
+                stage_index = validator.onboarding_stages.index(stage_lower)
+                if stage_index > 0:
+                    if "completed_stages" in onboarding_data:
+                        completed_stages = onboarding_data["completed_stages"]
+                        if isinstance(completed_stages, list):
+                            for prev_stage in validator.onboarding_stages[:stage_index]:
+                                if prev_stage not in completed_stages:
+                                    result = validator._create_result(
+                                        rule_id="stage_progression_invalid",
+                                        rule_name="Stage Progression Invalid",
+                                        status=ValidationStatus.WARNING,
+                                        severity=ValidationSeverity.WARNING,
+                                        message=f"Stage '{stage}' reached before completing '{prev_stage}'",
+                                        field_path="stage",
+                                        actual_value=f"current: {stage}, missing: {prev_stage}",
+                                        expected_value=f"complete {prev_stage} before {stage}",
+                                    )
+                                    results.append(result)
+    if "stage" in onboarding_data and "required_fields" in onboarding_data:
+        stage = onboarding_data["stage"]
+        required_fields = onboarding_data["required_fields"]
+        if isinstance(required_fields, dict) and isinstance(stage, str):
+            stage_requirements = required_fields.get(stage.lower(), [])
+            if isinstance(stage_requirements, list) and len(stage_requirements) > 0:
+                if "completed_fields" in onboarding_data:
+                    completed_fields = onboarding_data["completed_fields"]
+                    if isinstance(completed_fields, list):
+                        missing_fields = [
+                            field
+                            for field in stage_requirements
+                            if field not in completed_fields
+                        ]
+                        if missing_fields:
+                            result = validator._create_result(
+                                rule_id="required_fields_incomplete",
+                                rule_name="Required Fields Incomplete",
+                                status=ValidationStatus.WARNING,
+                                severity=ValidationSeverity.WARNING,
+                                message=f"Missing required fields for stage '{stage}': {missing_fields}",
+                                field_path="required_fields",
+                                actual_value=f"missing: {missing_fields}",
+                                expected_value=f"complete all required fields for {stage}",
+                            )
+                            results.append(result)
+    return results
+
+
+# --- Extended workflow helpers ----------------------------------------------
+
+def add_onboarding_stage(validator: BaseValidator, stage: str) -> bool:
+    """Add a custom onboarding stage."""
+    try:
+        if stage not in validator.onboarding_stages:
+            validator.onboarding_stages.append(stage)
+            validator.logger.info(f"Onboarding stage added: {stage}")
+        return True
+    except Exception as e:  # pragma: no cover - defensive
+        validator.logger.error(f"Failed to add onboarding stage: {e}")
+        return False
+
+
+def add_verification_method(validator: BaseValidator, method: str) -> bool:
+    """Add a custom verification method."""
+    try:
+        if method not in validator.verification_methods:
+            validator.verification_methods.append(method)
+            validator.logger.info(f"Verification method added: {method}")
+        return True
+    except Exception as e:  # pragma: no cover - defensive
+        validator.logger.error(f"Failed to add verification method: {e}")
+        return False
+
+
+def wait_for_phase_response(
+    validator: BaseValidator,
+    session: Dict[str, Any],
+    phase: str,
+    message_id: str,
+    phase_timeout: float = 30.0,
+) -> bool:
+    """Wait for and validate phase response."""
+    import time
+
+    start = time.time()
+    while time.time() - start < phase_timeout:
+        time.sleep(0.1)
+        return True
+    validator.logger.warning(
+        f"Timeout waiting for response for phase {phase} in session {session.get('session_id', 'unknown')}"
+    )
+    return False
+
+
+def validate_onboarding_completion(
+    validator: BaseValidator,
+    session: Dict[str, Any],
+    role_definitions: Optional[Dict[str, Any]] = None,
+    fsm_core: Any = None,
+) -> bool:
+    """Validate that onboarding has been completed successfully."""
+    try:
+        if not role_definitions:
+            role_definitions = {}
+        agent_id = session.get("agent_id", "unknown")
+        required_phases = role_definitions.get(agent_id, {}).get("onboarding_phases", [])
+        if required_phases:
+            completed_phases = session.get("completed_phases", [])
+            if not all(phase in completed_phases for phase in required_phases):
+                validator.logger.warning(
+                    f"Not all required phases completed for {agent_id}"
+                )
+                return False
+        if not validate_performance_metrics(validator, session):
+            validator.logger.warning(f"Performance validation failed for {agent_id}")
+            return False
+        if fsm_core and hasattr(fsm_core, "create_task"):
+            try:
+                fsm_core.create_task(
+                    title=f"Onboarding Completion - {agent_id}",
+                    description=(
+                        f"Agent {agent_id} has completed onboarding and is ready for active participation"
+                    ),
+                    assigned_agent=agent_id,
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                validator.logger.warning(f"Failed to create FSM task: {e}")
+        return True
+    except Exception as e:  # pragma: no cover - defensive
+        validator.logger.error(f"Onboarding completion validation failed: {e}")
+        return False
+
+
+def validate_performance_metrics(validator: BaseValidator, session: Dict[str, Any]) -> bool:
+    """Validate performance metrics for onboarding completion."""
+    try:
+        performance_data = session.get("performance_metrics", {})
+        required_metrics = ["completion_time", "success_rate", "error_count"]
+        for metric in required_metrics:
+            if metric not in performance_data:
+                validator.logger.warning(f"Missing performance metric: {metric}")
+                return False
+        completion_time = performance_data.get("completion_time", 0)
+        if completion_time < 0:
+            validator.logger.warning("Completion time cannot be negative")
+            return False
+        success_rate = performance_data.get("success_rate", 0)
+        if not (0 <= success_rate <= 100):
+            validator.logger.warning("Success rate must be between 0 and 100")
+            return False
+        error_count = performance_data.get("error_count", 0)
+        if error_count < 0:
+            validator.logger.warning("Error count cannot be negative")
+            return False
+        return True
+    except Exception as e:  # pragma: no cover - defensive
+        validator.logger.error(f"Performance metrics validation failed: {e}")
+        return False

--- a/src/core/validation/onboarding_validator.py
+++ b/src/core/validation/onboarding_validator.py
@@ -1,524 +1,58 @@
-"""
-Onboarding Validator - Unified Validation Framework
+"""Onboarding Validator - Unified Validation Framework.
 
-This module provides onboarding validation functionality, inheriting from BaseValidator
-and following the unified validation framework patterns.
+This module now acts as a slim coordinator that orchestrates onboarding
+validation by delegating to modular workflow, rule, and reporting helpers.
 """
+from typing import Any, Dict, List
 
-from typing import Dict, List, Any, Optional
 from .base_validator import (
     BaseValidator,
+    ValidationResult,
     ValidationSeverity,
     ValidationStatus,
-    ValidationResult,
 )
+from .onboarding import reporting, rules, workflows
 
 
 class OnboardingValidator(BaseValidator):
-    """Validates onboarding data and processes using unified validation framework"""
+    """Validates onboarding data using modular workflow components."""
 
-    def __init__(self):
-        """Initialize onboarding validator"""
+    def __init__(self) -> None:
         super().__init__("OnboardingValidator")
-        self.onboarding_stages = [
-            "registration",
-            "verification",
-            "profile_setup",
-            "training",
-            "activation",
-            "completion",
-        ]
-        self.verification_methods = [
-            "email",
-            "sms",
-            "phone",
-            "document",
-            "biometric",
-            "social",
-            "manual",
-        ]
+        self.onboarding_stages = list(rules.ONBOARDING_STAGES)
+        self.verification_methods = list(rules.VERIFICATION_METHODS)
 
-    def validate(
-        self, onboarding_data: Dict[str, Any], **kwargs
-    ) -> List[ValidationResult]:
-        """Validate onboarding data and return validation results.
-
-        Returns:
-            List[ValidationResult]: Validation results produced during
-            onboarding validation.
-        """
-        results = []
-
+    def validate(self, onboarding_data: Dict[str, Any], **kwargs) -> List[ValidationResult]:
+        """Validate onboarding data and return validation results."""
+        results: List[ValidationResult] = []
         try:
-            # Validate onboarding data structure
-            structure_results = self._validate_onboarding_structure(onboarding_data)
-            results.extend(structure_results)
-
-            # Validate required fields
+            results.extend(workflows.validate_onboarding_structure(self, onboarding_data))
             required_fields = ["user_id", "stage", "start_date", "status"]
-            field_results = self._validate_required_fields(
-                onboarding_data, required_fields
-            )
-            results.extend(field_results)
-
-            # Validate onboarding stage if present
+            results.extend(self._validate_required_fields(onboarding_data, required_fields))
             if "stage" in onboarding_data:
-                stage_result = self._validate_onboarding_stage(onboarding_data["stage"])
+                stage_result = workflows.validate_onboarding_stage(self, onboarding_data["stage"])
                 if stage_result:
                     results.append(stage_result)
-
-            # Validate onboarding flow if present
             if "flow" in onboarding_data:
-                flow_results = self._validate_onboarding_flow(onboarding_data["flow"])
-                results.extend(flow_results)
-
-            # Validate verification if present
+                results.extend(workflows.validate_onboarding_flow(self, onboarding_data["flow"]))
             if "verification" in onboarding_data:
-                verification_results = self._validate_verification(
-                    onboarding_data["verification"]
-                )
-                results.extend(verification_results)
-
-            # Validate compliance if present
+                results.extend(workflows.validate_verification(self, onboarding_data["verification"]))
             if "compliance" in onboarding_data:
-                compliance_results = self._validate_compliance(
-                    onboarding_data["compliance"]
-                )
-                results.extend(compliance_results)
-
-            # Check onboarding progression
-            progression_results = self._validate_onboarding_progression(onboarding_data)
-            results.extend(progression_results)
-
-            # Add overall success result if no critical errors
+                results.extend(workflows.validate_compliance(self, onboarding_data["compliance"]))
+            results.extend(workflows.validate_onboarding_progression(self, onboarding_data))
             if not any(r.severity == ValidationSeverity.ERROR for r in results):
-                success_result = self._create_result(
-                    rule_id="overall_onboarding_validation",
-                    rule_name="Overall Onboarding Validation",
-                    status=ValidationStatus.PASSED,
-                    severity=ValidationSeverity.INFO,
-                    message="Onboarding validation passed successfully",
-                    details={"total_checks": len(results)},
-                )
-                results.append(success_result)
-
-        except Exception as e:
-            error_result = self._create_result(
-                rule_id="onboarding_validation_error",
-                rule_name="Onboarding Validation Error",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.CRITICAL,
-                message=f"Onboarding validation error: {str(e)}",
-                details={"error_type": type(e).__name__},
-            )
-            results.append(error_result)
-
+                results.append(reporting.generate_success_result(self, len(results)))
+        except Exception as e:  # pragma: no cover - defensive
+            results.append(reporting.generate_error_result(self, e))
         return results
 
-    def _validate_onboarding_structure(
-        self, onboarding_data: Dict[str, Any]
-    ) -> List[ValidationResult]:
-        """Validate onboarding data structure and format"""
-        results = []
-
-        if not isinstance(onboarding_data, dict):
-            result = self._create_result(
-                rule_id="onboarding_type",
-                rule_name="Onboarding Type Validation",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.ERROR,
-                message="Onboarding data must be a dictionary",
-                actual_value=type(onboarding_data).__name__,
-                expected_value="dict",
-            )
-            results.append(result)
-            return results
-
-        if len(onboarding_data) == 0:
-            result = self._create_result(
-                rule_id="onboarding_empty",
-                rule_name="Onboarding Empty Check",
-                status=ValidationStatus.WARNING,
-                severity=ValidationSeverity.WARNING,
-                message="Onboarding data is empty",
-                actual_value=onboarding_data,
-                expected_value="non-empty onboarding data",
-            )
-            results.append(result)
-
-        return results
-
-    def _validate_onboarding_stage(self, stage: Any) -> Optional[ValidationResult]:
-        """Validate onboarding stage value"""
-        if not isinstance(stage, str):
-            return self._create_result(
-                rule_id="stage_type",
-                rule_name="Stage Type Validation",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.ERROR,
-                message="Onboarding stage must be a string",
-                field_path="stage",
-                actual_value=type(stage).__name__,
-                expected_value="str",
-            )
-
-        if stage.lower() not in self.onboarding_stages:
-            return self._create_result(
-                rule_id="stage_invalid",
-                rule_name="Stage Invalid Value",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.ERROR,
-                message=f"Invalid onboarding stage: {stage}",
-                field_path="stage",
-                actual_value=stage,
-                expected_value=f"one of {self.onboarding_stages}",
-            )
-
-        return None
-
-    def _validate_onboarding_flow(self, flow: Any) -> List[ValidationResult]:
-        """Validate onboarding flow data"""
-        results = []
-
-        if not isinstance(flow, dict):
-            result = self._create_result(
-                rule_id="flow_type",
-                rule_name="Flow Type Validation",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.ERROR,
-                message="Onboarding flow must be a dictionary",
-                field_path="flow",
-                actual_value=type(flow).__name__,
-                expected_value="dict",
-            )
-            results.append(result)
-            return results
-
-        # Validate stages if present
-        if "stages" in flow:
-            stages = flow["stages"]
-            if isinstance(stages, list):
-                if len(stages) == 0:
-                    result = self._create_result(
-                        rule_id="flow_stages_empty",
-                        rule_name="Flow Stages Empty Check",
-                        status=ValidationStatus.FAILED,
-                        severity=ValidationSeverity.ERROR,
-                        message="Onboarding flow must have at least one stage",
-                        field_path="flow.stages",
-                        actual_value=stages,
-                        expected_value="non-empty list of stages",
-                    )
-                    results.append(result)
-                else:
-                    # Validate each stage
-                    for i, stage in enumerate(stages):
-                        if not isinstance(stage, dict):
-                            result = self._create_result(
-                                rule_id=f"flow_stage_{i}_type",
-                                rule_name=f"Flow Stage {i} Type Validation",
-                                status=ValidationStatus.FAILED,
-                                severity=ValidationSeverity.ERROR,
-                                message=f"Flow stage {i} must be a dictionary",
-                                field_path=f"flow.stages[{i}]",
-                                actual_value=type(stage).__name__,
-                                expected_value="dict",
-                            )
-                            results.append(result)
-                            continue
-
-                        # Validate required stage fields
-                        stage_required_fields = ["name", "order", "required"]
-                        stage_field_results = self._validate_required_fields(
-                            stage, stage_required_fields
-                        )
-                        for stage_result in stage_field_results:
-                            stage_result.field_path = (
-                                f"flow.stages[{i}].{stage_result.field_path}"
-                            )
-                        results.extend(stage_field_results)
-
-                        # Validate stage order
-                        if "order" in stage:
-                            order = stage["order"]
-                            if isinstance(order, int):
-                                if order <= 0:
-                                    result = self._create_result(
-                                        rule_id=f"flow_stage_{i}_order",
-                                        rule_name=f"Flow Stage {i} Order Validation",
-                                        status=ValidationStatus.FAILED,
-                                        severity=ValidationSeverity.ERROR,
-                                        message=f"Flow stage {i} order must be greater than 0",
-                                        field_path=f"flow.stages[{i}].order",
-                                        actual_value=order,
-                                        expected_value="> 0",
-                                    )
-                                    results.append(result)
-
-        return results
-
-    def _validate_verification(self, verification: Any) -> List[ValidationResult]:
-        """Validate verification data"""
-        results = []
-
-        if not isinstance(verification, dict):
-            result = self._create_result(
-                rule_id="verification_type",
-                rule_name="Verification Type Validation",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.ERROR,
-                message="Verification data must be a dictionary",
-                field_path="verification",
-                actual_value=type(verification).__name__,
-                expected_value="dict",
-            )
-            results.append(result)
-            return results
-
-        # Validate verification method if present
-        if "method" in verification:
-            method = verification["method"]
-            if isinstance(method, str):
-                if method.lower() not in self.verification_methods:
-                    result = self._create_result(
-                        rule_id="verification_method_invalid",
-                        rule_name="Verification Method Invalid Value",
-                        status=ValidationStatus.FAILED,
-                        severity=ValidationSeverity.ERROR,
-                        message=f"Invalid verification method: {method}",
-                        field_path="verification.method",
-                        actual_value=method,
-                        expected_value=f"one of {self.verification_methods}",
-                    )
-                    results.append(result)
-
-        # Validate verification status if present
-        if "status" in verification:
-            status = verification["status"]
-            valid_statuses = [
-                "pending",
-                "in_progress",
-                "completed",
-                "failed",
-                "expired",
-            ]
-
-            if isinstance(status, str):
-                if status.lower() not in valid_statuses:
-                    result = self._create_result(
-                        rule_id="verification_status_invalid",
-                        rule_name="Verification Status Invalid Value",
-                        status=ValidationStatus.FAILED,
-                        severity=ValidationSeverity.ERROR,
-                        message=f"Invalid verification status: {status}",
-                        field_path="verification.status",
-                        actual_value=status,
-                        expected_value=f"one of {valid_statuses}",
-                    )
-                    results.append(result)
-
-        # Validate verification attempts if present
-        if "attempts" in verification:
-            attempts = verification["attempts"]
-            if isinstance(attempts, int):
-                if attempts < 0:
-                    result = self._create_result(
-                        rule_id="verification_attempts_invalid",
-                        rule_name="Verification Attempts Invalid Value",
-                        status=ValidationStatus.FAILED,
-                        severity=ValidationSeverity.ERROR,
-                        message="Verification attempts cannot be negative",
-                        field_path="verification.attempts",
-                        actual_value=attempts,
-                        expected_value=">= 0",
-                    )
-                    results.append(result)
-
-        return results
-
-    def _validate_compliance(self, compliance: Any) -> List[ValidationResult]:
-        """Validate compliance data"""
-        results = []
-
-        if not isinstance(compliance, dict):
-            result = self._create_result(
-                rule_id="compliance_type",
-                rule_name="Compliance Type Validation",
-                status=ValidationStatus.FAILED,
-                severity=ValidationSeverity.ERROR,
-                message="Compliance data must be a dictionary",
-                field_path="compliance",
-                actual_value=type(compliance).__name__,
-                expected_value="dict",
-            )
-            results.append(result)
-            return results
-
-        # Validate required compliance fields if present
-        if "required_fields" in compliance:
-            required_fields = compliance["required_fields"]
-            if isinstance(required_fields, list):
-                if len(required_fields) == 0:
-                    result = self._create_result(
-                        rule_id="compliance_required_fields_empty",
-                        rule_name="Compliance Required Fields Empty Check",
-                        status=ValidationStatus.WARNING,
-                        severity=ValidationSeverity.WARNING,
-                        message="No required compliance fields specified",
-                        field_path="compliance.required_fields",
-                        actual_value=required_fields,
-                        expected_value="non-empty list of required fields",
-                    )
-                    results.append(result)
-                else:
-                    # Validate each required field
-                    for i, field in enumerate(required_fields):
-                        if not isinstance(field, str):
-                            result = self._create_result(
-                                rule_id=f"compliance_field_{i}_type",
-                                rule_name=f"Compliance Field {i} Type Validation",
-                                status=ValidationStatus.FAILED,
-                                severity=ValidationSeverity.ERROR,
-                                message=f"Compliance field {i} must be a string",
-                                field_path=f"compliance.required_fields[{i}]",
-                                actual_value=type(field).__name__,
-                                expected_value="str",
-                            )
-                            results.append(result)
-
-        # Validate compliance status if present
-        if "status" in compliance:
-            status = compliance["status"]
-            valid_statuses = [
-                "pending",
-                "in_review",
-                "approved",
-                "rejected",
-                "requires_action",
-            ]
-
-            if isinstance(status, str):
-                if status.lower() not in valid_statuses:
-                    result = self._create_result(
-                        rule_id="compliance_status_invalid",
-                        rule_name="Compliance Status Invalid Value",
-                        status=ValidationStatus.FAILED,
-                        severity=ValidationSeverity.ERROR,
-                        message=f"Invalid compliance status: {status}",
-                        field_path="compliance.status",
-                        actual_value=status,
-                        expected_value=f"one of {valid_statuses}",
-                    )
-                    results.append(result)
-
-        return results
-
-    def _validate_onboarding_progression(
-        self, onboarding_data: Dict[str, Any]
-    ) -> List[ValidationResult]:
-        """Validate onboarding progression logic"""
-        results = []
-
-        # Check if current stage is valid for the current status
-        if "stage" in onboarding_data and "status" in onboarding_data:
-            stage = onboarding_data["stage"]
-            status = onboarding_data["status"]
-
-            if isinstance(stage, str) and isinstance(status, str):
-                stage_lower = stage.lower()
-                status_lower = status.lower()
-
-                # Validate stage progression logic
-                if stage_lower == "completion" and status_lower != "completed":
-                    result = self._create_result(
-                        rule_id="stage_completion_mismatch",
-                        rule_name="Stage Completion Mismatch",
-                        status=ValidationStatus.WARNING,
-                        severity=ValidationSeverity.WARNING,
-                        message="Completion stage should have 'completed' status",
-                        field_path="stage",
-                        actual_value=f"stage: {stage}, status: {status}",
-                        expected_value="status: completed for completion stage",
-                    )
-                    results.append(result)
-
-                # Check if stage is in valid progression order
-                if stage_lower in self.onboarding_stages:
-                    stage_index = self.onboarding_stages.index(stage_lower)
-                    if stage_index > 0:  # Not the first stage
-                        # Check if previous stages are completed
-                        if "completed_stages" in onboarding_data:
-                            completed_stages = onboarding_data["completed_stages"]
-                            if isinstance(completed_stages, list):
-                                for prev_stage in self.onboarding_stages[:stage_index]:
-                                    if prev_stage not in completed_stages:
-                                        result = self._create_result(
-                                            rule_id="stage_progression_invalid",
-                                            rule_name="Stage Progression Invalid",
-                                            status=ValidationStatus.WARNING,
-                                            severity=ValidationSeverity.WARNING,
-                                            message=f"Stage '{stage}' reached before completing '{prev_stage}'",
-                                            field_path="stage",
-                                            actual_value=f"current: {stage}, missing: {prev_stage}",
-                                            expected_value=f"complete {prev_stage} before {stage}",
-                                        )
-                                        results.append(result)
-
-        # Check if required fields are completed for current stage
-        if "stage" in onboarding_data and "required_fields" in onboarding_data:
-            stage = onboarding_data["stage"]
-            required_fields = onboarding_data["required_fields"]
-
-            if isinstance(required_fields, dict) and isinstance(stage, str):
-                stage_requirements = required_fields.get(stage.lower(), [])
-                if isinstance(stage_requirements, list) and len(stage_requirements) > 0:
-                    # Check if all required fields are completed
-                    if "completed_fields" in onboarding_data:
-                        completed_fields = onboarding_data["completed_fields"]
-                        if isinstance(completed_fields, list):
-                            missing_fields = [
-                                field
-                                for field in stage_requirements
-                                if field not in completed_fields
-                            ]
-                            if missing_fields:
-                                result = self._create_result(
-                                    rule_id="required_fields_incomplete",
-                                    rule_name="Required Fields Incomplete",
-                                    status=ValidationStatus.WARNING,
-                                    severity=ValidationSeverity.WARNING,
-                                    message=f"Missing required fields for stage '{stage}': {missing_fields}",
-                                    field_path="required_fields",
-                                    actual_value=f"missing: {missing_fields}",
-                                    expected_value=f"complete all required fields for {stage}",
-                                )
-                                results.append(result)
-
-        return results
-
+    # Exposed workflow helpers -------------------------------------------------
     def add_onboarding_stage(self, stage: str) -> bool:
-        """Add a custom onboarding stage"""
-        try:
-            if stage not in self.onboarding_stages:
-                self.onboarding_stages.append(stage)
-                self.logger.info(f"Onboarding stage added: {stage}")
-            return True
-        except Exception as e:
-            self.logger.error(f"Failed to add onboarding stage: {e}")
-            return False
+        return workflows.add_onboarding_stage(self, stage)
 
     def add_verification_method(self, method: str) -> bool:
-        """Add a custom verification method"""
-        try:
-            if method not in self.verification_methods:
-                self.verification_methods.append(method)
-                self.logger.info(f"Verification method added: {method}")
-            return True
-        except Exception as e:
-            self.logger.error(f"Failed to add verification method: {e}")
-            return False
+        return workflows.add_verification_method(self, method)
 
-    # V2OnboardingSequenceValidator functionality integration
     def _wait_for_phase_response(
         self,
         session: Dict[str, Any],
@@ -526,20 +60,7 @@ class OnboardingValidator(BaseValidator):
         message_id: str,
         phase_timeout: float = 30.0,
     ) -> bool:
-        """Wait for and validate phase response (from V2OnboardingSequenceValidator)"""
-        import time
-
-        start = time.time()
-        while time.time() - start < phase_timeout:
-            time.sleep(0.1)
-            # In a real implementation, this would check for actual response
-            # For now, return True after timeout for testing/non-interactive environments
-            return True
-
-        self.logger.warning(
-            f"Timeout waiting for response for phase {phase} in session {session.get('session_id', 'unknown')}"
-        )
-        return False
+        return workflows.wait_for_phase_response(self, session, phase, message_id, phase_timeout)
 
     def _validate_onboarding_completion(
         self,
@@ -547,78 +68,7 @@ class OnboardingValidator(BaseValidator):
         role_definitions: Dict[str, Any] = None,
         fsm_core: Any = None,
     ) -> bool:
-        """Validate that onboarding has been completed successfully (from V2OnboardingSequenceValidator)"""
-        try:
-            if not role_definitions:
-                role_definitions = {}
-
-            agent_id = session.get("agent_id", "unknown")
-            required_phases = role_definitions.get(agent_id, {}).get(
-                "onboarding_phases", []
-            )
-
-            if required_phases:
-                completed_phases = session.get("completed_phases", [])
-                if not all(phase in completed_phases for phase in required_phases):
-                    self.logger.warning(
-                        f"Not all required phases completed for {agent_id}"
-                    )
-                    return False
-
-            if not self._validate_performance_metrics(session):
-                self.logger.warning(f"Performance validation failed for {agent_id}")
-                return False
-
-            # Create FSM task if FSM core is available
-            if fsm_core and hasattr(fsm_core, "create_task"):
-                try:
-                    fsm_core.create_task(
-                        title=f"Onboarding Completion - {agent_id}",
-                        description=(
-                            f"Agent {agent_id} has completed onboarding and is ready for active participation"
-                        ),
-                        assigned_agent=agent_id,
-                    )
-                except Exception as e:
-                    self.logger.warning(f"Failed to create FSM task: {e}")
-
-            return True
-
-        except Exception as e:
-            self.logger.error(f"Onboarding completion validation failed: {e}")
-            return False
+        return workflows.validate_onboarding_completion(self, session, role_definitions, fsm_core)
 
     def _validate_performance_metrics(self, session: Dict[str, Any]) -> bool:
-        """Validate performance metrics for onboarding completion (from V2OnboardingSequenceValidator)"""
-        try:
-            # Basic performance validation - can be extended
-            performance_data = session.get("performance_metrics", {})
-
-            # Check if required metrics are present
-            required_metrics = ["completion_time", "success_rate", "error_count"]
-            for metric in required_metrics:
-                if metric not in performance_data:
-                    self.logger.warning(f"Missing performance metric: {metric}")
-                    return False
-
-            # Validate metric values
-            completion_time = performance_data.get("completion_time", 0)
-            if completion_time < 0:
-                self.logger.warning("Completion time cannot be negative")
-                return False
-
-            success_rate = performance_data.get("success_rate", 0)
-            if not (0 <= success_rate <= 100):
-                self.logger.warning("Success rate must be between 0 and 100")
-                return False
-
-            error_count = performance_data.get("error_count", 0)
-            if error_count < 0:
-                self.logger.warning("Error count cannot be negative")
-                return False
-
-            return True
-
-        except Exception as e:
-            self.logger.error(f"Performance metrics validation failed: {e}")
-            return False
+        return workflows.validate_performance_metrics(self, session)


### PR DESCRIPTION
## Summary
- Move onboarding workflow checks into dedicated `validation/onboarding/workflows.py`
- Centralize rule constants in `validation/onboarding/rules.py`
- Isolate success and error reporting helpers in `validation/onboarding/reporting.py`
- Slim down `onboarding_validator.py` to orchestrate modular logic

## Testing
- `pytest src/core/validation/test_simple.py::test_onboarding_validator -q` *(fails: SyntaxError in existing validation package __init__)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a575ebc0832983842a3a59b566a7