### PR TITLE
refactor: modularize status manager

### DIFF
--- a/src/core/managers/status/__init__.py
+++ b/src/core/managers/status/__init__.py
@@ -1,0 +1,11 @@
+"""Status management utilities"""
+
+from .tracker import StatusTracker
+from .broadcaster import StatusBroadcaster
+from .storage import StatusStorage
+
+__all__ = [
+    "StatusTracker",
+    "StatusBroadcaster",
+    "StatusStorage",
+]

--- a/src/core/managers/status/broadcaster.py
+++ b/src/core/managers/status/broadcaster.py
@@ -1,22 +1,33 @@
-"""Status update logic and health monitoring."""
+"""Status broadcast and update utilities."""
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
-from .status_entities import ComponentHealth
-from .status_types import HealthStatus
-from .health_monitor import HealthMonitor
+from ..status_entities import ComponentHealth
+from ..status_types import HealthStatus
+from ..health_monitor import HealthMonitor
 
 
-class StatusUpdater:
-    """Manage health checks and component health state."""
+class StatusBroadcaster:
+    """Manage health checks and broadcast updates."""
 
-    def __init__(self, interval: int) -> None:
+    def __init__(
+        self,
+        interval: int,
+        event_callback: Optional[Callable[[str, Dict[str, Any]], None]] = None,
+    ) -> None:
         self.health_monitor = HealthMonitor(interval)
         self.component_health: Dict[str, ComponentHealth] = {}
         self.health_monitor.setup_default_checks()
+        self._event_callback = event_callback
+
+    def set_event_callback(
+        self, callback: Callable[[str, Dict[str, Any]], None]
+    ) -> None:
+        """Register callback for health update broadcasts."""
+        self._event_callback = callback
 
     def register_health_check(
         self, name: str, check: Callable[[], HealthStatus]
@@ -28,9 +39,21 @@ class StatusUpdater:
         for name, status in results.items():
             self.component_health[name] = ComponentHealth(
                 component_id=name,
+                name=name,
                 status=status,
                 last_check=datetime.now().isoformat(),
+                uptime=0.0,
+                response_time=0.0,
+                error_count=0,
+                success_rate=1.0,
+                metrics=[],
+                dependencies=[],
             )
+            if self._event_callback:
+                self._event_callback(
+                    "health_check",
+                    {"component_id": name, "status": status.value},
+                )
         return results
 
     def get_health_status(self, component_id: str) -> Optional[ComponentHealth]:

--- a/src/core/managers/status/storage.py
+++ b/src/core/managers/status/storage.py
@@ -1,0 +1,59 @@
+"""Persistence utilities for status data."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, Union
+
+from ..status_entities import ComponentHealth
+from .tracker import StatusTracker
+from .broadcaster import StatusBroadcaster
+
+
+class StatusStorage:
+    """Handle persistence of status information."""
+
+    def __init__(self, tracker: StatusTracker, broadcaster: StatusBroadcaster) -> None:
+        self.tracker = tracker
+        self.broadcaster = broadcaster
+
+    # ------------------------------------------------------------------
+    # In-memory state management
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        """Clear all tracked status information."""
+        self.tracker.clear()
+        self.broadcaster.clear()
+
+    def backup(self) -> Dict[str, Any]:
+        """Create an in-memory backup of current status."""
+        data = self.tracker.registry.backup()
+        data["component_health"] = {
+            k: asdict(v) for k, v in self.broadcaster.component_health.items()
+        }
+        return data
+
+    def restore(self, state: Dict[str, Any]) -> None:
+        """Restore status information from backup."""
+        self.tracker.registry.restore(state)
+        for k, v in state.get("component_health", {}).items():
+            self.broadcaster.component_health[k] = ComponentHealth(**v)
+
+    # ------------------------------------------------------------------
+    # File persistence helpers
+    # ------------------------------------------------------------------
+    def save(self, path: Union[str, Path]) -> None:
+        """Persist current status to a JSON file."""
+        data = self.backup()
+        with open(path, "w") as f:
+            json.dump(data, f)
+
+    def load(self, path: Union[str, Path]) -> None:
+        """Load status information from a JSON file."""
+        file_path = Path(path)
+        if file_path.exists():
+            with open(file_path, "r") as f:
+                data = json.load(f)
+            self.restore(data)

--- a/src/core/managers/status/tracker.py
+++ b/src/core/managers/status/tracker.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from .status_entities import StatusItem, StatusMetrics
-from .status_registry import StatusRegistry
-from .status_types import StatusLevel
+from ..status_entities import StatusItem, StatusMetrics
+from ..status_registry import StatusRegistry
+from ..status_types import StatusLevel
 
 
 class StatusTracker:

--- a/src/core/status/__init__.py
+++ b/src/core/status/__init__.py
@@ -26,6 +26,7 @@ from ..managers.status_entities import (
     StatusMetrics,
     ActivitySummary,
 )
+from ..managers.status import StatusTracker, StatusBroadcaster, StatusStorage
 
 # Backward compatibility
 __all__ = [
@@ -41,6 +42,9 @@ __all__ = [
     "StatusEvent",
     "StatusMetrics",
     "ActivitySummary",
+    "StatusTracker",
+    "StatusBroadcaster",
+    "StatusStorage",
     "run_smoke_test",
     "main",
 ]


### PR DESCRIPTION
## Summary
- extract status tracking into `status/tracker.py`
- centralize update broadcasting in `status/broadcaster.py`
- add `status/storage.py` for persistence and wire orchestrator to new modules

## Testing
- `pytest tests/test_status_manager_lifecycle.py -q`
- `pytest tests/test_status_manager_consolidation.py tests/test_status_manager_lifecycle.py -q` *(fails: IndentationError in tests/test_status_manager_consolidation.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a578a15083299cb073be4623b198