### PR TITLE
refactor: modularize phase transition analyzer

### DIFF
--- a/src/core/workflow/optimization/phase_transition_workflow_analyzer.py
+++ b/src/core/workflow/optimization/phase_transition_workflow_analyzer.py
@@ -1,641 +1,80 @@
 #!/usr/bin/env python3
-"""
-Phase Transition Workflow Analyzer - Integration Enhancement Optimization
-======================================================================
-
-Implements phase transition workflow analysis strategies for contract PHASE-001:
-1. Phase transition workflow analysis
-2. Bottleneck identification and optimization
-3. Performance improvement strategies
-4. Workflow optimization implementation
-5. Performance validation and testing
-
-Author: Agent-8 (Integration Enhancement Manager)
-License: MIT
-Contract: PHASE-001 - Phase Transition Workflow Analysis
-"""
-
+"""Phase Transition Workflow Analyzer - minimal coordinator."""
 import logging
-import asyncio
 import time
-from typing import Dict, List, Optional, Any, Tuple
 from datetime import datetime
-from dataclasses import dataclass
-from concurrent.futures import ThreadPoolExecutor, as_completed
-import json
+from typing import Any, Dict, List
 
-# Import existing workflow systems (following V2 standards)
-try:
-    from ...workflow.workflow_engine_integration import FSMWorkflowIntegration
-    from ...workflow.types.workflow_enums import WorkflowType, WorkflowStatus, TaskStatus
-    from ...managers.fsm_coordination import FSMSystemManager
-    from ...swarm_integration_manager import SwarmIntegrationManager
-except ImportError:
-    # Fallback for direct execution
-    pass
-
-
-@dataclass
-class PhaseTransitionMetrics:
-    """Metrics for measuring phase transition performance"""
-    transition_latency: float = 0.0  # milliseconds
-    phase_throughput: float = 0.0  # phases per second
-    resource_utilization: float = 0.0  # percentage
-    error_rate: float = 0.0  # percentage
-    workflow_coverage: float = 0.0  # percentage
-
-
-@dataclass
-class WorkflowAnalysisResult:
-    """Result of workflow analysis"""
-    analysis_id: str
-    timestamp: str
-    baseline_metrics: Dict[str, Any]
-    current_metrics: Dict[str, Any]
-    performance_improvement: float
-    optimization_strategies_applied: List[str]
-    quality_validation_passed: bool
-    next_phase_ready: bool
+from .transition_rules import (
+    implement_automated_phase_handoffs,
+    implement_parallel_phase_execution,
+    implement_real_time_phase_monitoring,
+)
+from .transition_analytics import (
+    analyze_current_phase_transition_workflows,
+    calculate_workflow_performance_improvement,
+    measure_current_workflow_performance,
+    measure_optimized_workflow_performance,
+    WorkflowAnalysisResult,
+)
+from .transition_visuals import generate_workflow_analysis_report
 
 
 class PhaseTransitionWorkflowAnalyzer:
-    """
-    Phase Transition Workflow Analyzer
-    
-    Single responsibility: Analyze and optimize phase transition workflows
-    following V2 standards - use existing architecture first.
-    """
-    
-    def __init__(self):
-        """Initialize the workflow analyzer"""
+    """Coordinate transition rules, analytics and visualization."""
+
+    def __init__(self) -> None:
         self.logger = logging.getLogger(f"{__name__}.PhaseTransitionWorkflowAnalyzer")
-        
-        # Initialize existing workflow systems
-        try:
-            self.fsm_workflow_integration = None  # Will be initialized if available
-            self.fsm_system_manager = None  # Will be initialized if available
-            self.swarm_integration_manager = None  # Will be initialized if available
-            self.logger.info("✅ Workflow systems ready for analysis")
-        except Exception as e:
-            self.logger.error(f"❌ Failed to initialize workflow systems: {e}")
-        
-        # Analysis state
-        self.analysis_active = False
-        self.phase_metrics = PhaseTransitionMetrics()
         self.analysis_results: List[WorkflowAnalysisResult] = []
-        
-        # Performance tracking
-        self.baseline_metrics = {}
-        self.current_metrics = {}
-        
-        # Thread pool for parallel operations
-        self.thread_pool = ThreadPoolExecutor(max_workers=4)
-        
-        # Analysis configuration
-        self.analysis_config = {
-            "workflow_analysis": True,
-            "bottleneck_identification": True,
-            "performance_optimization": True,
-            "quality_validation": True,
-            "continuous_analysis": True
-        }
-        
-        self.logger.info("✅ PhaseTransitionWorkflowAnalyzer initialized")
-    
+
     def analyze_current_phase_transition_workflows(self) -> Dict[str, Any]:
-        """
-        Analyze current phase transition workflows for optimization opportunities
-        
-        Returns:
-            Dictionary containing workflow analysis results
-        """
-        self.logger.info("🔍 Analyzing current phase transition workflows...")
-        
-        analysis_results = {
-            "workflow_patterns": [],
-            "optimization_opportunities": [],
-            "performance_metrics": {},
-            "bottlenecks_identified": [],
-            "analysis_timestamp": datetime.now().isoformat()
-        }
-        
-        try:
-            # Analyze current workflow patterns
-            analysis_results["workflow_patterns"] = [
-                "Sequential phase execution without parallelization",
-                "Manual phase handoff procedures",
-                "Basic phase transition monitoring",
-                "Limited phase optimization strategies",
-                "Basic phase performance metrics"
-            ]
-            
-            # Identify optimization opportunities
-            analysis_results["optimization_opportunities"] = [
-                "Parallel phase execution can improve transition efficiency by 70%",
-                "Automated handoffs can reduce transition time by 80%",
-                "Real-time monitoring can improve phase visibility by 90%",
-                "Automated optimization can increase phase performance by 6x",
-                "Advanced metrics can provide 95% phase transition coverage"
-            ]
-            
-            # Measure current performance metrics
-            analysis_results["performance_metrics"] = self._measure_current_workflow_performance()
-            
-            # Identify critical bottlenecks
-            analysis_results["bottlenecks_identified"] = [
-                "Sequential Phase Execution: Phases execute one by one without parallelization",
-                "Manual Handoffs: Phase transitions require manual intervention",
-                "Basic Monitoring: Limited phase transition performance insights",
-                "Limited Optimization: No real-time phase transition optimization",
-                "Basic Metrics: Limited phase transition performance measurement"
-            ]
-            
-            self.logger.info("✅ Phase transition workflow analysis completed successfully")
-            
-        except Exception as e:
-            self.logger.error(f"❌ Workflow analysis failed: {e}")
-            analysis_results["error"] = str(e)
-        
-        return analysis_results
-    
-    def _measure_current_workflow_performance(self) -> Dict[str, Any]:
-        """Measure current phase transition workflow performance metrics"""
-        metrics = {
-            "transition_latency": 0.0,
-            "phase_throughput": 0.0,
-            "resource_utilization": 0.0,
-            "error_rate": 0.0,
-            "workflow_coverage": 0.0
-        }
-        
-        try:
-            # Measure transition latency (simulated)
-            start_time = time.time()
-            time.sleep(0.5)  # Simulate phase transition execution
-            metrics["transition_latency"] = (time.time() - start_time) * 1000  # Convert to ms
-            
-            # Measure phase throughput (simulated)
-            metrics["phase_throughput"] = 2  # Current baseline: 2 phases/sec
-            
-            # Measure resource utilization (simulated)
-            metrics["resource_utilization"] = 80  # Current baseline: 80%
-            
-            # Measure error rate (simulated)
-            metrics["error_rate"] = 20  # Current baseline: 20%
-            
-            # Measure workflow coverage (simulated)
-            metrics["workflow_coverage"] = 30  # Current baseline: 30%
-            
-        except Exception as e:
-            self.logger.warning(f"Workflow performance measurement warning: {e}")
-        
-        return metrics
-    
-    def implement_parallel_phase_execution(self) -> Dict[str, Any]:
-        """
-        Implement parallel phase execution strategy
-        
-        Returns:
-            Dictionary containing implementation results
-        """
-        self.logger.info("⚡ Implementing parallel phase execution...")
-        
-        implementation_results = {
-            "strategy": "Parallel Phase Execution",
-            "status": "implemented",
-            "parallelization_percentage": 0.0,
-            "implementation_details": [],
-            "timestamp": datetime.now().isoformat()
-        }
-        
-        try:
-            # Implement phase parallelization
-            phase_parallelization = self._implement_phase_parallelization()
-            implementation_results["implementation_details"].append(phase_parallelization)
-            
-            # Implement transition optimization
-            transition_optimization = self._implement_transition_optimization()
-            implementation_results["implementation_details"].append(transition_optimization)
-            
-            # Calculate parallelization percentage
-            total_parallelization = sum([
-                phase_parallelization.get("parallelization_level", 0),
-                transition_optimization.get("parallelization_level", 0)
-            ]) / 2
-            
-            implementation_results["parallelization_percentage"] = total_parallelization
-            
-            self.logger.info(f"✅ Parallel phase execution implemented with {total_parallelization:.1f}% parallelization")
-            
-        except Exception as e:
-            self.logger.error(f"❌ Parallel execution implementation failed: {e}")
-            implementation_results["status"] = "failed"
-            implementation_results["error"] = str(e)
-        
-        return implementation_results
-    
-    def _implement_phase_parallelization(self) -> Dict[str, Any]:
-        """Implement phase parallelization"""
-        start_time = time.time()
-        
-        # Simulate phase parallelization
-        parallelization_tasks = ["Concurrent_Execution", "Dependency_Management", "Resource_Allocation", "Conflict_Resolution", "Load_Balancing"]
-        
-        # Process parallelization tasks automatically
-        parallelization_results = []
-        for task in parallelization_tasks:
-            time.sleep(0.01)  # Simulate parallelization time
-            parallelization_results.append(f"Parallelized: {task}")
-        
-        duration = time.time() - start_time
-        parallelization_level = 80.0  # Simulated 80% parallelization coverage
-        
-        return {
-            "component": "Phase Parallelization",
-            "parallelization_level": parallelization_level,
-            "processing_time": duration,
-            "tasks_parallelized": len(parallelization_tasks)
-        }
-    
-    def _implement_transition_optimization(self) -> Dict[str, Any]:
-        """Implement transition optimization"""
-        start_time = time.time()
-        
-        # Simulate transition optimization
-        optimization_tasks = ["Automated_Handoffs", "Transition_Monitoring", "Performance_Optimization", "Resource_Management", "Error_Handling"]
-        
-        # Process optimization tasks automatically
-        optimization_results = []
-        for task in optimization_tasks:
-            time.sleep(0.012)  # Simulate optimization time
-            optimization_results.append(f"Optimized: {task}")
-        
-        duration = time.time() - start_time
-        parallelization_level = 70.0  # Simulated 70% parallelization coverage
-        
-        return {
-            "component": "Transition Optimization",
-            "parallelization_level": parallelization_level,
-            "processing_time": duration,
-            "tasks_optimized": len(optimization_tasks)
-        }
-    
-    def implement_automated_phase_handoffs(self) -> Dict[str, Any]:
-        """
-        Implement automated phase handoffs strategy
-        
-        Returns:
-            Dictionary containing implementation results
-        """
-        self.logger.info("🤖 Implementing automated phase handoffs...")
-        
-        implementation_results = {
-            "strategy": "Automated Phase Handoffs",
-            "status": "implemented",
-            "automation_percentage": 0.0,
-            "implementation_details": [],
-            "timestamp": datetime.now().isoformat()
-        }
-        
-        try:
-            # Implement handoff automation
-            handoff_automation = self._implement_handoff_automation()
-            implementation_results["implementation_details"].append(handoff_automation)
-            
-            # Implement transition management
-            transition_management = self._implement_transition_management()
-            implementation_results["implementation_details"].append(transition_management)
-            
-            # Calculate automation percentage
-            total_automation = sum([
-                handoff_automation.get("automation_level", 0),
-                transition_management.get("automation_level", 0)
-            ]) / 2
-            
-            implementation_results["automation_percentage"] = total_automation
-            
-            self.logger.info(f"✅ Automated phase handoffs implemented with {total_automation:.1f}% automation")
-            
-        except Exception as e:
-            self.logger.error(f"❌ Automated handoffs implementation failed: {e}")
-            implementation_results["status"] = "failed"
-            implementation_results["error"] = str(e)
-        
-        return implementation_results
-    
-    def _implement_handoff_automation(self) -> Dict[str, Any]:
-        """Implement handoff automation"""
-        start_time = time.time()
-        
-        # Simulate handoff automation
-        automation_tasks = ["Completion_Detection", "Next_Phase_Activation", "Resource_Transfer", "Status_Synchronization", "Validation_Checks"]
-        
-        # Process automation tasks automatically
-        automation_results = []
-        for task in automation_tasks:
-            time.sleep(0.008)  # Simulate automation time
-            automation_results.append(f"Automated: {task}")
-        
-        duration = time.time() - start_time
-        automation_level = 90.0  # Simulated 90% automation coverage
-        
-        return {
-            "component": "Handoff Automation",
-            "automation_level": automation_level,
-            "processing_time": duration,
-            "tasks_automated": len(automation_tasks)
-        }
-    
-    def _implement_transition_management(self) -> Dict[str, Any]:
-        """Implement transition management"""
-        start_time = time.time()
-        
-        # Simulate transition management
-        management_tasks = ["State_Management", "Transition_Validation", "Error_Handling", "Performance_Tracking", "Resource_Allocation"]
-        
-        # Process management tasks automatically
-        management_results = []
-        for task in management_tasks:
-            time.sleep(0.009)  # Simulate management time
-            management_results.append(f"Managed: {task}")
-        
-        duration = time.time() - start_time
-        automation_level = 80.0  # Simulated 80% automation coverage
-        
-        return {
-            "component": "Transition Management",
-            "automation_level": automation_level,
-            "processing_time": duration,
-            "tasks_managed": len(management_tasks)
-        }
-    
-    def implement_real_time_phase_monitoring(self) -> Dict[str, Any]:
-        """
-        Implement real-time phase monitoring strategy
-        
-        Returns:
-            Dictionary containing implementation results
-        """
-        self.logger.info("📊 Implementing real-time phase monitoring...")
-        
-        implementation_results = {
-            "strategy": "Real-Time Phase Monitoring",
-            "status": "implemented",
-            "monitoring_percentage": 0.0,
-            "implementation_details": [],
-            "timestamp": datetime.now().isoformat()
-        }
-        
-        try:
-            # Implement performance monitoring
-            performance_monitoring = self._implement_performance_monitoring()
-            implementation_results["implementation_details"].append(performance_monitoring)
-            
-            # Implement transition analytics
-            transition_analytics = self._implement_transition_analytics()
-            implementation_results["implementation_details"].append(transition_analytics)
-            
-            # Calculate monitoring percentage
-            total_monitoring = sum([
-                performance_monitoring.get("monitoring_level", 0),
-                transition_analytics.get("monitoring_level", 0)
-            ]) / 2
-            
-            implementation_results["monitoring_percentage"] = total_monitoring
-            
-            self.logger.info(f"✅ Real-time phase monitoring implemented with {total_monitoring:.1f}% coverage")
-            
-        except Exception as e:
-            self.logger.error(f"❌ Real-time monitoring implementation failed: {e}")
-            implementation_results["status"] = "failed"
-            implementation_results["error"] = str(e)
-        
-        return implementation_results
-    
-    def _implement_performance_monitoring(self) -> Dict[str, Any]:
-        """Implement performance monitoring"""
-        start_time = time.time()
-        
-        # Simulate performance monitoring
-        monitoring_tasks = ["Real_Time_Metrics", "Performance_Trends", "Bottleneck_Detection", "Optimization_Recommendations", "Alert_Generation"]
-        
-        # Process monitoring tasks automatically
-        monitoring_results = []
-        for task in monitoring_tasks:
-            time.sleep(0.007)  # Simulate monitoring time
-            monitoring_results.append(f"Monitored: {task}")
-        
-        duration = time.time() - start_time
-        monitoring_level = 92.0  # Simulated 92% monitoring coverage
-        
-        return {
-            "component": "Performance Monitoring",
-            "monitoring_level": monitoring_level,
-            "processing_time": duration,
-            "tasks_monitored": len(monitoring_tasks)
-        }
-    
-    def _implement_transition_analytics(self) -> Dict[str, Any]:
-        """Implement transition analytics"""
-        start_time = time.time()
-        
-        # Simulate transition analytics
-        analytics_tasks = ["Transition_Timing", "Resource_Tracking", "Performance_Correlation", "Predictive_Optimization", "Trend_Analysis"]
-        
-        # Process analytics tasks automatically
-        analytics_results = []
-        for task in analytics_tasks:
-            time.sleep(0.006)  # Simulate analytics time
-            analytics_results.append(f"Analyzed: {task}")
-        
-        duration = time.time() - start_time
-        monitoring_level = 88.0  # Simulated 88% monitoring coverage
-        
-        return {
-            "component": "Transition Analytics",
-            "monitoring_level": monitoring_level,
-            "processing_time": duration,
-            "tasks_analyzed": len(analytics_tasks)
-        }
-    
+        return analyze_current_phase_transition_workflows()
+
     def execute_workflow_analysis_strategies(self) -> WorkflowAnalysisResult:
-        """
-        Execute all workflow analysis strategies
-        
-        Returns:
-            WorkflowAnalysisResult containing analysis results
-        """
         self.logger.info("🚀 Executing phase transition workflow analysis strategies...")
-        
-        # Measure baseline performance
-        self.baseline_metrics = self._measure_current_workflow_performance()
-        
-        # Execute analysis strategies
-        analysis_results = []
-        
-        # 1. Parallel Phase Execution
-        parallel_execution = self.implement_parallel_phase_execution()
-        analysis_results.append(parallel_execution)
-        
-        # 2. Automated Phase Handoffs
-        automated_handoffs = self.implement_automated_phase_handoffs()
-        analysis_results.append(automated_handoffs)
-        
-        # 3. Real-Time Phase Monitoring
-        real_time_monitoring = self.implement_real_time_phase_monitoring()
-        analysis_results.append(real_time_monitoring)
-        
-        # Measure current performance
-        self.current_metrics = self._measure_optimized_workflow_performance()
-        
-        # Calculate overall performance improvement
-        performance_improvement = self._calculate_workflow_performance_improvement()
-        
-        # Create analysis result
+        baseline_metrics = measure_current_workflow_performance()
+
+        implement_parallel_phase_execution()
+        implement_automated_phase_handoffs()
+        implement_real_time_phase_monitoring()
+
+        current_metrics = measure_optimized_workflow_performance(baseline_metrics)
+        performance_improvement = calculate_workflow_performance_improvement(
+            baseline_metrics, current_metrics
+        )
+
         result = WorkflowAnalysisResult(
             analysis_id=f"ANALYSIS-{int(time.time())}",
             timestamp=datetime.now().isoformat(),
-            baseline_metrics=self.baseline_metrics,
-            current_metrics=self.current_metrics,
+            baseline_metrics=baseline_metrics,
+            current_metrics=current_metrics,
             performance_improvement=performance_improvement,
             optimization_strategies_applied=[
                 "Parallel Phase Execution",
                 "Automated Phase Handoffs",
-                "Real-Time Phase Monitoring"
+                "Real-Time Phase Monitoring",
             ],
             quality_validation_passed=True,
-            next_phase_ready=True
+            next_phase_ready=True,
         )
-        
-        # Store result
         self.analysis_results.append(result)
-        
-        self.logger.info(f"✅ Workflow analysis strategies executed with {performance_improvement:.1f}% performance improvement")
-        
+        self.logger.info(
+            f"✅ Workflow analysis strategies executed with {performance_improvement:.1f}% performance improvement"
+        )
         return result
-    
-    def _measure_optimized_workflow_performance(self) -> Dict[str, Any]:
-        """Measure optimized phase transition workflow performance metrics"""
-        metrics = {
-            "transition_latency": 0.0,
-            "phase_throughput": 0.0,
-            "resource_utilization": 0.0,
-            "error_rate": 0.0,
-            "workflow_coverage": 0.0
-        }
-        
-        try:
-            # Apply optimization improvements
-            metrics["transition_latency"] = self.baseline_metrics.get("transition_latency", 500) * 0.2  # 80% reduction
-            metrics["phase_throughput"] = self.baseline_metrics.get("phase_throughput", 2) * 6  # 6x improvement
-            metrics["resource_utilization"] = self.baseline_metrics.get("resource_utilization", 80) * 0.75  # 25% reduction
-            metrics["error_rate"] = self.baseline_metrics.get("error_rate", 20) * 0.15  # 85% reduction
-            metrics["workflow_coverage"] = self.baseline_metrics.get("workflow_coverage", 30) * 2.83  # 95% coverage
-            
-        except Exception as e:
-            self.logger.warning(f"Optimized workflow performance measurement warning: {e}")
-        
-        return metrics
-    
-    def _calculate_workflow_performance_improvement(self) -> float:
-        """Calculate overall workflow performance improvement percentage"""
-        try:
-            baseline_latency = self.baseline_metrics.get("transition_latency", 500)
-            optimized_latency = self.current_metrics.get("transition_latency", 100)
-            
-            if baseline_latency > 0:
-                improvement = ((baseline_latency - optimized_latency) / baseline_latency) * 100
-                return improvement
-            else:
-                return 0.0
-                
-        except Exception as e:
-            self.logger.warning(f"Workflow performance improvement calculation warning: {e}")
-            return 0.0
-    
+
     def generate_workflow_analysis_report(self) -> Dict[str, Any]:
-        """
-        Generate comprehensive workflow analysis report
-        
-        Returns:
-            Dictionary containing workflow analysis report
-        """
-        self.logger.info("📊 Generating workflow analysis report...")
-        
         if not self.analysis_results:
             return {"error": "No analysis results available"}
-        
-        latest_result = self.analysis_results[-1]
-        
-        report = {
-            "analysis_summary": {
-                "analysis_id": latest_result.analysis_id,
-                "timestamp": latest_result.timestamp,
-                "performance_improvement": f"{latest_result.performance_improvement:.1f}%",
-                "strategies_applied": latest_result.optimization_strategies_applied,
-                "quality_validation": "PASSED" if latest_result.quality_validation_passed else "FAILED",
-                "next_phase_ready": latest_result.next_phase_ready
-            },
-            "performance_metrics": {
-                "baseline": latest_result.baseline_metrics,
-                "optimized": latest_result.current_metrics,
-                "improvements": {
-                    "transition_latency": f"{((latest_result.baseline_metrics.get('transition_latency', 0) - latest_result.current_metrics.get('transition_latency', 0)) / latest_result.baseline_metrics.get('transition_latency', 1)) * 100:.1f}%",
-                    "phase_throughput": f"{latest_result.current_metrics.get('phase_throughput', 0) / max(latest_result.baseline_metrics.get('phase_throughput', 1), 1):.1f}x",
-                    "resource_utilization": f"{((latest_result.baseline_metrics.get('resource_utilization', 0) - latest_result.current_metrics.get('resource_utilization', 0)) / latest_result.baseline_metrics.get('resource_utilization', 1)) * 100:.1f}%",
-                    "error_rate": f"{((latest_result.baseline_metrics.get('error_rate', 0) - latest_result.current_metrics.get('error_rate', 0)) / latest_result.baseline_metrics.get('error_rate', 1)) * 100:.1f}%",
-                    "workflow_coverage": f"{((latest_result.current_metrics.get('workflow_coverage', 0) - latest_result.baseline_metrics.get('workflow_coverage', 0)) / latest_result.baseline_metrics.get('workflow_coverage', 1)) * 100:.1f}%"
-                }
-            },
-            "optimization_strategies": {
-                "parallel_phase_execution": {
-                    "status": "implemented",
-                    "parallelization": "75%"
-                },
-                "automated_phase_handoffs": {
-                    "status": "implemented",
-                    "automation": "85%"
-                },
-                "real_time_phase_monitoring": {
-                    "status": "implemented",
-                    "monitoring_coverage": "90%"
-                }
-            },
-            "contract_completion": {
-                "contract_id": "PHASE-001",
-                "title": "Phase Transition Workflow Analysis",
-                "status": "COMPLETED",
-                "deliverables": [
-                    "Phase Transition Workflow Analysis Report",
-                    "Parallel Phase Execution Implementation",
-                    "Automated Phase Handoffs System",
-                    "Real-Time Phase Monitoring Implementation",
-                    "Performance Validation Report"
-                ]
-            }
-        }
-        
-        self.logger.info("✅ Workflow analysis report generated successfully")
-        return report
+        return generate_workflow_analysis_report(self.analysis_results[-1])
 
 
-def main():
-    """Main execution function for testing"""
+def main() -> None:
     logging.basicConfig(level=logging.INFO)
-    
-    # Initialize workflow analyzer
     analyzer = PhaseTransitionWorkflowAnalyzer()
-    
-    # Execute analysis strategies
-    result = analyzer.execute_workflow_analysis_strategies()
-    
-    # Generate report
+    analyzer.execute_workflow_analysis_strategies()
     report = analyzer.generate_workflow_analysis_report()
-    
-    # Print results
-    print(f"✅ Workflow analysis completed with {result.performance_improvement:.1f}% performance improvement")
-    print(f"📊 Report: {report['analysis_summary']['performance_improvement']} overall improvement")
-    print(f"🚀 Next phase ready: {result.next_phase_ready}")
+    print(report["analysis_summary"]["performance_improvement"])
 
 
 if __name__ == "__main__":

--- a/src/core/workflow/optimization/transition_analytics.py
+++ b/src/core/workflow/optimization/transition_analytics.py
@@ -1,0 +1,130 @@
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PhaseTransitionMetrics:
+    """Metrics for measuring phase transition performance."""
+    transition_latency: float = 0.0
+    phase_throughput: float = 0.0
+    resource_utilization: float = 0.0
+    error_rate: float = 0.0
+    workflow_coverage: float = 0.0
+
+
+@dataclass
+class WorkflowAnalysisResult:
+    """Result of workflow analysis."""
+    analysis_id: str
+    timestamp: str
+    baseline_metrics: Dict[str, Any]
+    current_metrics: Dict[str, Any]
+    performance_improvement: float
+    optimization_strategies_applied: List[str]
+    quality_validation_passed: bool
+    next_phase_ready: bool
+
+
+def analyze_current_phase_transition_workflows() -> Dict[str, Any]:
+    """Analyze current phase transition workflows for optimization opportunities."""
+    logger.info("🔍 Analyzing current phase transition workflows...")
+
+    analysis_results: Dict[str, Any] = {
+        "workflow_patterns": [],
+        "optimization_opportunities": [],
+        "performance_metrics": {},
+        "bottlenecks_identified": [],
+        "analysis_timestamp": datetime.now().isoformat(),
+    }
+
+    try:
+        analysis_results["workflow_patterns"] = [
+            "Sequential phase execution without parallelization",
+            "Manual phase handoff procedures",
+            "Basic phase transition monitoring",
+            "Limited phase optimization strategies",
+            "Basic phase performance metrics",
+        ]
+        analysis_results["optimization_opportunities"] = [
+            "Parallel phase execution can improve transition efficiency by 70%",
+            "Automated handoffs can reduce transition time by 80%",
+            "Real-time monitoring can improve phase visibility by 90%",
+            "Automated optimization can increase phase performance by 6x",
+            "Advanced metrics can provide 95% phase transition coverage",
+        ]
+        analysis_results["performance_metrics"] = measure_current_workflow_performance()
+        analysis_results["bottlenecks_identified"] = [
+            "Sequential Phase Execution: Phases execute one by one without parallelization",
+            "Manual Handoffs: Phase transitions require manual intervention",
+            "Basic Monitoring: Limited phase transition performance insights",
+            "Limited Optimization: No real-time phase transition optimization",
+            "Basic Metrics: Limited phase transition performance measurement",
+        ]
+        logger.info("✅ Phase transition workflow analysis completed successfully")
+    except Exception as e:  # pragma: no cover - simple logging wrapper
+        logger.error(f"❌ Workflow analysis failed: {e}")
+        analysis_results["error"] = str(e)
+
+    return analysis_results
+
+
+def measure_current_workflow_performance() -> Dict[str, Any]:
+    """Measure current phase transition workflow performance metrics."""
+    metrics = {
+        "transition_latency": 0.0,
+        "phase_throughput": 0.0,
+        "resource_utilization": 0.0,
+        "error_rate": 0.0,
+        "workflow_coverage": 0.0,
+    }
+    try:
+        start_time = time.time()
+        time.sleep(0.5)
+        metrics["transition_latency"] = (time.time() - start_time) * 1000
+        metrics["phase_throughput"] = 2
+        metrics["resource_utilization"] = 80
+        metrics["error_rate"] = 20
+        metrics["workflow_coverage"] = 30
+    except Exception as e:  # pragma: no cover - simple logging wrapper
+        logger.warning(f"Workflow performance measurement warning: {e}")
+    return metrics
+
+
+def measure_optimized_workflow_performance(baseline_metrics: Dict[str, Any]) -> Dict[str, Any]:
+    """Measure optimized phase transition workflow performance metrics."""
+    metrics = {
+        "transition_latency": 0.0,
+        "phase_throughput": 0.0,
+        "resource_utilization": 0.0,
+        "error_rate": 0.0,
+        "workflow_coverage": 0.0,
+    }
+    try:
+        metrics["transition_latency"] = baseline_metrics.get("transition_latency", 500) * 0.2
+        metrics["phase_throughput"] = baseline_metrics.get("phase_throughput", 2) * 6
+        metrics["resource_utilization"] = baseline_metrics.get("resource_utilization", 80) * 0.75
+        metrics["error_rate"] = baseline_metrics.get("error_rate", 20) * 0.15
+        metrics["workflow_coverage"] = baseline_metrics.get("workflow_coverage", 30) * 2.83
+    except Exception as e:  # pragma: no cover - simple logging wrapper
+        logger.warning(f"Optimized workflow performance measurement warning: {e}")
+    return metrics
+
+
+def calculate_workflow_performance_improvement(
+    baseline_metrics: Dict[str, Any], current_metrics: Dict[str, Any]
+) -> float:
+    """Calculate overall workflow performance improvement percentage."""
+    try:
+        baseline_latency = baseline_metrics.get("transition_latency", 500)
+        optimized_latency = current_metrics.get("transition_latency", 100)
+        if baseline_latency > 0:
+            return ((baseline_latency - optimized_latency) / baseline_latency) * 100
+        return 0.0
+    except Exception as e:  # pragma: no cover - simple logging wrapper
+        logger.warning(f"Workflow performance improvement calculation warning: {e}")
+        return 0.0

--- a/src/core/workflow/optimization/transition_rules.py
+++ b/src/core/workflow/optimization/transition_rules.py
@@ -1,0 +1,261 @@
+import logging
+import time
+from datetime import datetime
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def implement_parallel_phase_execution() -> Dict[str, Any]:
+    """Implement parallel phase execution strategy."""
+    logger.info("⚡ Implementing parallel phase execution...")
+
+    implementation_results = {
+        "strategy": "Parallel Phase Execution",
+        "status": "implemented",
+        "parallelization_percentage": 0.0,
+        "implementation_details": [],
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    try:
+        phase_parallelization = _implement_phase_parallelization()
+        implementation_results["implementation_details"].append(phase_parallelization)
+
+        transition_optimization = _implement_transition_optimization()
+        implementation_results["implementation_details"].append(transition_optimization)
+
+        total_parallelization = (
+            phase_parallelization.get("parallelization_level", 0)
+            + transition_optimization.get("parallelization_level", 0)
+        ) / 2
+        implementation_results["parallelization_percentage"] = total_parallelization
+        logger.info(
+            f"✅ Parallel phase execution implemented with {total_parallelization:.1f}% parallelization"
+        )
+    except Exception as e:  # pragma: no cover - simple logging wrapper
+        logger.error(f"❌ Parallel execution implementation failed: {e}")
+        implementation_results["status"] = "failed"
+        implementation_results["error"] = str(e)
+
+    return implementation_results
+
+
+def _implement_phase_parallelization() -> Dict[str, Any]:
+    """Implement phase parallelization."""
+    start_time = time.time()
+    parallelization_tasks = [
+        "Concurrent_Execution",
+        "Dependency_Management",
+        "Resource_Allocation",
+        "Conflict_Resolution",
+        "Load_Balancing",
+    ]
+    parallelization_results = []
+    for task in parallelization_tasks:
+        time.sleep(0.01)
+        parallelization_results.append(f"Parallelized: {task}")
+
+    duration = time.time() - start_time
+    parallelization_level = 80.0
+    return {
+        "component": "Phase Parallelization",
+        "parallelization_level": parallelization_level,
+        "processing_time": duration,
+        "tasks_parallelized": len(parallelization_tasks),
+    }
+
+
+def _implement_transition_optimization() -> Dict[str, Any]:
+    """Implement transition optimization."""
+    start_time = time.time()
+    optimization_tasks = [
+        "Automated_Handoffs",
+        "Transition_Monitoring",
+        "Performance_Optimization",
+        "Resource_Management",
+        "Error_Handling",
+    ]
+    optimization_results = []
+    for task in optimization_tasks:
+        time.sleep(0.012)
+        optimization_results.append(f"Optimized: {task}")
+
+    duration = time.time() - start_time
+    parallelization_level = 70.0
+    return {
+        "component": "Transition Optimization",
+        "parallelization_level": parallelization_level,
+        "processing_time": duration,
+        "tasks_optimized": len(optimization_tasks),
+    }
+
+
+def implement_automated_phase_handoffs() -> Dict[str, Any]:
+    """Implement automated phase handoffs strategy."""
+    logger.info("🤖 Implementing automated phase handoffs...")
+
+    implementation_results = {
+        "strategy": "Automated Phase Handoffs",
+        "status": "implemented",
+        "automation_percentage": 0.0,
+        "implementation_details": [],
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    try:
+        handoff_automation = _implement_handoff_automation()
+        implementation_results["implementation_details"].append(handoff_automation)
+
+        transition_management = _implement_transition_management()
+        implementation_results["implementation_details"].append(transition_management)
+
+        total_automation = (
+            handoff_automation.get("automation_level", 0)
+            + transition_management.get("automation_level", 0)
+        ) / 2
+        implementation_results["automation_percentage"] = total_automation
+        logger.info(
+            f"✅ Automated phase handoffs implemented with {total_automation:.1f}% automation"
+        )
+    except Exception as e:  # pragma: no cover - simple logging wrapper
+        logger.error(f"❌ Automated handoffs implementation failed: {e}")
+        implementation_results["status"] = "failed"
+        implementation_results["error"] = str(e)
+
+    return implementation_results
+
+
+def _implement_handoff_automation() -> Dict[str, Any]:
+    """Implement handoff automation."""
+    start_time = time.time()
+    automation_tasks = [
+        "Completion_Detection",
+        "Next_Phase_Activation",
+        "Resource_Transfer",
+        "Status_Synchronization",
+        "Validation_Checks",
+    ]
+    automation_results = []
+    for task in automation_tasks:
+        time.sleep(0.008)
+        automation_results.append(f"Automated: {task}")
+
+    duration = time.time() - start_time
+    automation_level = 90.0
+    return {
+        "component": "Handoff Automation",
+        "automation_level": automation_level,
+        "processing_time": duration,
+        "tasks_automated": len(automation_tasks),
+    }
+
+
+def _implement_transition_management() -> Dict[str, Any]:
+    """Implement transition management."""
+    start_time = time.time()
+    management_tasks = [
+        "State_Management",
+        "Transition_Validation",
+        "Error_Handling",
+        "Performance_Tracking",
+        "Resource_Allocation",
+    ]
+    management_results = []
+    for task in management_tasks:
+        time.sleep(0.009)
+        management_results.append(f"Managed: {task}")
+
+    duration = time.time() - start_time
+    automation_level = 80.0
+    return {
+        "component": "Transition Management",
+        "automation_level": automation_level,
+        "processing_time": duration,
+        "tasks_managed": len(management_tasks),
+    }
+
+
+def implement_real_time_phase_monitoring() -> Dict[str, Any]:
+    """Implement real-time phase monitoring strategy."""
+    logger.info("📊 Implementing real-time phase monitoring...")
+
+    implementation_results = {
+        "strategy": "Real-Time Phase Monitoring",
+        "status": "implemented",
+        "monitoring_percentage": 0.0,
+        "implementation_details": [],
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    try:
+        performance_monitoring = _implement_performance_monitoring()
+        implementation_results["implementation_details"].append(performance_monitoring)
+
+        transition_analytics = _implement_transition_analytics()
+        implementation_results["implementation_details"].append(transition_analytics)
+
+        total_monitoring = (
+            performance_monitoring.get("monitoring_level", 0)
+            + transition_analytics.get("monitoring_level", 0)
+        ) / 2
+        implementation_results["monitoring_percentage"] = total_monitoring
+        logger.info(
+            f"✅ Real-time phase monitoring implemented with {total_monitoring:.1f}% coverage"
+        )
+    except Exception as e:  # pragma: no cover - simple logging wrapper
+        logger.error(f"❌ Real-time monitoring implementation failed: {e}")
+        implementation_results["status"] = "failed"
+        implementation_results["error"] = str(e)
+
+    return implementation_results
+
+
+def _implement_performance_monitoring() -> Dict[str, Any]:
+    """Implement performance monitoring."""
+    start_time = time.time()
+    monitoring_tasks = [
+        "Real_Time_Metrics",
+        "Performance_Trends",
+        "Bottleneck_Detection",
+        "Optimization_Recommendations",
+        "Alert_Generation",
+    ]
+    monitoring_results = []
+    for task in monitoring_tasks:
+        time.sleep(0.007)
+        monitoring_results.append(f"Monitored: {task}")
+
+    duration = time.time() - start_time
+    monitoring_level = 92.0
+    return {
+        "component": "Performance Monitoring",
+        "monitoring_level": monitoring_level,
+        "processing_time": duration,
+        "tasks_monitored": len(monitoring_tasks),
+    }
+
+
+def _implement_transition_analytics() -> Dict[str, Any]:
+    """Implement transition analytics."""
+    start_time = time.time()
+    analytics_tasks = [
+        "Transition_Timing",
+        "Resource_Tracking",
+        "Performance_Correlation",
+        "Predictive_Optimization",
+        "Trend_Analysis",
+    ]
+    analytics_results = []
+    for task in analytics_tasks:
+        time.sleep(0.006)
+        analytics_results.append(f"Analyzed: {task}")
+
+    duration = time.time() - start_time
+    monitoring_level = 88.0
+    return {
+        "component": "Transition Analytics",
+        "monitoring_level": monitoring_level,
+        "processing_time": duration,
+        "tasks_analyzed": len(analytics_tasks),
+    }

--- a/src/core/workflow/optimization/transition_visuals.py
+++ b/src/core/workflow/optimization/transition_visuals.py
@@ -1,0 +1,62 @@
+import logging
+from typing import Any, Dict
+
+from .transition_analytics import WorkflowAnalysisResult
+
+logger = logging.getLogger(__name__)
+
+
+def generate_workflow_analysis_report(result: WorkflowAnalysisResult) -> Dict[str, Any]:
+    """Generate a comprehensive workflow analysis report."""
+    logger.info("📊 Generating workflow analysis report...")
+
+    report = {
+        "analysis_summary": {
+            "analysis_id": result.analysis_id,
+            "timestamp": result.timestamp,
+            "performance_improvement": f"{result.performance_improvement:.1f}%",
+            "strategies_applied": result.optimization_strategies_applied,
+            "quality_validation": "PASSED" if result.quality_validation_passed else "FAILED",
+            "next_phase_ready": result.next_phase_ready,
+        },
+        "performance_metrics": {
+            "baseline": result.baseline_metrics,
+            "optimized": result.current_metrics,
+            "improvements": {
+                "transition_latency": f"{((result.baseline_metrics.get('transition_latency', 0) - result.current_metrics.get('transition_latency', 0)) / result.baseline_metrics.get('transition_latency', 1)) * 100:.1f}%",
+                "phase_throughput": f"{result.current_metrics.get('phase_throughput', 0) / max(result.baseline_metrics.get('phase_throughput', 1), 1):.1f}x",
+                "resource_utilization": f"{((result.baseline_metrics.get('resource_utilization', 0) - result.current_metrics.get('resource_utilization', 0)) / result.baseline_metrics.get('resource_utilization', 1)) * 100:.1f}%",
+                "error_rate": f"{((result.baseline_metrics.get('error_rate', 0) - result.current_metrics.get('error_rate', 0)) / result.baseline_metrics.get('error_rate', 1)) * 100:.1f}%",
+                "workflow_coverage": f"{((result.current_metrics.get('workflow_coverage', 0) - result.baseline_metrics.get('workflow_coverage', 0)) / result.baseline_metrics.get('workflow_coverage', 1)) * 100:.1f}%",
+            },
+        },
+        "optimization_strategies": {
+            "parallel_phase_execution": {
+                "status": "implemented",
+                "parallelization": "75%",
+            },
+            "automated_phase_handoffs": {
+                "status": "implemented",
+                "automation": "85%",
+            },
+            "real_time_phase_monitoring": {
+                "status": "implemented",
+                "monitoring_coverage": "90%",
+            },
+        },
+        "contract_completion": {
+            "contract_id": "PHASE-001",
+            "title": "Phase Transition Workflow Analysis",
+            "status": "COMPLETED",
+            "deliverables": [
+                "Phase Transition Workflow Analysis Report",
+                "Parallel Phase Execution Implementation",
+                "Automated Phase Handoffs System",
+                "Real-Time Phase Monitoring Implementation",
+                "Performance Validation Report",
+            ],
+        },
+    }
+
+    logger.info("✅ Workflow analysis report generated successfully")
+    return report


### PR DESCRIPTION
## Summary
- split phase transition rules into `transition_rules`
- move analytics utilities into `transition_analytics`
- extract reporting to `transition_visuals`
- shrink `phase_transition_workflow_analyzer` to coordinate new modules

## Testing
- `pytest` *(fails: ModuleNotFoundError and ImportError leading to 133 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a582615483299a6a8c24a94d65e7