### PR TITLE
refactor: modularize emergency docs

### DIFF
--- a/src/core/emergency/docs/__init__.py
+++ b/src/core/emergency/docs/__init__.py
@@ -1,0 +1,1 @@
+"""Documentation utilities for emergency system."""

--- a/src/core/emergency/docs/distribution.py
+++ b/src/core/emergency/docs/distribution.py
@@ -1,0 +1,37 @@
+"""Distribution utilities for emergency documentation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def save_document_to_file(base_path: Path, document: Any) -> None:
+    """Persist a document dataclass to the filesystem."""
+    type_dir = {
+        "event_log": "events",
+        "response_timeline": "timelines",
+        "recovery_validation": "validations",
+        "lessons_learned": "lessons",
+    }.get(getattr(document, "document_type").value, "reports")
+
+    file_path = base_path / type_dir / f"{document.document_id}.json"
+
+    doc_data = {
+        "document_id": document.document_id,
+        "document_type": document.document_type.value,
+        "title": document.title,
+        "content": document.content,
+        "created_at": document.created_at.isoformat(),
+        "updated_at": document.updated_at.isoformat(),
+        "author": document.author,
+        "priority": document.priority.value,
+        "tags": document.tags,
+        "related_emergencies": document.related_emergencies,
+    }
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w") as f:
+        json.dump(doc_data, f, indent=2)
+
+    document.file_path = str(file_path)

--- a/src/core/emergency/docs/generator.py
+++ b/src/core/emergency/docs/generator.py
@@ -1,0 +1,109 @@
+"""Report generation utilities for the emergency documentation system."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from string import Template
+from typing import Any, List, Optional
+
+
+def _load_template(name: str) -> Template:
+    """Load a Markdown template by name."""
+    template_path = Path(__file__).resolve().parent / "templates" / f"{name}.md"
+    return Template(template_path.read_text())
+
+
+def generate_report_content(
+    emergency_id: str,
+    events: List[Any],
+    timeline: Optional[Any],
+    validations: List[Any],
+    lessons: List[Any],
+) -> str:
+    """Generate emergency report content from provided data."""
+    template = _load_template("report")
+
+    if events:
+        event_lines = [
+            f"- **{e.timestamp.strftime('%H:%M:%S')}** ["
+            f"{e.severity.upper()}] {e.event_type}: {e.description}"
+            for e in events
+        ]
+        events_section = "\n".join(event_lines)
+    else:
+        events_section = "No events recorded for this emergency."
+
+    timeline_section = ""
+    if timeline:
+        lines = [
+            "## Response Timeline",
+            f"**Start Time:** {timeline.start_time.strftime('%Y-%m-%d %H:%M:%S')}",
+        ]
+        if getattr(timeline, "end_time", None):
+            lines.append(
+                f"**End Time:** {timeline.end_time.strftime('%Y-%m-%d %H:%M:%S')}"
+            )
+            if getattr(timeline, "duration", None):
+                lines.append(f"**Duration:** {timeline.duration}")
+        lines.append("")
+
+        if getattr(timeline, "actions", None):
+            lines.append("### Response Actions")
+            for action in timeline.actions:
+                lines.append(
+                    f"- **{action['timestamp'].strftime('%H:%M:%S')}** "
+                    f"{action['action']}: {action['description']}"
+                )
+            lines.append("")
+
+        if getattr(timeline, "milestones", None):
+            lines.append("### Key Milestones")
+            for milestone in timeline.milestones:
+                lines.append(
+                    f"- **{milestone['timestamp'].strftime('%H:%M:%S')}** "
+                    f"{milestone['milestone']}: {milestone['description']}"
+                )
+            lines.append("")
+        timeline_section = "\n".join(lines)
+
+    validation_section = ""
+    if validations:
+        lines = ["## Recovery Validation Results"]
+        for validation in validations:
+            lines.append(f"**Validation ID:** {validation.validation_id}")
+            lines.append(
+                f"**Overall Success:** {'✅ PASSED' if validation.overall_success else '❌ FAILED'}"
+            )
+            lines.append(
+                f"**Timestamp:** {validation.timestamp.strftime('%Y-%m-%d %H:%M:%S')}"
+            )
+            if getattr(validation, "notes", None):
+                lines.append(f"**Notes:** {validation.notes}")
+            lines.append("")
+        validation_section = "\n".join(lines)
+
+    lessons_section = ""
+    if lessons:
+        lines = ["## Lessons Learned"]
+        for lesson in lessons:
+            lines.append(f"**Category:** {lesson.category}")
+            lines.append(f"**Description:** {lesson.description}")
+            lines.append(f"**Impact:** {lesson.impact}")
+            if getattr(lesson, "recommendations", None):
+                lines.append("**Recommendations:**")
+                for rec in lesson.recommendations:
+                    lines.append(f"- {rec}")
+            lines.append(f"**Priority:** {lesson.implementation_priority.value}")
+            if getattr(lesson, "assigned_to", None):
+                lines.append(f"**Assigned To:** {lesson.assigned_to}")
+            lines.append("")
+        lessons_section = "\n".join(lines)
+
+    return template.substitute(
+        emergency_id=emergency_id,
+        generated_at=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        events_section=events_section,
+        timeline_section=timeline_section,
+        validation_section=validation_section,
+        lessons_section=lessons_section,
+    )

--- a/src/core/emergency/docs/templates/report.md
+++ b/src/core/emergency/docs/templates/report.md
@@ -1,0 +1,9 @@
+# Emergency Report - ${emergency_id}
+Generated: ${generated_at}
+
+## Emergency Events Summary
+${events_section}
+
+${timeline_section}
+${validation_section}
+${lessons_section}


### PR DESCRIPTION
## Summary
- separate emergency documentation generation and distribution into dedicated modules
- load report content from markdown templates
- orchestrator delegates document creation and persistence

## Testing
- `pre-commit run --files src/core/emergency/docs/__init__.py src/core/emergency/docs/templates/report.md src/core/emergency/docs/generator.py src/core/emergency/docs/distribution.py src/core/emergency/emergency_documentation.py` *(failed: ModuleNotFoundError: No module named 'src')*
- `pytest` *(failed: ModuleNotFoundError: multiple tests during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a581d0988329aac55aa7aad8b4e1