### PR TITLE
refactor: modularize emergency protocols

### DIFF
--- a/src/core/emergency/alerts.py
+++ b/src/core/emergency/alerts.py
@@ -1,0 +1,20 @@
+"""Alerting and notification utilities for emergency protocols."""
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def send_alert(alert_type: str, details: Dict[str, Any]) -> Dict[str, Any]:
+    """Send an alert or notification.
+
+    This function centralizes alerting logic so that protocol execution and
+    escalation procedures can trigger notifications without embedding the
+    implementation details.
+    """
+    logger.info(f"Alert triggered: {alert_type}", extra={"details": details})
+    return {"status": "sent", "alert_type": alert_type, **details}
+
+
+__all__ = ["send_alert"]

--- a/src/core/emergency/protocol_manager.py
+++ b/src/core/emergency/protocol_manager.py
@@ -4,7 +4,7 @@ Emergency Protocol Manager - Component of Emergency Response System
 =================================================================
 
 Responsible for managing emergency protocols, their activation conditions,
-and response procedures. Extracted from EmergencyResponseSystem to follow 
+and response procedures. Extracted from EmergencyResponseSystem to follow
 Single Responsibility Principle.
 
 Author: Agent-7 (Class Hierarchy Refactoring)
@@ -13,106 +13,27 @@ License: MIT
 """
 
 import logging
-import time
-from datetime import datetime
-from typing import Dict, List, Optional, Any, Callable
-from dataclasses import dataclass, field
-from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
 
 from ..base_manager import BaseManager
-
+from .protocols import (
+    EmergencyProtocol,
+    EscalationProcedure,
+    ProtocolExecution,
+    ProtocolPriority,
+    ProtocolStatus,
+    RecoveryProcedure,
+    ResponseAction,
+)
+from .state_machine import ProtocolStateMachine
 
 logger = logging.getLogger(__name__)
-
-
-class ProtocolStatus(Enum):
-    """Protocol activation status"""
-    INACTIVE = "inactive"
-    ACTIVE = "active"
-    ESCALATED = "escalated"
-    COMPLETED = "completed"
-    FAILED = "failed"
-
-
-class ProtocolPriority(Enum):
-    """Protocol priority levels"""
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
-
-
-@dataclass
-class ResponseAction:
-    """Emergency response action definition"""
-    action: str
-    description: str
-    priority: ProtocolPriority
-    timeout: int  # seconds
-    required: bool = True
-    completed: bool = False
-    completion_time: Optional[datetime] = None
-    result: Optional[Dict[str, Any]] = None
-
-
-@dataclass
-class EscalationProcedure:
-    """Protocol escalation procedure"""
-    level: ProtocolPriority
-    action: str
-    timeout: int  # seconds
-    description: str
-    triggered: bool = False
-    trigger_time: Optional[datetime] = None
-
-
-@dataclass
-class RecoveryProcedure:
-    """Protocol recovery procedure"""
-    action: str
-    description: str
-    validation_criteria: List[str]
-    required: bool = True
-    completed: bool = False
-    completion_time: Optional[datetime] = None
-    validation_results: Optional[Dict[str, bool]] = None
-
-
-@dataclass
-class EmergencyProtocol:
-    """Emergency response protocol definition"""
-    name: str
-    description: str
-    activation_conditions: List[str]
-    response_actions: List[ResponseAction]
-    escalation_procedures: List[EscalationProcedure]
-    recovery_procedures: List[RecoveryProcedure]
-    validation_criteria: List[str]
-    documentation_requirements: List[str]
-    status: ProtocolStatus = ProtocolStatus.INACTIVE
-    activated_at: Optional[datetime] = None
-    completed_at: Optional[datetime] = None
-    activation_source: Optional[str] = None
-
-
-@dataclass
-class ProtocolExecution:
-    """Protocol execution tracking"""
-    protocol_name: str
-    start_time: datetime
-    end_time: Optional[datetime] = None
-    status: ProtocolStatus = ProtocolStatus.ACTIVE
-    actions_completed: int = 0
-    total_actions: int = 0
-    escalation_level: ProtocolPriority = ProtocolPriority.LOW
-    errors: List[str] = field(default_factory=list)
-    results: Dict[str, Any] = field(default_factory=dict)
 
 
 class ProtocolManager(BaseManager):
     """
     Emergency Protocol Manager - Single responsibility: Protocol management and execution
-    
+
     This component is responsible for:
     - Managing emergency protocol definitions
     - Evaluating activation conditions
@@ -128,41 +49,47 @@ class ProtocolManager(BaseManager):
             config_path=config_path,
             enable_metrics=True,
             enable_events=True,
-            enable_persistence=True
+            enable_persistence=True,
         )
-        
+
         # Protocol storage
         self.emergency_protocols: Dict[str, EmergencyProtocol] = {}
         self.protocol_handlers: Dict[str, Callable] = {}
-        
+
         # Execution tracking
         self.active_executions: Dict[str, ProtocolExecution] = {}
         self.execution_history: List[ProtocolExecution] = []
-        
+
         # Protocol state
         self.protocols_loaded = False
         self.default_protocols_configured = False
-        
+
+        # State machine
+        self.state_machine = ProtocolStateMachine(self)
+
         # Load configuration and setup
         self._load_protocol_config()
         self._setup_default_protocols()
-        
+
         self.logger.info("✅ Emergency Protocol Manager initialized successfully")
 
+    # ------------------------------------------------------------------
+    # Configuration and setup
+    # ------------------------------------------------------------------
     def _load_protocol_config(self):
         """Load protocol manager configuration"""
         try:
             config = self.get_config()
-            
+
             # Load custom protocols if available
-            if 'custom_protocols' in config:
-                for protocol_data in config['custom_protocols']:
+            if "custom_protocols" in config:
+                for protocol_data in config["custom_protocols"]:
                     protocol = self._create_protocol_from_data(protocol_data)
                     if protocol:
                         self.emergency_protocols[protocol.name] = protocol
-            
+
             self.protocols_loaded = True
-            
+
         except Exception as e:
             self.logger.error(f"Failed to load protocol config: {e}")
 
@@ -177,74 +104,74 @@ class ProtocolManager(BaseManager):
                     "Workflow stall detected in any agent mission",
                     "Sprint acceleration momentum loss",
                     "Contract claiming system failures",
-                    "Agent coordination breakdowns"
+                    "Agent coordination breakdowns",
                 ],
                 response_actions=[
                     ResponseAction(
                         action="generate_emergency_contracts",
                         description="Generate 10+ emergency contracts worth 4,375+ points",
                         priority=ProtocolPriority.CRITICAL,
-                        timeout=300  # 5 minutes
+                        timeout=300,
                     ),
                     ResponseAction(
                         action="activate_agent_mobilization",
                         description="Send emergency directives to all agents",
                         priority=ProtocolPriority.HIGH,
-                        timeout=60  # 1 minute
+                        timeout=60,
                     ),
                     ResponseAction(
                         action="validate_system_health",
                         description="Perform comprehensive system health audit",
                         priority=ProtocolPriority.HIGH,
-                        timeout=600  # 10 minutes
-                    )
+                        timeout=600,
+                    ),
                 ],
                 escalation_procedures=[
                     EscalationProcedure(
                         level=ProtocolPriority.HIGH,
                         action="notify_captain_coordinator",
                         timeout=120,
-                        description="Notify captain coordinator of critical situation"
+                        description="Notify captain coordinator of critical situation",
                     ),
                     EscalationProcedure(
                         level=ProtocolPriority.CRITICAL,
                         action="activate_code_black_protocol",
                         timeout=60,
-                        description="Activate highest level emergency protocol"
-                    )
+                        description="Activate highest level emergency protocol",
+                    ),
                 ],
                 recovery_procedures=[
                     RecoveryProcedure(
                         action="restore_contract_system",
                         description="Fix contract claiming system and synchronization",
-                        validation_criteria=["Contract availability > 40"]
+                        validation_criteria=["Contract availability > 40"],
                     ),
                     RecoveryProcedure(
                         action="resolve_task_conflicts",
                         description="Resolve task assignment conflicts",
-                        validation_criteria=["No task assignment conflicts"]
+                        validation_criteria=["No task assignment conflicts"],
                     ),
                     RecoveryProcedure(
                         action="optimize_agent_priority",
                         description="Optimize agent priority system",
-                        validation_criteria=["Agent priority system aligned"]
-                    )
+                        validation_criteria=["Agent priority system aligned"],
+                    ),
                 ],
                 validation_criteria=[
                     "All agents can claim emergency contracts",
                     "Perpetual motion system resumes operation",
                     "Contract system corruption resolved",
                     "System returns to 40+ available contracts",
-                    "Workflow momentum restored"
+                    "Workflow momentum restored",
                 ],
                 documentation_requirements=[
                     "Emergency event log",
                     "Response action timeline",
                     "Recovery validation results",
-                    "Lessons learned documentation"
-                ]
+                    "Lessons learned documentation",
+                ],
             )
-            
+
             # Crisis Management Protocol
             crisis_management = EmergencyProtocol(
                 name="Crisis Management",
@@ -253,132 +180,131 @@ class ProtocolManager(BaseManager):
                     "Contract completion rate < 40%",
                     "Agent idle time > 15 minutes",
                     "Workflow synchronization errors",
-                    "Task assignment conflicts"
+                    "Task assignment conflicts",
                 ],
                 response_actions=[
                     ResponseAction(
                         action="deploy_emergency_contracts",
                         description="Generate and deploy emergency contracts within 5 minutes",
                         priority=ProtocolPriority.CRITICAL,
-                        timeout=300
+                        timeout=300,
                     ),
                     ResponseAction(
                         action="implement_bulk_messaging",
                         description="Send system-wide emergency announcements",
                         priority=ProtocolPriority.HIGH,
-                        timeout=120
+                        timeout=120,
                     ),
                     ResponseAction(
                         action="activate_health_monitoring",
                         description="Enable continuous system health assessment",
                         priority=ProtocolPriority.HIGH,
-                        timeout=60
-                    )
+                        timeout=60,
+                    ),
                 ],
                 escalation_procedures=[
                     EscalationProcedure(
                         level=ProtocolPriority.MEDIUM,
                         action="increase_monitoring_frequency",
                         timeout=300,
-                        description="Increase monitoring frequency for crisis situation"
+                        description="Increase monitoring frequency for crisis situation",
                     ),
                     EscalationProcedure(
                         level=ProtocolPriority.HIGH,
                         action="activate_emergency_coordination",
                         timeout=180,
-                        description="Activate emergency coordination protocols"
-                    )
+                        description="Activate emergency coordination protocols",
+                    ),
                 ],
                 recovery_procedures=[
                     RecoveryProcedure(
                         action="restore_workflow_momentum",
                         description="Restore workflow momentum and agent engagement",
-                        validation_criteria=["Agent engagement > 90%"]
+                        validation_criteria=["Agent engagement > 90%"],
                     ),
                     RecoveryProcedure(
                         action="validate_system_synchronization",
                         description="Ensure system component synchronization",
-                        validation_criteria=["All systems synchronized"]
-                    )
+                        validation_criteria=["All systems synchronized"],
+                    ),
                 ],
                 validation_criteria=[
                     "Workflow momentum restored",
                     "Agent engagement levels normalized",
                     "System synchronization validated",
-                    "Performance metrics within thresholds"
+                    "Performance metrics within thresholds",
                 ],
                 documentation_requirements=[
                     "Crisis timeline documentation",
                     "Response effectiveness analysis",
                     "System recovery validation",
-                    "Prevention strategy documentation"
-                ]
+                    "Prevention strategy documentation",
+                ],
             )
-            
+
             # Add default protocols
             self.emergency_protocols["workflow_restoration"] = workflow_restoration
             self.emergency_protocols["crisis_management"] = crisis_management
-            
+
             self.default_protocols_configured = True
             self.logger.info("✅ Default emergency protocols configured")
-            
+
         except Exception as e:
             self.logger.error(f"Failed to setup default protocols: {e}")
 
     def _create_protocol_from_data(self, protocol_data: Dict[str, Any]) -> Optional[EmergencyProtocol]:
         """Create EmergencyProtocol from configuration data"""
         try:
-            # Convert response actions
             response_actions = []
-            for action_data in protocol_data.get('response_actions', []):
+            for action_data in protocol_data.get("response_actions", []):
                 action = ResponseAction(
-                    action=action_data['action'],
-                    description=action_data['description'],
-                    priority=ProtocolPriority(action_data['priority']),
-                    timeout=action_data['timeout'],
-                    required=action_data.get('required', True)
+                    action=action_data["action"],
+                    description=action_data["description"],
+                    priority=ProtocolPriority(action_data["priority"]),
+                    timeout=action_data["timeout"],
+                    required=action_data.get("required", True),
                 )
                 response_actions.append(action)
-            
-            # Convert escalation procedures
+
             escalation_procedures = []
-            for escalation_data in protocol_data.get('escalation_procedures', []):
+            for escalation_data in protocol_data.get("escalation_procedures", []):
                 escalation = EscalationProcedure(
-                    level=ProtocolPriority(escalation_data['level']),
-                    action=escalation_data['action'],
-                    timeout=escalation_data['timeout'],
-                    description=escalation_data.get('description', '')
+                    level=ProtocolPriority(escalation_data["level"]),
+                    action=escalation_data["action"],
+                    timeout=escalation_data["timeout"],
+                    description=escalation_data.get("description", ""),
                 )
                 escalation_procedures.append(escalation)
-            
-            # Convert recovery procedures
+
             recovery_procedures = []
-            for recovery_data in protocol_data.get('recovery_procedures', []):
+            for recovery_data in protocol_data.get("recovery_procedures", []):
                 recovery = RecoveryProcedure(
-                    action=recovery_data['action'],
-                    description=recovery_data['description'],
-                    validation_criteria=recovery_data['validation_criteria']
+                    action=recovery_data["action"],
+                    description=recovery_data["description"],
+                    validation_criteria=recovery_data["validation_criteria"],
                 )
                 recovery_procedures.append(recovery)
-            
-            # Create protocol
+
             protocol = EmergencyProtocol(
-                name=protocol_data['name'],
-                description=protocol_data['description'],
-                activation_conditions=protocol_data['activation_conditions'],
+                name=protocol_data["name"],
+                description=protocol_data["description"],
+                activation_conditions=protocol_data["activation_conditions"],
                 response_actions=response_actions,
                 escalation_procedures=escalation_procedures,
                 recovery_procedures=recovery_procedures,
-                validation_criteria=protocol_data['validation_criteria'],
-                documentation_requirements=protocol_data['documentation_requirements']
+                validation_criteria=protocol_data["validation_criteria"],
+                documentation_requirements=protocol_data["documentation_requirements"],
             )
-            
+
             return protocol
-            
+
         except Exception as e:
             self.logger.error(f"Failed to create protocol from data: {e}")
             return None
 
+    # ------------------------------------------------------------------
+    # Protocol management API
+    # ------------------------------------------------------------------
     def add_protocol(self, protocol: EmergencyProtocol):
         """Add a new emergency protocol"""
         self.emergency_protocols[protocol.name] = protocol
@@ -398,184 +324,28 @@ class ProtocolManager(BaseManager):
         """List all available protocol names"""
         return list(self.emergency_protocols.keys())
 
-    def evaluate_activation_conditions(self, protocol_name: str, 
-                                    system_state: Dict[str, Any]) -> bool:
-        """Evaluate if a protocol's activation conditions are met"""
-        try:
-            protocol = self.get_protocol(protocol_name)
-            if not protocol:
-                return False
-            
-            # Check each activation condition
-            for condition in protocol.activation_conditions:
-                if not self._evaluate_condition(condition, system_state):
-                    return False
-            
-            return True
-            
-        except Exception as e:
-            self.logger.error(f"Failed to evaluate activation conditions for {protocol_name}: {e}")
-            return False
-
-    def _evaluate_condition(self, condition: str, system_state: Dict[str, Any]) -> bool:
-        """Evaluate a single activation condition"""
-        try:
-            # Simple condition evaluation - can be enhanced with more sophisticated logic
-            if "contract completion rate" in condition:
-                rate = system_state.get('contract_completion_rate', 100)
-                return rate < 40
-            elif "agent idle time" in condition:
-                idle_time = system_state.get('max_agent_idle_time', 0)
-                return idle_time > 900  # 15 minutes
-            elif "workflow stall" in condition:
-                return system_state.get('workflow_stalled', False)
-            elif "contract system down" in condition:
-                return system_state.get('contract_system_available', True) == False
-            else:
-                # Default to true for unknown conditions
-                return True
-                
-        except Exception as e:
-            self.logger.error(f"Failed to evaluate condition '{condition}': {e}")
-            return False
+    # Delegated state machine operations ---------------------------------
+    def evaluate_activation_conditions(self, protocol_name: str, system_state: Dict[str, Any]) -> bool:
+        return self.state_machine.evaluate_activation_conditions(protocol_name, system_state)
 
     def activate_protocol(self, protocol_name: str, source: str = "system") -> bool:
-        """Activate an emergency protocol"""
-        try:
-            protocol = self.get_protocol(protocol_name)
-            if not protocol:
-                self.logger.error(f"Protocol not found: {protocol_name}")
-                return False
-            
-            if protocol.status != ProtocolStatus.INACTIVE:
-                self.logger.warning(f"Protocol {protocol_name} is already {protocol.status.value}")
-                return False
-            
-            # Update protocol status
-            protocol.status = ProtocolStatus.ACTIVE
-            protocol.activated_at = datetime.now()
-            protocol.activation_source = source
-            
-            # Create execution tracking
-            execution = ProtocolExecution(
-                protocol_name=protocol_name,
-                start_time=datetime.now(),
-                total_actions=len(protocol.response_actions)
-            )
-            
-            self.active_executions[protocol_name] = execution
-            
-            # Record event
-            self.record_event("protocol_activated", {
-                "protocol_name": protocol_name,
-                "source": source,
-                "timestamp": datetime.now().isoformat()
-            })
-            
-            self.logger.info(f"🚨 Emergency protocol activated: {protocol_name}")
-            return True
-            
-        except Exception as e:
-            self.logger.error(f"Failed to activate protocol {protocol_name}: {e}")
-            return False
+        return self.state_machine.activate_protocol(protocol_name, source)
 
     def execute_protocol_actions(self, protocol_name: str) -> Dict[str, Any]:
-        """Execute all actions for an active protocol"""
-        try:
-            protocol = self.get_protocol(protocol_name)
-            execution = self.active_executions.get(protocol_name)
-            
-            if not protocol or not execution:
-                return {"error": "Protocol not found or not active"}
-            
-            if protocol.status != ProtocolStatus.ACTIVE:
-                return {"error": f"Protocol is {protocol.status.value}"}
-            
-            results = {}
-            
-            # Execute response actions
-            for action in protocol.response_actions:
-                if not action.completed:
-                    result = self._execute_action(action, protocol_name)
-                    action.completed = True
-                    action.completion_time = datetime.now()
-                    action.result = result
-                    
-                    results[action.action] = result
-                    execution.actions_completed += 1
-                    
-                    # Check for timeout
-                    if action.timeout > 0:
-                        elapsed = (datetime.now() - execution.start_time).total_seconds()
-                        if elapsed > action.timeout:
-                            self.logger.warning(f"Action {action.action} timed out after {action.timeout}s")
-            
-            # Check if all actions completed
-            if execution.actions_completed >= execution.total_actions:
-                protocol.status = ProtocolStatus.COMPLETED
-                protocol.completed_at = datetime.now()
-                execution.status = ProtocolStatus.COMPLETED
-                execution.end_time = datetime.now()
-                
-                # Move to history
-                self.execution_history.append(execution)
-                del self.active_executions[protocol_name]
-                
-                self.logger.info(f"✅ Protocol {protocol_name} completed successfully")
-            
-            return results
-            
-        except Exception as e:
-            self.logger.error(f"Failed to execute protocol actions for {protocol_name}: {e}")
-            return {"error": str(e)}
+        return self.state_machine.execute_protocol_actions(protocol_name)
 
-    def _execute_action(self, action: ResponseAction, protocol_name: str) -> Dict[str, Any]:
-        """Execute a single protocol action"""
-        try:
-            # This would integrate with actual action execution systems
-            # For now, simulate action execution
-            
-            if action.action == "generate_emergency_contracts":
-                return {
-                    "status": "success",
-                    "contracts_generated": 15,
-                    "total_points": 5000,
-                    "execution_time": 2.5
-                }
-            elif action.action == "activate_agent_mobilization":
-                return {
-                    "status": "success",
-                    "agents_notified": 8,
-                    "response_rate": 100,
-                    "execution_time": 0.8
-                }
-            elif action.action == "validate_system_health":
-                return {
-                    "status": "success",
-                    "health_score": 0.85,
-                    "issues_found": 2,
-                    "execution_time": 8.2
-                }
-            else:
-                return {
-                    "status": "simulated",
-                    "action": action.action,
-                    "execution_time": 1.0
-                }
-                
-        except Exception as e:
-            self.logger.error(f"Failed to execute action {action.action}: {e}")
-            return {"status": "error", "error": str(e)}
-
+    # ------------------------------------------------------------------
+    # Status and health reporting
+    # ------------------------------------------------------------------
     def get_protocol_status(self, protocol_name: str) -> Optional[Dict[str, Any]]:
         """Get status of a specific protocol"""
         try:
             protocol = self.get_protocol(protocol_name)
             execution = self.active_executions.get(protocol_name)
-            
+
             if not protocol:
                 return None
-            
+
             return {
                 "name": protocol.name,
                 "status": protocol.status.value,
@@ -586,20 +356,19 @@ class ProtocolManager(BaseManager):
                     "actions_completed": execution.actions_completed if execution else 0,
                     "total_actions": execution.total_actions if execution else len(protocol.response_actions),
                     "start_time": execution.start_time.isoformat() if execution else None,
-                    "status": execution.status.value if execution else "not_started"
-                } if execution else None
+                    "status": execution.status.value if execution else "not_started",
+                }
+                if execution
+                else None,
             }
-            
+
         except Exception as e:
             self.logger.error(f"Failed to get protocol status for {protocol_name}: {e}")
             return None
 
     def get_all_protocol_statuses(self) -> Dict[str, Dict[str, Any]]:
         """Get status of all protocols"""
-        return {
-            name: self.get_protocol_status(name)
-            for name in self.list_protocols()
-        }
+        return {name: self.get_protocol_status(name) for name in self.list_protocols()}
 
     def get_execution_history(self) -> List[Dict[str, Any]]:
         """Get protocol execution history"""
@@ -613,7 +382,7 @@ class ProtocolManager(BaseManager):
                 "total_actions": e.total_actions,
                 "escalation_level": e.escalation_level.value,
                 "errors": e.errors,
-                "results": e.results
+                "results": e.results,
             }
             for e in self.execution_history
         ]
@@ -628,18 +397,19 @@ class ProtocolManager(BaseManager):
                 "total_protocols": len(self.emergency_protocols),
                 "active_executions": len(self.active_executions),
                 "total_executions": len(self.execution_history),
-                "protocols": list(self.emergency_protocols.keys())
+                "protocols": list(self.emergency_protocols.keys()),
             }
-            
         except Exception as e:
-            return {
-                "is_healthy": False,
-                "error": str(e)
-            }
+            return {"is_healthy": False, "error": str(e)}
 
 
-# Export the main classes
 __all__ = [
-    "ProtocolManager", "EmergencyProtocol", "ProtocolStatus", "ProtocolPriority",
-    "ResponseAction", "EscalationProcedure", "RecoveryProcedure", "ProtocolExecution"
+    "ProtocolManager",
+    "EmergencyProtocol",
+    "ProtocolStatus",
+    "ProtocolPriority",
+    "ResponseAction",
+    "EscalationProcedure",
+    "RecoveryProcedure",
+    "ProtocolExecution",
 ]

--- a/src/core/emergency/protocols.py
+++ b/src/core/emergency/protocols.py
@@ -1,0 +1,101 @@
+"""Protocol definitions for emergency response system."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class ProtocolStatus(Enum):
+    """Protocol activation status."""
+    INACTIVE = "inactive"
+    ACTIVE = "active"
+    ESCALATED = "escalated"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ProtocolPriority(Enum):
+    """Protocol priority levels."""
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+@dataclass
+class ResponseAction:
+    """Emergency response action definition."""
+    action: str
+    description: str
+    priority: ProtocolPriority
+    timeout: int  # seconds
+    required: bool = True
+    completed: bool = False
+    completion_time: Optional[datetime] = None
+    result: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class EscalationProcedure:
+    """Protocol escalation procedure."""
+    level: ProtocolPriority
+    action: str
+    timeout: int  # seconds
+    description: str
+    triggered: bool = False
+    trigger_time: Optional[datetime] = None
+
+
+@dataclass
+class RecoveryProcedure:
+    """Protocol recovery procedure."""
+    action: str
+    description: str
+    validation_criteria: List[str]
+    required: bool = True
+    completed: bool = False
+    completion_time: Optional[datetime] = None
+    validation_results: Optional[Dict[str, bool]] = None
+
+
+@dataclass
+class EmergencyProtocol:
+    """Emergency response protocol definition."""
+    name: str
+    description: str
+    activation_conditions: List[str]
+    response_actions: List[ResponseAction]
+    escalation_procedures: List[EscalationProcedure]
+    recovery_procedures: List[RecoveryProcedure]
+    validation_criteria: List[str]
+    documentation_requirements: List[str]
+    status: ProtocolStatus = ProtocolStatus.INACTIVE
+    activated_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    activation_source: Optional[str] = None
+
+
+@dataclass
+class ProtocolExecution:
+    """Protocol execution tracking."""
+    protocol_name: str
+    start_time: datetime
+    end_time: Optional[datetime] = None
+    status: ProtocolStatus = ProtocolStatus.ACTIVE
+    actions_completed: int = 0
+    total_actions: int = 0
+    escalation_level: ProtocolPriority = ProtocolPriority.LOW
+    errors: List[str] = field(default_factory=list)
+    results: Dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = [
+    "ProtocolStatus",
+    "ProtocolPriority",
+    "ResponseAction",
+    "EscalationProcedure",
+    "RecoveryProcedure",
+    "EmergencyProtocol",
+    "ProtocolExecution",
+]

--- a/src/core/emergency/state_machine.py
+++ b/src/core/emergency/state_machine.py
@@ -1,0 +1,141 @@
+"""State transition handlers for emergency protocols."""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict
+
+from .alerts import send_alert
+from .protocols import (
+    EmergencyProtocol,
+    ProtocolExecution,
+    ProtocolPriority,
+    ProtocolStatus,
+    ResponseAction,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ProtocolStateMachine:
+    """Handles state transitions for emergency protocols."""
+
+    def __init__(self, manager: "ProtocolManager") -> None:  # pragma: no cover - forward ref
+        self.manager = manager
+
+    # Activation and evaluation -------------------------------------------------
+    def evaluate_activation_conditions(self, protocol_name: str, system_state: Dict[str, Any]) -> bool:
+        """Evaluate if a protocol's activation conditions are met."""
+        protocol = self.manager.get_protocol(protocol_name)
+        if not protocol:
+            return False
+
+        for condition in protocol.activation_conditions:
+            if not self._evaluate_condition(condition, system_state):
+                return False
+        return True
+
+    def _evaluate_condition(self, condition: str, system_state: Dict[str, Any]) -> bool:
+        """Evaluate a single activation condition."""
+        try:
+            if "contract completion rate" in condition:
+                rate = system_state.get("contract_completion_rate", 100)
+                return rate < 40
+            if "agent idle time" in condition:
+                idle_time = system_state.get("max_agent_idle_time", 0)
+                return idle_time > 900  # 15 minutes
+            if "workflow stall" in condition:
+                return system_state.get("workflow_stalled", False)
+            if "contract system down" in condition:
+                return system_state.get("contract_system_available", True) is False
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to evaluate condition %s: %s", condition, exc)
+            return False
+
+    # State transitions ---------------------------------------------------------
+    def activate_protocol(self, protocol_name: str, source: str = "system") -> bool:
+        """Activate an emergency protocol."""
+        protocol = self.manager.get_protocol(protocol_name)
+        if not protocol or protocol.status is not ProtocolStatus.INACTIVE:
+            return False
+
+        protocol.status = ProtocolStatus.ACTIVE
+        protocol.activated_at = datetime.now()
+        protocol.activation_source = source
+
+        execution = ProtocolExecution(
+            protocol_name=protocol_name,
+            start_time=datetime.now(),
+            total_actions=len(protocol.response_actions),
+        )
+        self.manager.active_executions[protocol_name] = execution
+
+        self.manager.record_event(
+            "protocol_activated",
+            {
+                "protocol_name": protocol_name,
+                "source": source,
+                "timestamp": datetime.now().isoformat(),
+            },
+        )
+        logger.info("🚨 Emergency protocol activated: %s", protocol_name)
+        return True
+
+    def execute_protocol_actions(self, protocol_name: str) -> Dict[str, Any]:
+        """Execute all actions for an active protocol."""
+        protocol = self.manager.get_protocol(protocol_name)
+        execution = self.manager.active_executions.get(protocol_name)
+        if not protocol or not execution or protocol.status is not ProtocolStatus.ACTIVE:
+            return {"error": "Protocol not active"}
+
+        results: Dict[str, Any] = {}
+        for action in protocol.response_actions:
+            if not action.completed:
+                result = self._execute_action(action)
+                action.completed = True
+                action.completion_time = datetime.now()
+                action.result = result
+                results[action.action] = result
+                execution.actions_completed += 1
+
+                if action.timeout > 0:
+                    elapsed = (datetime.now() - execution.start_time).total_seconds()
+                    if elapsed > action.timeout:
+                        logger.warning("Action %s timed out after %ss", action.action, action.timeout)
+
+        if execution.actions_completed >= execution.total_actions:
+            protocol.status = ProtocolStatus.COMPLETED
+            protocol.completed_at = datetime.now()
+            execution.status = ProtocolStatus.COMPLETED
+            execution.end_time = datetime.now()
+            self.manager.execution_history.append(execution)
+            del self.manager.active_executions[protocol_name]
+            logger.info("✅ Protocol %s completed successfully", protocol_name)
+        return results
+
+    def _execute_action(self, action: ResponseAction) -> Dict[str, Any]:
+        """Execute a single protocol action."""
+        try:
+            if action.action == "generate_emergency_contracts":
+                return {
+                    "status": "success",
+                    "contracts_generated": 15,
+                    "total_points": 5000,
+                    "execution_time": 2.5,
+                }
+            if action.action in {"activate_agent_mobilization", "notify_captain_coordinator"}:
+                return send_alert(action.action, {"priority": action.priority.value})
+            if action.action == "validate_system_health":
+                return {
+                    "status": "success",
+                    "health_score": 0.85,
+                    "issues_found": 2,
+                    "execution_time": 8.2,
+                }
+            return {"status": "simulated", "action": action.action, "execution_time": 1.0}
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to execute action %s: %s", action.action, exc)
+            return {"status": "error", "error": str(exc)}
+
+
+__all__ = ["ProtocolStateMachine"]


### PR DESCRIPTION
## Summary
- move protocol dataclasses into emergency/protocols.py
- add ProtocolStateMachine and alert utilities for emergency actions
- delegate ProtocolManager state transitions to new state machine

## Testing
- `pytest` *(fails: 133 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a587a8b88329b8528aa3aa4c5648