### PR TITLE
Refactor task system into dedicated modules

### DIFF
--- a/agent_workspaces/meeting/coding_standards_compliance_report.md
+++ b/agent_workspaces/meeting/coding_standards_compliance_report.md
@@ -58,7 +58,7 @@
 - ..\..\src\core\health\unified_health_manager.py: File exceeds standard limit: 492 lines (limit: 400)
 - ..\..\src\core\health\notifications\health_notification_manager.py: File exceeds standard limit: 433 lines (limit: 400)
 - ..\..\src\core\health\recovery\health_recovery_manager.py: File exceeds standard limit: 425 lines (limit: 400)
-- ..\..\src\core\tasks\execution.py: File exceeds standard limit: 482 lines (limit: 400)
+- ..\..\src\core\tasks\executor.py: File exceeds standard limit: 482 lines (limit: 400)
 - ..\..\src\core\managers\config_manager.py: File exceeds standard limit: 414 lines (limit: 400)
 - ..\..\src\core\managers\data_manager.py: File exceeds standard limit: 667 lines (limit: 400)
 - ..\..\src\core\managers\repository_system_manager.py: File exceeds standard limit: 610 lines (limit: 400)
@@ -345,7 +345,7 @@
 - ..\..\src\security\db_utils.py: File contains procedural code without class structure
 - ..\..\src\services_v2\auth\auth_integration_tester_core.py: File contains procedural code without class structure
 - ..\..\src\services_v2\auth\auth_integration_tester_validation.py: File contains procedural code without class structure
-- ..\..\src\services_v2\auth\auth_integration_test_execution.py: File contains procedural code without class structure
+- ..\..\src\services_v2\auth\auth_integration_test_executor.py: File contains procedural code without class structure
 - ..\..\src\services_v2\auth\auth_integration_test_validation.py: File contains procedural code without class structure
 - ..\..\src\services_v2\auth\run_integration_tests.py: File contains procedural code without class structure
 - ..\..\src\services_v2\auth\auth_performance_config.py: File contains procedural code without class structure
@@ -647,7 +647,7 @@
 - ..\..\src\core\tasks\monitoring.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\tasks\recovery.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\tasks\__init__.py: Missing CLI interface for testing and agent usability
-- ..\..\src\core\tasks\execution.py: Missing CLI interface for testing and agent usability
+- ..\..\src\core\tasks\executor.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\tasks\logger.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\tasks\scheduling.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\managers\config_manager.py: Missing CLI interface for testing and agent usability
@@ -727,14 +727,14 @@
 - ..\..\src\core\managers\testing_framework_manager\performance_analysis.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\managers\testing_framework_manager\result_aggregation.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\managers\testing_framework_manager\strategy_management.py: Missing CLI interface for testing and agent usability
-- ..\..\src\core\managers\testing_framework_manager\test_execution.py: Missing CLI interface for testing and agent usability
+- ..\..\src\core\managers\testing_framework_manager\test_executor.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\managers\testing_framework_manager\test_orchestration.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\managers\testing_framework_manager\test_utilities.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\testing\test_categories.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\testing\output_formatter.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\testing\__init__.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\testing\test_discovery.py: Missing CLI interface for testing and agent usability
-- ..\..\src\core\testing\test_execution.py: Missing CLI interface for testing and agent usability
+- ..\..\src\core\testing\test_executor.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\testing\test_reporting.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\testing\testing_orchestrator.py: Missing CLI interface for testing and agent usability
 - ..\..\src\core\testing\testing_utils.py: Missing CLI interface for testing and agent usability
@@ -1220,7 +1220,7 @@
 - ..\..\src\services_v2\auth\auth_integration_tester_config.py: Missing CLI interface for testing and agent usability
 - ..\..\src\services_v2\auth\auth_integration_tester_core.py: Missing CLI interface for testing and agent usability
 - ..\..\src\services_v2\auth\auth_integration_tester_validation.py: Missing CLI interface for testing and agent usability
-- ..\..\src\services_v2\auth\auth_integration_test_execution.py: Missing CLI interface for testing and agent usability
+- ..\..\src\services_v2\auth\auth_integration_test_executor.py: Missing CLI interface for testing and agent usability
 - ..\..\src\services_v2\auth\auth_integration_test_validation.py: Missing CLI interface for testing and agent usability
 - ..\..\src\services_v2\auth\auth_performance_config.py: Missing CLI interface for testing and agent usability
 - ..\..\src\services_v2\auth\auth_integration_test_setup.py: Missing CLI interface for testing and agent usability
@@ -1715,7 +1715,7 @@
 - ..\..\src\core\tasks\monitoring.py: Missing smoke test file: test_monitoring.py
 - ..\..\src\core\tasks\recovery.py: Missing smoke test file: test_recovery.py
 - ..\..\src\core\tasks\__init__.py: Missing smoke test file: test___init__.py
-- ..\..\src\core\tasks\execution.py: Missing smoke test file: test_execution.py
+- ..\..\src\core\tasks\executor.py: Missing smoke test file: test_executor.py
 - ..\..\src\core\tasks\logger.py: Missing smoke test file: test_logger.py
 - ..\..\src\core\tasks\scheduling.py: Missing smoke test file: test_scheduling.py
 - ..\..\src\core\managers\config_manager.py: Missing smoke test file: test_config_manager.py
@@ -1796,7 +1796,7 @@
 - ..\..\src\core\managers\testing_framework_manager\performance_analysis.py: Missing smoke test file: test_performance_analysis.py
 - ..\..\src\core\managers\testing_framework_manager\result_aggregation.py: Missing smoke test file: test_result_aggregation.py
 - ..\..\src\core\managers\testing_framework_manager\strategy_management.py: Missing smoke test file: test_strategy_management.py
-- ..\..\src\core\managers\testing_framework_manager\test_execution.py: Missing smoke test file: test_test_execution.py
+- ..\..\src\core\managers\testing_framework_manager\test_executor.py: Missing smoke test file: test_test_executor.py
 - ..\..\src\core\managers\testing_framework_manager\test_orchestration.py: Missing smoke test file: test_test_orchestration.py
 - ..\..\src\core\managers\testing_framework_manager\test_utilities.py: Missing smoke test file: test_test_utilities.py
 - ..\..\src\core\testing\testing_cli.py: Missing smoke test file: test_testing_cli.py
@@ -1808,7 +1808,7 @@
 - ..\..\src\core\testing\__init__.py: Missing smoke test file: test___init__.py
 - ..\..\src\core\testing\example_tests.py: Missing smoke test file: test_example_tests.py
 - ..\..\src\core\testing\test_discovery.py: Missing smoke test file: test_test_discovery.py
-- ..\..\src\core\testing\test_execution.py: Missing smoke test file: test_test_execution.py
+- ..\..\src\core\testing\test_executor.py: Missing smoke test file: test_test_executor.py
 - ..\..\src\core\testing\test_reporting.py: Missing smoke test file: test_test_reporting.py
 - ..\..\src\core\testing\testing_orchestrator.py: Missing smoke test file: test_testing_orchestrator.py
 - ..\..\src\core\testing\testing_utils.py: Missing smoke test file: test_testing_utils.py
@@ -1986,11 +1986,11 @@
 - ..\..\src\core\refactoring\workflow_integration_manager.py: Missing smoke test file: test_workflow_integration_manager.py
 - ..\..\src\core\refactoring\automated_refactoring_workflows\__init__.py: Missing smoke test file: test___init__.py
 - ..\..\src\core\refactoring\automated_refactoring_workflows\common.py: Missing smoke test file: test_common.py
-- ..\..\src\core\refactoring\automated_refactoring_workflows\execution.py: Missing smoke test file: test_execution.py
+- ..\..\src\core\refactoring\automated_refactoring_workflows\execution.py: Missing smoke test file: test_executor.py
 - ..\..\src\core\refactoring\automated_refactoring_workflows\postprocess.py: Missing smoke test file: test_postprocess.py
 - ..\..\src\core\refactoring\automated_refactoring_workflows\setup.py: Missing smoke test file: test_setup.py
 - ..\..\src\core\refactoring\automated_workflow_orchestrator\__init__.py: Missing smoke test file: test___init__.py
-- ..\..\src\core\refactoring\automated_workflow_orchestrator\execution.py: Missing smoke test file: test_execution.py
+- ..\..\src\core\refactoring\automated_workflow_orchestrator\execution.py: Missing smoke test file: test_executor.py
 - ..\..\src\core\refactoring\automated_workflow_orchestrator\monitoring.py: Missing smoke test file: test_monitoring.py
 - ..\..\src\core\refactoring\automated_workflow_orchestrator\planning.py: Missing smoke test file: test_planning.py
 - ..\..\src\core\refactoring\automated_workflow_orchestrator\settings.py: Missing smoke test file: test_settings.py
@@ -2274,7 +2274,7 @@
 - ..\..\src\services\financial\trading_intelligence\analysis.py: Missing smoke test file: test_analysis.py
 - ..\..\src\services\financial\trading_intelligence\constants.py: Missing smoke test file: test_constants.py
 - ..\..\src\services\financial\trading_intelligence\data_processing.py: Missing smoke test file: test_data_processing.py
-- ..\..\src\services\financial\trading_intelligence\execution.py: Missing smoke test file: test_execution.py
+- ..\..\src\services\financial\trading_intelligence\execution.py: Missing smoke test file: test_executor.py
 - ..\..\src\services\financial\trading_intelligence\reporting.py: Missing smoke test file: test_reporting.py
 - ..\..\src\services\financial\trading_intelligence\service.py: Missing smoke test file: test_service.py
 - ..\..\src\services\financial\trading_intelligence\strategy_analysis.py: Missing smoke test file: test_strategy_analysis.py
@@ -2427,7 +2427,7 @@
 - ..\..\src\services_v2\auth\auth_integration_tester_config.py: Missing smoke test file: test_auth_integration_tester_config.py
 - ..\..\src\services_v2\auth\auth_integration_tester_core.py: Missing smoke test file: test_auth_integration_tester_core.py
 - ..\..\src\services_v2\auth\auth_integration_tester_validation.py: Missing smoke test file: test_auth_integration_tester_validation.py
-- ..\..\src\services_v2\auth\auth_integration_test_execution.py: Missing smoke test file: test_auth_integration_test_execution.py
+- ..\..\src\services_v2\auth\auth_integration_test_executor.py: Missing smoke test file: test_auth_integration_test_executor.py
 - ..\..\src\services_v2\auth\auth_integration_test_validation.py: Missing smoke test file: test_auth_integration_test_validation.py
 - ..\..\src\services_v2\auth\run_integration_tests.py: Missing smoke test file: test_run_integration_tests.py
 - ..\..\src\services_v2\auth\auth_performance_config.py: Missing smoke test file: test_auth_performance_config.py

--- a/contracts/EASY_ISSUES_FOR_REPOSITORY.md
+++ b/contracts/EASY_ISSUES_FOR_REPOSITORY.md
@@ -181,7 +181,7 @@ This document contains **73 easy issues** for the repository to complete Phase 3
 - **MODERATE-023**: `src/services/messaging/unified_pyautogui_messaging.py` (421 lines) - Extract messaging modules
 - **MODERATE-024**: `src/scripts/refactoring_executor.py` (421 lines) - Extract executor modules
 - **MODERATE-025**: `src/core/autonomous_development.py` (419 lines) - Extract development modules
-- **MODERATE-026**: `src/core/tasks/execution.py` (414 lines) - Extract execution modules
+- **MODERATE-026**: `src/core/tasks/executor.py` (414 lines) - Extract execution modules
 - **MODERATE-027**: `src/scripts/setup/setup_web_development_env.py` (413 lines) - Extract setup modules
 - **MODERATE-028**: `src/services/report_generator_service.py` (412 lines) - Extract generator modules
 - **MODERATE-029**: `src/web/frontend/frontend_testing.py` (412 lines) - Extract testing modules

--- a/contracts/phase3h_completion_contracts.json
+++ b/contracts/phase3h_completion_contracts.json
@@ -360,7 +360,7 @@
     },
     {
       "contract_id": "MODERATE-061",
-      "file_path": "src/core/tasks/execution.py",
+      "file_path": "src/core/tasks/executor.py",
       "current_lines": 413,
       "target_lines": 400,
       "reduction_target": "3%",

--- a/data/refactoring_tasks.json
+++ b/data/refactoring_tasks.json
@@ -386,7 +386,7 @@
         "completion_date": "2024-12-19",
         "extraction_modules": [
           "src/core/tasks/scheduling.py",
-          "src/core/tasks/execution.py",
+          "src/core/tasks/executor.py",
           "src/core/tasks/monitoring.py",
           "src/core/tasks/recovery.py"
         ],

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -48,7 +48,7 @@ except ImportError:
     TaskManager = None
 
 try:
-    from .tasks.execution import TaskExecutor
+    from .tasks.executor import TaskExecutor
 except ImportError:
     TaskExecutor = None
 

--- a/src/core/task_manager.py
+++ b/src/core/task_manager.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional, Any
 
 from src.core.base_manager import BaseManager
 from src.core.tasks.scheduling import TaskScheduler, Task, TaskPriority, TaskStatus
-from src.core.tasks.execution import TaskExecutor
+from src.core.tasks.executor import TaskExecutor
 from src.core.tasks.monitoring import TaskMonitor
 from src.core.tasks.recovery import TaskRecovery
 

--- a/src/core/tasks/__init__.py
+++ b/src/core/tasks/__init__.py
@@ -3,22 +3,44 @@ Tasks Package - Agent Cellphone V2
 =================================
 
 This package contains extracted task management modules following SRP:
+- definitions: Task data structures and mock enums
+- executor: Task execution and workflow management
 - scheduling: Task scheduling and prioritization
-- execution: Task execution and workflow management
 - monitoring: Task monitoring and status tracking
 - recovery: Task recovery and error handling
+- results: Task result aggregation utilities
 """
 
+from .definitions import (
+    DevelopmentTask,
+    MockTaskStatus,
+    MockTaskPriority,
+    MockTaskComplexity,
+)
+from .executor import TaskExecutor
 from .scheduling import TaskScheduler
-from .execution import TaskExecutor
 from .monitoring import TaskMonitor
 from .recovery import TaskRecovery
+from .results import (
+    get_task_statistics,
+    get_task_summary,
+    get_priority_distribution,
+    get_complexity_distribution,
+)
 from .logger import get_task_logger
 
 __all__ = [
-    "TaskScheduler",
+    "DevelopmentTask",
+    "MockTaskStatus",
+    "MockTaskPriority",
+    "MockTaskComplexity",
     "TaskExecutor",
+    "TaskScheduler",
     "TaskMonitor",
     "TaskRecovery",
+    "get_task_statistics",
+    "get_task_summary",
+    "get_priority_distribution",
+    "get_complexity_distribution",
     "get_task_logger",
 ]

--- a/src/core/tasks/definitions.py
+++ b/src/core/tasks/definitions.py
@@ -1,0 +1,159 @@
+"""Task data structures and mock enums for development tasks."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+class DevelopmentTask:
+    """Simple task model used by the executor."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.status = MockTaskStatus.AVAILABLE
+        self.claimed_by: Optional[str] = None
+        self.completed_at: Optional[str] = None
+        self.started_at: Optional[str] = None
+        self.metadata: Dict[str, Any] = {}
+
+    def is_available(self) -> bool:
+        return self.status == MockTaskStatus.AVAILABLE
+
+    def is_completed(self) -> bool:
+        return self.status == MockTaskStatus.COMPLETED
+
+    def claim(self, agent_id: str) -> bool:
+        if self.is_available():
+            self.claimed_by = agent_id
+            self.status = MockTaskStatus.CLAIMED
+            return True
+        return False
+
+    def start_work(self) -> bool:
+        if self.status == MockTaskStatus.CLAIMED:
+            self.status = MockTaskStatus.IN_PROGRESS
+            self.started_at = datetime.now().isoformat()
+            return True
+        return False
+
+    def complete(self) -> bool:
+        if self.status in [MockTaskStatus.IN_PROGRESS, MockTaskStatus.CLAIMED]:
+            self.status = MockTaskStatus.COMPLETED
+            self.completed_at = datetime.now().isoformat()
+            return True
+        return False
+
+    def block(self, reason: str) -> bool:
+        if self.status != MockTaskStatus.COMPLETED:
+            self.status = MockTaskStatus.BLOCKED
+            self.metadata.setdefault("block_reason", reason)
+            return True
+        return False
+
+    def unblock(self) -> bool:
+        if self.status == MockTaskStatus.BLOCKED:
+            self.status = MockTaskStatus.CLAIMED
+            return True
+        return False
+
+    def cancel(self) -> bool:
+        if self.status != MockTaskStatus.COMPLETED:
+            self.status = MockTaskStatus.CANCELLED
+            return True
+        return False
+
+    def update_progress(self, percentage: float) -> bool:
+        if hasattr(self, "progress"):
+            self.progress = max(0, min(100, percentage))
+            return True
+        return False
+
+    def get_elapsed_time(self) -> Optional[float]:
+        if self.started_at and self.completed_at:
+            start = datetime.fromisoformat(self.started_at)
+            end = datetime.fromisoformat(self.completed_at)
+            return (end - start).total_seconds() / 3600
+        return None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items()}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DevelopmentTask":
+        return cls(**data)
+
+
+class MockTaskStatus:
+    AVAILABLE = "available"
+    CLAIMED = "claimed"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    BLOCKED = "blocked"
+    CANCELLED = "cancelled"
+
+
+class MockTaskPriorityMeta(type):
+    def __getitem__(cls, key: str):
+        mapping = {
+            "MINIMAL": cls.MINIMAL,
+            "LOW": cls.LOW,
+            "MEDIUM": cls.MEDIUM,
+            "HIGH": cls.HIGH,
+            "CRITICAL": cls.CRITICAL,
+        }
+        if key not in mapping:
+            raise KeyError(f"'{key}' is not a valid MockTaskPriority key")
+        return mapping[key]
+
+    def __iter__(cls):
+        return iter([cls.MINIMAL, cls.LOW, cls.MEDIUM, cls.HIGH, cls.CRITICAL])
+
+
+class MockTaskPriority(metaclass=MockTaskPriorityMeta):
+    MINIMAL = type("MockPriority", (), {"value": 1})()
+    LOW = type("MockPriority", (), {"value": 2})()
+    MEDIUM = type("MockPriority", (), {"value": 3})()
+    HIGH = type("MockPriority", (), {"value": 4})()
+    CRITICAL = type("MockPriority", (), {"value": 5})()
+
+    def __new__(cls, value: int):
+        mapping = {
+            1: cls.MINIMAL,
+            2: cls.LOW,
+            3: cls.MEDIUM,
+            4: cls.HIGH,
+            5: cls.CRITICAL,
+        }
+        if value not in mapping:
+            raise ValueError(f"'{value}' is not a valid MockTaskPriority")
+        return mapping[value]
+
+
+class MockTaskComplexity:
+    LOW = type("MockComplexity", (), {"value": "low"})()
+    MEDIUM = type("MockComplexity", (), {"value": "medium"})()
+    HIGH = type("MockComplexity", (), {"value": "high"})()
+
+    def __new__(cls, value: str):
+        mapping = {
+            "low": cls.LOW,
+            "medium": cls.MEDIUM,
+            "high": cls.HIGH,
+        }
+        if value not in mapping:
+            raise ValueError(f"'{value}' is not a valid MockTaskComplexity")
+        return mapping[value]
+
+    @classmethod
+    def __iter__(cls):
+        return iter([cls.LOW, cls.MEDIUM, cls.HIGH])
+
+
+__all__ = [
+    "DevelopmentTask",
+    "MockTaskStatus",
+    "MockTaskPriority",
+    "MockTaskComplexity",
+]

--- a/src/core/tasks/results.py
+++ b/src/core/tasks/results.py
@@ -1,0 +1,95 @@
+"""Result aggregation utilities for task execution."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .definitions import (
+    DevelopmentTask,
+    MockTaskStatus,
+    MockTaskPriority,
+    MockTaskComplexity,
+)
+
+
+def get_task_statistics(
+    tasks: Dict[str, DevelopmentTask], workflow_stats: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Compute aggregate statistics for a collection of tasks."""
+    total_tasks = len(tasks)
+    available_tasks = len(
+        [t for t in tasks.values() if t.status == MockTaskStatus.AVAILABLE]
+    )
+    claimed_tasks = len(
+        [t for t in tasks.values() if t.status == MockTaskStatus.CLAIMED]
+    )
+    in_progress_tasks = len(
+        [t for t in tasks.values() if t.status == MockTaskStatus.IN_PROGRESS]
+    )
+    completed_tasks = len(
+        [t for t in tasks.values() if t.status == MockTaskStatus.COMPLETED]
+    )
+    blocked_tasks = len(
+        [t for t in tasks.values() if t.status == MockTaskStatus.BLOCKED]
+    )
+
+    completed_times = []
+    for task in tasks.values():
+        if task.status == MockTaskStatus.COMPLETED:
+            elapsed = task.get_elapsed_time()
+            if elapsed is not None:
+                completed_times.append(elapsed)
+
+    avg_completion_time = (
+        sum(completed_times) / len(completed_times) if completed_times else 0
+    )
+
+    return {
+        "total_tasks": total_tasks,
+        "available_tasks": available_tasks,
+        "claimed_tasks": claimed_tasks,
+        "in_progress_tasks": in_progress_tasks,
+        "completed_tasks": completed_tasks,
+        "blocked_tasks": blocked_tasks,
+        "avg_completion_time_hours": avg_completion_time,
+        "workflow_stats": workflow_stats.copy(),
+    }
+
+
+def get_task_summary(
+    tasks: Dict[str, DevelopmentTask], workflow_stats: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Return statistics with completion rate."""
+    stats = get_task_statistics(tasks, workflow_stats)
+    total = stats["total_tasks"]
+    completed = stats["completed_tasks"]
+    stats["completion_rate"] = (completed / total * 100) if total else 0
+    return stats
+
+
+def get_priority_distribution(tasks: Dict[str, DevelopmentTask]) -> Dict[str, int]:
+    """Count tasks by priority."""
+    distribution: Dict[str, int] = {}
+    for priority in MockTaskPriority:
+        distribution[priority.name] = len(
+            [t for t in tasks.values() if t.priority == priority]
+        )
+    return distribution
+
+
+def get_complexity_distribution(tasks: Dict[str, DevelopmentTask]) -> Dict[str, int]:
+    """Count tasks by complexity."""
+    distribution: Dict[str, int] = {}
+    for complexity in MockTaskComplexity:
+        distribution[complexity.name] = len(
+            [t for t in tasks.values() if t.complexity == complexity]
+        )
+    return distribution
+
+
+__all__ = [
+    "get_task_statistics",
+    "get_task_summary",
+    "get_priority_distribution",
+    "get_complexity_distribution",
+]

--- a/tests/test_task_modules.py
+++ b/tests/test_task_modules.py
@@ -4,7 +4,7 @@ import sys
 
 import unittest
 
-from src.core.tasks.execution import TaskExecutor
+from src.core.tasks.executor import TaskExecutor
 from src.core.tasks.monitoring import TaskMonitor
 from src.core.tasks.recovery import TaskRecovery
 from src.core.tasks.scheduling import TaskScheduler, Task, TaskPriority, TaskStatus
@@ -132,7 +132,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_dev_task = Mock()
         mock_dev_task.task_id = "task_0001"
         
-        with patch('src.core.tasks.execution.DevelopmentTask', return_value=mock_dev_task):
+        with patch('src.core.tasks.definitions.DevelopmentTask', return_value=mock_dev_task):
             task_id = self.executor.create_task(
                 "Test Dev Task",
                 "Test Description",
@@ -153,7 +153,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_dev_task.claim.return_value = True
         mock_dev_task.claimed_by = "Agent-1"
         
-        with patch('src.core.tasks.execution.DevelopmentTask', return_value=mock_dev_task):
+        with patch('src.core.tasks.definitions.DevelopmentTask', return_value=mock_dev_task):
             # Create a task
             task_id = self.executor.create_task(
                 "Test Task",
@@ -183,7 +183,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_dev_task2.task_id = "task_0002"
         mock_dev_task2.is_available.return_value = True
         
-        with patch('src.core.tasks.execution.DevelopmentTask', return_value=mock_dev_task1):
+        with patch('src.core.tasks.definitions.DevelopmentTask', return_value=mock_dev_task1):
             # Create some tasks
             self.executor.create_task("Task 1", "Desc 1", "medium", "HIGH", 2.0, ["python"])
             self.executor.create_task("Task 2", "Desc 2", "low", "MEDIUM", 1.0, ["python"])


### PR DESCRIPTION
## Summary
- split task model and enums into `tasks/definitions.py`
- move task execution logic into `tasks/executor.py`
- centralize aggregation helpers in `tasks/results.py`
- update imports and references to new task module layout

## Testing
- `pytest tests/test_task_modules.py`
- `pytest tests/test_task_modules.py tests/unit/test_task_manager_refactored.py` *(fails: IndentationError in tests/unit/test_task_manager_refactored.py)*


------
https://chatgpt.com/codex/tasks/task_e_68b1a591ba0c8329a476a52d74cab550