### PR TITLE
chore: remove obsolete api gateway config backup

### DIFF
--- a/config_backup/services/api_gateway.yaml
+++ b/config_backup/services/api_gateway.yaml
@@ -1,4 +1,0 @@
-jwt:
-  algorithm: HS256
-  audience: v2-api
-  secret_env: JWT_SECRET


### PR DESCRIPTION
## Summary
- drop outdated backup of api gateway config

## Testing
- `pre-commit run --files config/services/api_gateway.yaml`
- `pytest` *(fails: NameError: name 'ENABLE_TRUE' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ed85d6c883299dcebd1ebc692c80