### PR TITLE
refactor: centralize contract integrity utilities

### DIFF
--- a/agent_workspaces/Agent-5/EMERGENCY_RESTORE_004_DATABASE_AUDIT.py
+++ b/agent_workspaces/Agent-5/EMERGENCY_RESTORE_004_DATABASE_AUDIT.py
@@ -391,8 +391,8 @@ class EmergencyContractDatabaseRecovery:
                         "issues": identify_corruption_issues(contract)
                     })
                                 
-        except Exception as e:
-            corruption_scan["corruption_indicators"].append(f"Failed to scan for corruption: {e}")
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            corruption_scan["corruption_indicators"].append(f"Failed to read or parse task list for corruption scan: {e}")
             
         # Generate recovery actions
         if corruption_scan["corruption_indicators"]:

--- a/agent_workspaces/Agent-5/EMERGENCY_RESTORE_004_DATABASE_AUDIT.py
+++ b/agent_workspaces/Agent-5/EMERGENCY_RESTORE_004_DATABASE_AUDIT.py
@@ -14,6 +14,13 @@ from typing import Dict, List, Any, Tuple
 from datetime import datetime
 import sys
 
+from src.database.integrity_tools import (
+    setup_logging,
+    iter_contracts,
+    is_contract_corrupted,
+    identify_corruption_issues,
+)
+
 class EmergencyContractDatabaseRecovery:
     """EMERGENCY-RESTORE-004: Contract Database Recovery System"""
     
@@ -24,22 +31,10 @@ class EmergencyContractDatabaseRecovery:
         self.audit_results = {}
         self.integrity_issues = []
         self.recovery_actions = []
-        self.logger = self._setup_logging()
-        
-    def _setup_logging(self) -> logging.Logger:
-        """Setup emergency logging for database recovery"""
-        logger = logging.getLogger("EMERGENCY_RESTORE_004")
-        logger.setLevel(logging.INFO)
-        
-        if not logger.handlers:
-            handler = logging.StreamHandler()
-            formatter = logging.Formatter(
-                '[EMERGENCY] %(asctime)s - %(name)s - %(levelname)s - %(message)s'
-            )
-            handler.setFormatter(formatter)
-            logger.addHandler(handler)
-            
-        return logger
+        self.logger = setup_logging(
+            "EMERGENCY_RESTORE_004",
+            fmt="[EMERGENCY] %(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
         
     def execute_emergency_recovery(self) -> Dict[str, Any]:
         """Execute EMERGENCY-RESTORE-004 immediately"""
@@ -372,33 +367,29 @@ class EmergencyContractDatabaseRecovery:
         try:
             with open(self.task_list_path, 'r') as f:
                 task_list = json.load(f)
-                
-            if "contracts" in task_list:
-                contract_ids = set()
-                
-                for category, category_data in task_list["contracts"].items():
-                    if "contracts" in category_data and isinstance(category_data["contracts"], list):
-                        for contract in category_data["contracts"]:
-                            contract_id = contract.get("contract_id")
-                            
-                            if not contract_id:
-                                corruption_scan["corruption_indicators"].append(
-                                    f"Contract missing ID in category {category}"
-                                )
-                                continue
-                                
-                            # Check for duplicates
-                            if contract_id in contract_ids:
-                                corruption_scan["duplicate_contracts"].append(contract_id)
-                            else:
-                                contract_ids.add(contract_id)
-                                
-                            # Check for data corruption indicators
-                            if self._is_contract_corrupted(contract):
-                                corruption_scan["data_integrity_issues"].append({
-                                    "contract_id": contract_id,
-                                    "issues": self._identify_corruption_issues(contract)
-                                })
+
+            contract_ids = set()
+            for category, contract in iter_contracts(task_list):
+                contract_id = contract.get("contract_id")
+
+                if not contract_id:
+                    corruption_scan["corruption_indicators"].append(
+                        f"Contract missing ID in category {category}"
+                    )
+                    continue
+
+                # Check for duplicates
+                if contract_id in contract_ids:
+                    corruption_scan["duplicate_contracts"].append(contract_id)
+                else:
+                    contract_ids.add(contract_id)
+
+                # Check for data corruption indicators
+                if is_contract_corrupted(contract):
+                    corruption_scan["data_integrity_issues"].append({
+                        "contract_id": contract_id,
+                        "issues": identify_corruption_issues(contract)
+                    })
                                 
         except Exception as e:
             corruption_scan["corruption_indicators"].append(f"Failed to scan for corruption: {e}")
@@ -416,38 +407,6 @@ class EmergencyContractDatabaseRecovery:
             )
             
         return corruption_scan
-        
-    def _is_contract_corrupted(self, contract: Dict[str, Any]) -> bool:
-        """Check if a contract appears to be corrupted"""
-        corruption_indicators = [
-            not contract.get("contract_id"),
-            not contract.get("title"),
-            not contract.get("description"),
-            not contract.get("status"),
-            contract.get("extra_credit_points", 0) < 0,
-            contract.get("estimated_time") == "INVALID_TIME"
-        ]
-        
-        return any(corruption_indicators)
-        
-    def _identify_corruption_issues(self, contract: Dict[str, Any]) -> List[str]:
-        """Identify specific corruption issues in a contract"""
-        issues = []
-        
-        if not contract.get("contract_id"):
-            issues.append("Missing contract ID")
-        if not contract.get("title"):
-            issues.append("Missing title")
-        if not contract.get("description"):
-            issues.append("Missing description")
-        if not contract.get("status"):
-            issues.append("Missing status")
-        if contract.get("extra_credit_points", 0) < 0:
-            issues.append("Invalid extra credit points")
-        if contract.get("estimated_time") == "INVALID_TIME":
-            issues.append("Invalid estimated time")
-            
-        return issues
         
     def implement_integrity_checks(self) -> Dict[str, Any]:
         """Implement database integrity checks to prevent future corruption"""

--- a/src/database/integrity_tools.py
+++ b/src/database/integrity_tools.py
@@ -1,0 +1,87 @@
+"""Utility functions for contract database integrity operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Any, Iterable, Tuple, List
+
+
+def setup_logging(name: str,
+                  level: int = logging.INFO,
+                  fmt: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s") -> logging.Logger:
+    """Create and configure a logger.
+
+    Parameters
+    ----------
+    name: str
+        Name of the logger to create.
+    level: int, optional
+        Logging level to set. Defaults to :data:`logging.INFO`.
+    fmt: str, optional
+        Log message format string. Defaults to a simple timestamped format.
+
+    Returns
+    -------
+    logging.Logger
+        Configured logger instance.
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(fmt))
+        logger.addHandler(handler)
+
+    return logger
+
+
+def iter_contracts(task_list: Dict[str, Any]) -> Iterable[Tuple[str, Dict[str, Any]]]:
+    """Yield all contracts from a task list structure.
+
+    Parameters
+    ----------
+    task_list: Dict[str, Any]
+        Parsed task list JSON data.
+
+    Yields
+    ------
+    Tuple[str, Dict[str, Any]]
+        Pairs of category name and individual contract dictionaries.
+    """
+    contracts_section = task_list.get("contracts", {})
+    for category, category_data in contracts_section.items():
+        items = category_data.get("contracts")
+        if isinstance(items, list):
+            for contract in items:
+                yield category, contract
+
+
+def is_contract_corrupted(contract: Dict[str, Any]) -> bool:
+    """Determine if a contract appears corrupted."""
+    return any([
+        not contract.get("contract_id"),
+        not contract.get("title"),
+        not contract.get("description"),
+        not contract.get("status"),
+        contract.get("extra_credit_points", 0) < 0,
+        contract.get("estimated_time") == "INVALID_TIME",
+    ])
+
+
+def identify_corruption_issues(contract: Dict[str, Any]) -> List[str]:
+    """List specific corruption issues for a contract."""
+    issues: List[str] = []
+    if not contract.get("contract_id"):
+        issues.append("Missing contract ID")
+    if not contract.get("title"):
+        issues.append("Missing title")
+    if not contract.get("description"):
+        issues.append("Missing description")
+    if not contract.get("status"):
+        issues.append("Missing status")
+    if contract.get("extra_credit_points", 0) < 0:
+        issues.append("Invalid extra credit points")
+    if contract.get("estimated_time") == "INVALID_TIME":
+        issues.append("Invalid estimated time")
+    return issues


### PR DESCRIPTION
## Summary
- add shared integrity_tools with logging and contract scanning helpers
- refactor emergency database audit to use integrity_tools
- refactor database integrity checker to use shared iteration and logging helpers

## Testing
- `pytest` *(fails: NameError: name 'ENABLE_TRUE' is not defined and other collection errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b2f628967c8329b030e3287473755d