### PR TITLE
refactor: centralize profiling utils

### DIFF
--- a/agent_workspaces/meeting/agent_workspaces/Agent-6/performance_profiling_tools/analysis_dashboard.py
+++ b/agent_workspaces/meeting/agent_workspaces/Agent-6/performance_profiling_tools/analysis_dashboard.py
@@ -14,6 +14,8 @@ from typing import Dict, List, Any, Optional, Tuple
 from pathlib import Path
 import logging
 
+from common import DEFAULT_THRESHOLDS, load_json_file, save_json_file
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -35,14 +37,7 @@ class PerformanceAnalysisDashboard:
         self.profiler_data_file = profiler_data_file
         self.performance_data: Dict[str, Any] = {}
         self.analysis_results: Dict[str, Any] = {}
-        self.performance_thresholds = {
-            'critical_cpu': 95.0,
-            'warning_cpu': 80.0,
-            'critical_memory': 90.0,
-            'warning_memory': 75.0,
-            'critical_function_time': 5.0,
-            'warning_function_time': 1.0
-        }
+        self.performance_thresholds = DEFAULT_THRESHOLDS.copy()
         
         if profiler_data_file:
             self.load_profiler_data(profiler_data_file)
@@ -59,14 +54,13 @@ class PerformanceAnalysisDashboard:
         Returns:
             True if data loaded successfully
         """
-        try:
-            with open(data_file, 'r') as f:
-                self.performance_data = json.load(f)
+        self.performance_data = load_json_file(data_file)
+        if self.performance_data:
             logger.info(f"Loaded profiling data from {data_file}")
             return True
-        except Exception as e:
-            logger.error(f"Error loading profiling data: {e}")
-            return False
+
+        logger.error(f"Failed to load profiling data from {data_file}")
+        return False
     
     def analyze_performance_trends(self) -> Dict[str, Any]:
         """
@@ -448,10 +442,8 @@ class PerformanceAnalysisDashboard:
             'performance_data': self.performance_data,
             'analysis_results': self.analysis_results
         }
-        
-        with open(output_file, 'w') as f:
-            json.dump(export_data, f, indent=2)
-        
+
+        save_json_file(output_file, export_data)
         logger.info(f"Exported analysis report to {output_file}")
         return output_file
     

--- a/agent_workspaces/meeting/agent_workspaces/Agent-6/performance_profiling_tools/common.py
+++ b/agent_workspaces/meeting/agent_workspaces/Agent-6/performance_profiling_tools/common.py
@@ -1,0 +1,53 @@
+"""Shared utilities for performance profiling tools."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Default performance thresholds used across profiling tools
+DEFAULT_THRESHOLDS: Dict[str, float] = {
+    "critical_cpu": 95.0,
+    "warning_cpu": 80.0,
+    "critical_memory": 90.0,
+    "warning_memory": 75.0,
+    "critical_function_time": 5.0,
+    "warning_function_time": 1.0,
+}
+
+def load_json_file(path: str) -> Any:
+    """Load and parse JSON data from ``path``.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        Parsed data or an empty dictionary if loading fails.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as exc:  # pragma: no cover - logging path
+        logger.error("Error reading JSON file %s: %s", path, exc)
+        return {}
+
+def save_json_file(path: str, data: Any) -> bool:
+    """Serialize ``data`` to ``path`` as JSON.
+
+    Args:
+        path: Destination file path.
+        data: Data to serialize.
+
+    Returns:
+        ``True`` if the file was written successfully, ``False`` otherwise.
+    """
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        return True
+    except Exception as exc:  # pragma: no cover - logging path
+        logger.error("Error writing JSON file %s: %s", path, exc)
+        return False

--- a/agent_workspaces/meeting/agent_workspaces/Agent-6/performance_profiling_tools/validation_system.py
+++ b/agent_workspaces/meeting/agent_workspaces/Agent-6/performance_profiling_tools/validation_system.py
@@ -8,13 +8,14 @@ Description: Validation system for ensuring profiling accuracy and reliability
 
 import time
 import statistics
-import json
 import logging
 from datetime import datetime
 from typing import Dict, List, Any, Optional, Tuple, Callable
 from dataclasses import dataclass, asdict
 from pathlib import Path
 import random
+
+from common import DEFAULT_THRESHOLDS, save_json_file
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -60,6 +61,7 @@ class ProfilingValidationSystem:
         self.tolerance = tolerance  # 5% tolerance by default
         self.validation_results: List[ValidationResult] = []
         self.calibration_data: Dict[str, Any] = {}
+        self.performance_thresholds = DEFAULT_THRESHOLDS.copy()
         
         logger.info("Profiling Validation System initialized")
     
@@ -458,10 +460,8 @@ class ProfilingValidationSystem:
         
         # Convert dataclass to dict for JSON serialization
         report_dict = asdict(report)
-        
-        with open(output_file, 'w') as f:
-            json.dump(report_dict, f, indent=2)
-        
+
+        save_json_file(output_file, report_dict)
         logger.info(f"Validation report exported to {output_file}")
         return output_file
     


### PR DESCRIPTION
## Summary
- add common utilities for performance thresholds and JSON helpers
- reuse shared thresholds and JSON helpers in analysis_dashboard
- adopt shared JSON helper and thresholds in validation_system

## Testing
- `pytest agent_workspaces/meeting/agent_workspaces/Agent-6/performance_profiling_tools/test_performance_profiler.py` *(fails: Another profiling tool is already active)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f6291a3c8329a585a3022ff48101