### PR TITLE
Relocate clean_message test script to tests folder

### DIFF
--- a/tests/clean_message_test.py
+++ b/tests/clean_message_test.py
@@ -6,10 +6,8 @@ Clean Message Delivery Test
 Clean test to see exactly what's happening with message delivery to all agents.
 """
 
-from src.services import UnifiedMessagingService
+from src.services.unified_messaging_service import UnifiedMessagingService
 import time
-
-from src.utils.stability_improvements import stability_manager, safe_import
 
 
 def clean_message_test():


### PR DESCRIPTION
## Summary
- move `clean_message_test.py` from `src/services` into `tests`
- fix UnifiedMessagingService import path after relocation

## Testing
- `PYTHONPATH=. python tests/clean_message_test.py` *(fails: ModuleNotFoundError: No module named 'pyautogui'; AttributeError: 'UnifiedMessagingService' object has no attribute 'agent_registry')*
- `PYTHONPATH=. pytest tests/clean_message_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68b46c283e008329a46ff7926918a088