### PR TITLE
refactor: centralize config loading

### DIFF
--- a/src/core/config_loader.py
+++ b/src/core/config_loader.py
@@ -2,12 +2,11 @@
 # MIGRATED: This file has been migrated to the centralized configuration system
 #!/usr/bin/env python3
 """
-Config Loader Module - Configuration File Loading Operations
+Config Loader Module - **Single Source of Truth** for configuration loading.
 
-This module handles configuration file loading and parsing.
-Follows Single Responsibility Principle - only file loading operations.
-Architecture: Single Responsibility Principle - file loading only
-LOC: 120 lines (under 200 limit)
+This module centralizes all configuration file loading and parsing logic.
+Other modules must import configuration utilities from here rather than
+implementing their own loaders.
 """
 
 import os
@@ -132,6 +131,23 @@ class ConfigLoader:
         """Get list of supported configuration file formats"""
         return [".yaml", ".yml", ".json"]
 
+
+def load_config(path: str | Path, defaults: Optional[Dict[str, Any]] | None = None) -> Dict[str, Any]:
+    """Load a configuration file and return its data.
+
+    This convenience function is the preferred entry point for modules that
+    need configuration data. It leverages :class:`ConfigLoader` to read the
+    file and applies optional *defaults* when loading fails.
+    """
+    config_path = Path(path)
+    loader = ConfigLoader(config_path.parent)
+    section = loader.load_config_file(config_path)
+    if section and section.data is not None:
+        data = section.data
+        if defaults:
+            return {**defaults, **data}
+        return data
+    return defaults.copy() if defaults else {}
 
 def run_smoke_test():
     """Run basic functionality test for ConfigLoader"""

--- a/src/fsm/utils/config.py
+++ b/src/fsm/utils/config.py
@@ -5,28 +5,22 @@ Configuration Management - FSM Core V2 Modularization
 Captain Agent-3: Configuration Utility Implementation
 """
 
-import json
-from pathlib import Path
 from typing import Dict, Any, Optional
+
+from src.core.config_loader import load_config as _load_config
 
 class FSMConfig:
     """Manages FSM configuration"""
     
     def __init__(self, config_path: Optional[str] = None):
         self.config_path = config_path or "fsm_config.json"
-        self.config_data = {}
+        self.config_data: Dict[str, Any] = {}
         self.load_config()
-    
+
     def load_config(self) -> bool:
-        """Load configuration from file"""
-        try:
-            if Path(self.config_path).exists():
-                with open(self.config_path, 'r') as f:
-                    self.config_data = json.load(f)
-                return True
-            return False
-        except Exception:
-            return False
+        """Load configuration using the project SSOT loader."""
+        self.config_data = _load_config(self.config_path, {})
+        return bool(self.config_data)
     
     def get_config(self, key: str, default: Any = None) -> Any:
         """Get configuration value"""

--- a/src/services/config_utils.py
+++ b/src/services/config_utils.py
@@ -1,43 +1,20 @@
+"""Compatibility utilities for configuration loading.
 
-# MIGRATED: This file has been migrated to the centralized configuration system
-import json
+This module provides a thin wrapper around the project-wide single source of
+truth for configuration loading located at ``src.core.config_loader``.
+"""
+
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Dict, Union
 
-try:
-    import yaml
-except Exception:  # pragma: no cover - optional dependency
-    yaml = None
+from src.core.config_loader import load_config as _load_config
 
 
 class ConfigLoader:
-    """Utility for loading JSON/YAML configuration files with defaults."""
+    """Backward-compatible wrapper for the core ``load_config`` function."""
 
     @staticmethod
     def load(path: Union[str, Path], defaults: Dict[str, Any]) -> Dict[str, Any]:
-        """Load configuration from *path*.
-
-        If the file does not exist it will be created with *defaults*.
-        Returns the loaded configuration or *defaults* on failure.
-        """
-        cfg_path = Path(path)
-        try:
-            if cfg_path.exists():
-                with open(cfg_path, "r", encoding="utf-8") as f:
-                    suffix = cfg_path.suffix.lower()
-                    if suffix in {".yaml", ".yml"}:
-                        if yaml is None:
-                            return defaults.copy()
-                        return yaml.safe_load(f) or {}
-                    return json.load(f)
-
-            cfg_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(cfg_path, "w", encoding="utf-8") as f:
-                suffix = cfg_path.suffix.lower()
-                if suffix in {".yaml", ".yml"} and yaml is not None:
-                    yaml.safe_dump(defaults, f)
-                else:
-                    json.dump(defaults, f, indent=2)
-            return defaults.copy()
-        except Exception:
-            return defaults.copy()
+        return _load_config(path, defaults)

--- a/src/services/continuous_quality_monitor/config.py
+++ b/src/services/continuous_quality_monitor/config.py
@@ -3,7 +3,7 @@
 """Configuration utilities for continuous quality monitoring."""
 from __future__ import annotations
 
-from src.services.config_utils import ConfigLoader
+from src.core.config_loader import load_config as _load_config
 
 DEFAULT_CONFIG = {
     "monitoring": {
@@ -32,5 +32,5 @@ DEFAULT_CONFIG = {
 
 
 def load_config(config_path: str) -> dict:
-    """Load configuration from ``config_path`` using :class:`ConfigLoader`."""
-    return ConfigLoader.load(config_path, DEFAULT_CONFIG)
+    """Load configuration from ``config_path`` using the SSOT loader."""
+    return _load_config(config_path, DEFAULT_CONFIG)

--- a/src/services/core_coordinator_service.py
+++ b/src/services/core_coordinator_service.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import Dict, List, Any, Optional
 from dataclasses import dataclass
 import argparse
-from src.services.config_utils import ConfigLoader
+from src.core.config_loader import load_config
 from src.services.performance_analysis import analyze_agent_activity
 
 
@@ -69,7 +69,7 @@ class CoreCoordinatorService:
             "voting_duration": 120,
             "term_duration": 1800,
         }
-        config_data = ConfigLoader.load(self.config_path / "coordination_config.json", default_config)
+        config_data = load_config(self.config_path / "coordination_config.json", default_config)
         self.config = CoordinationConfig(**config_data)
 
         # Initialize agent status


### PR DESCRIPTION
## Summary
- designate `src/core/config_loader.py` as the single source of truth for configuration loading
- simplify service utilities to wrap the core config loader
- refactor modules to import the SSOT loader instead of local `load_config` implementations

## Testing
- `pytest` *(fails: 154 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b46bc29c948329a9174280f65b7cfb