### PR TITLE
Remove metrics manager references and centralize counters

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,7 +1,6 @@
-"""Agent utilities including registration, scheduling, and metrics."""
+"""Agent utilities including registration and scheduling."""
 
 from .registration import AgentRegistry
 from .scheduler import TaskAssigner
-from .metrics import AgentMetricsManager
 
-__all__ = ["AgentRegistry", "TaskAssigner", "AgentMetricsManager"]
+__all__ = ["AgentRegistry", "TaskAssigner"]

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -24,9 +24,7 @@ class MetricsCollector:
 
     def __init__(self) -> None:
         self._metrics: Dict[str, float] = {}
-        self.total_operations = 0
-        self.successful_operations = 0
-        self.failed_operations = 0
+        self._counters = CounterMetrics()
 
     def record(self, name: str, value: float) -> None:
         """Record a metric value."""
@@ -43,17 +41,29 @@ class MetricsCollector:
 
         return dict(self._metrics)
 
+    @property
+    def total_operations(self) -> int:
+        return self._counters.get("total_operations")
+
+    @property
+    def successful_operations(self) -> int:
+        return self._counters.get("successful_operations")
+
+    @property
+    def failed_operations(self) -> int:
+        return self._counters.get("failed_operations")
+
     def record_success(self) -> None:
         """Record a successful operation."""
 
-        self.total_operations += 1
-        self.successful_operations += 1
+        self._counters.increment("total_operations")
+        self._counters.increment("successful_operations")
 
     def record_failure(self) -> None:
         """Record a failed operation."""
 
-        self.total_operations += 1
-        self.failed_operations += 1
+        self._counters.increment("total_operations")
+        self._counters.increment("failed_operations")
 
 
 class CounterMetrics:

--- a/src/managers/__init__.py
+++ b/src/managers/__init__.py
@@ -1,17 +1,15 @@
 """Agent manager modules.
 
 This package groups lightweight manager components responsible for
-lifecycle control, coordination and metrics tracking for agents.
+lifecycle control, coordination and repository management for agents.
 """
 
 from .lifecycle_manager import AgentLifecycleManager
 from .coordination_manager import AgentCoordinator
-from .metrics_manager import AgentMetricsManager
 from .repo_manager import RepositoryManager
 
 __all__ = [
     "AgentLifecycleManager",
     "AgentCoordinator",
-    "AgentMetricsManager",
     "RepositoryManager",
 ]


### PR DESCRIPTION
## Summary
- remove outdated metrics manager imports
- centralize counter tracking via CounterMetrics in MetricsCollector
- clarify manager package docstring

## Testing
- `pytest` *(fails: 155 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b4794cbd108329a0c085b538f22053