### PR TITLE
docs: set V2 LOC guideline to 400 lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,12 +45,12 @@
 ### 📏 **V2 COMPLIANCE THRESHOLDS (Updated)**
 
 #### **File Size Limits**
-- 🚨 **CRITICAL VIOLATION**: >500 lines (immediate refactoring required)
-- ⚠️ **MAJOR VIOLATION**: 400-500 lines (strategic refactoring target)
-- 📋 **MINOR VIOLATION**: 300-400 lines (acceptable with justification)
-- ✅ **COMPLIANT**: <300 lines (ideal target)
+- 🚨 **CRITICAL VIOLATION**: >600 lines (immediate refactoring required)
+- ⚠️ **MAJOR VIOLATION**: 400-600 lines (strategic refactoring target)
+- ✅ **GUIDELINE**: ≤400 lines per file (LOC flexible; prioritize clean, tested, reusable code)
 
-**Rationale**: Focus resources on eliminating truly problematic files (>400 lines) while maintaining high code quality standards. Strategic efficiency over micro-optimization.
+**Rationale**: LOC count is a guideline. The strict requirement is writing clean, tested, reusable code
+that scales and follows KISS, SOLID, SSOT, SRP, and object-oriented principles.
 
 #### **Architecture Requirements**
 - Follow existing architecture before proposing or implementing new patterns
@@ -325,10 +325,9 @@ python -m src.services.messaging_cli --check-status
 - ✅ Prefer dependency injection for shared utilities; avoid circular dependencies
 
 #### **File Size Management (Updated Thresholds)**
-- 🚨 **CRITICAL**: Eliminate files >500 lines immediately
-- ⚠️ **MAJOR**: Refactor files 400-500 lines strategically  
-- 📋 **MINOR**: Monitor files 300-400 lines (acceptable with justification)
-- ✅ **COMPLIANT**: Maintain files <300 lines as ideal
+- 🚨 **CRITICAL**: Eliminate files >600 lines immediately
+- ⚠️ **MAJOR**: Refactor files 400-600 lines strategically
+- ✅ **GUIDELINE**: Keep files ≤400 lines while focusing on clean, tested, reusable, scalable code
 
 #### **Code Quality Standards**
 - ✅ **Testing**: Unit tests for all new features, Jest naming clarity, mock externals

--- a/V2_COMPLIANCE_README.md
+++ b/V2_COMPLIANCE_README.md
@@ -18,12 +18,12 @@ This project enforces **V2 Compliance Standards** for JavaScript/TypeScript file
 ### 📏 **FILE SIZE THRESHOLDS (Updated Strategy)**
 
 #### **Strategic V2 Compliance Levels**
-- 🚨 **CRITICAL VIOLATION**: >500 lines (immediate refactoring required)
-- ⚠️ **MAJOR VIOLATION**: 400-500 lines (strategic refactoring target)  
-- 📋 **MINOR VIOLATION**: 300-400 lines (acceptable with justification)
-- ✅ **COMPLIANT**: <300 lines (ideal target)
+- 🚨 **CRITICAL VIOLATION**: >600 lines (immediate refactoring required)
+- ⚠️ **MAJOR VIOLATION**: 400-600 lines (strategic refactoring target)
+- ✅ **GUIDELINE**: ≤400 lines per file (LOC flexible; prioritize clean, tested, reusable code)
 
-**Rationale**: Focus development resources on eliminating truly problematic files (>400 lines) while maintaining code quality. Strategic efficiency over micro-optimization.
+**Rationale**: LOC is a guideline. The strict requirement is clean, tested, reusable, scalable code
+following KISS, SOLID, SSOT, SRP, and object-oriented class-based design.
 
 ### Per Function
 - **Maximum**: 30 lines (hard limit)
@@ -91,7 +91,7 @@ Shows the 20 largest files by line count:
 ## 🔧 Configuration
 
 ### ESLint Rules Summary (Updated)
-- `max-lines`: 400 lines per file (strategic threshold, 300 ideal)
+- `max-lines`: 400 lines per file (guideline; emphasis on clean, tested, reusable code)
 - `max-lines-per-function`: 30 lines per function
 - `complexity`: Maximum 10
 - `max-params`: Maximum 4 parameters
@@ -139,8 +139,9 @@ Shows the 20 largest files by line count:
 // src/services/user/index.js (50 lines) - Public interface
 ```
 
-### Files 300-400 Lines (Minor Violations)
-**Acceptable with justification** - Focus on code quality over line count:
+### Files Over 400 Lines
+**Requires justification** – LOC is flexible, but code must remain clean, tested, reusable,
+scalable, and class-based:
 - Clean, well-structured code with clear responsibilities
 - Comprehensive test coverage (>85%)
 - Clear class-based design with dependency injection
@@ -190,7 +191,7 @@ function processUserData(user) {
 - [ ] Maximum 4 levels of nesting
 
 ### 📋 **ACCEPTABLE WITH JUSTIFICATION**
-- [ ] Files 300-400 lines (minor violations, monitor and improve)
+- [ ] Files over 400 lines (monitor and refactor when feasible)
 - [ ] Legacy code with migration plan to modular architecture
 
 ## 📞 Support

--- a/scripts/index_v2_refactoring.py
+++ b/scripts/index_v2_refactoring.py
@@ -190,9 +190,9 @@ class V2RefactoringIndexer:
         This document captures the proven revolutionary pattern for transforming monolithic code into V2 compliant modular architecture.
 
         PATTERN OVERVIEW:
-        1. IDENTIFY: Scan for violations (>300 lines) using systematic analysis
+        1. IDENTIFY: Scan for violations (>400 lines) using systematic analysis
         2. ANALYZE: Understand monolithic responsibilities and coupling points
-        3. BREAKDOWN: Extract focused modules with single responsibilities (<300 lines each)
+        3. BREAKDOWN: Extract focused modules with single responsibilities (<400 lines each)
         4. SPECIALIZE: Create dedicated engines for specific functionality (load, stress, endurance testing)
         5. ORCHESTRATE: Build main coordinator using dependency injection pattern
         6. INTEGRATE: Implement clean interfaces and factory functions for testability
@@ -212,7 +212,7 @@ class V2RefactoringIndexer:
         - Revolutionary efficiency gains
 
         APPLICABILITY:
-        - Any monolithic file exceeding 300 lines
+        - Any monolithic file exceeding 400 lines
         - Complex systems with multiple responsibilities
         - Legacy code requiring modernization
         - Systems needing improved testability and maintainability
@@ -236,7 +236,7 @@ class V2RefactoringIndexer:
                 'author': 'Agent-2',
                 'timestamp': datetime.now().isoformat(),
                 'efficiency_gain': '90-95%',
-                'applicability': 'monolithic_files_over_300_lines',
+                'applicability': 'monolithic_files_over_400_lines',
                 'success_rate': '100%'
             },
             'source': 'V2_compliance_refactoring'

--- a/scripts/utilities/find_large_files.py
+++ b/scripts/utilities/find_large_files.py
@@ -2,7 +2,7 @@
 """Find Python files exceeding line limits."""
 
 
-def find_large_python_files(directory="src", min_lines=300):
+def find_large_python_files(directory="src", min_lines=400):
     """Find Python files exceeding the specified line count."""
     large_files = []
     
@@ -21,10 +21,10 @@ def find_large_python_files(directory="src", min_lines=300):
     return sorted(large_files, key=lambda x: x[1], reverse=True)
 
 if __name__ == "__main__":
-    get_logger(__name__).info("Python files over 300 lines:")
+    get_logger(__name__).info("Python files over 400 lines:")
     large_files = find_large_python_files()
     
     for file_path, line_count in large_files[:15]:
         get_logger(__name__).info(f"{file_path}: {line_count} lines")
     
-    get_logger(__name__).info(f"\nTotal files over 300 lines: {len(large_files)}")
+    get_logger(__name__).info(f"\nTotal files over 400 lines: {len(large_files)}")


### PR DESCRIPTION
## Summary
- Update V2 compliance docs and guidelines to use a 400 line LOC guideline and stress clean, tested, reusable code over strict counts
- Align helper scripts to flag files exceeding 400 lines instead of 300

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest` *(fails: multiple import and NameError issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bac4c4ca5c8329a96377d4c6771c56