### PR TITLE
Centralize agent coordinates registry

### DIFF
--- a/src/agent_registry.py
+++ b/src/agent_registry.py
@@ -1,0 +1,44 @@
+"""Shared agent registry for system-wide constants."""
+
+COORDINATES = {
+    "Agent-1": {
+        "x": -1269,
+        "y": 481,
+        "description": "Integration & Core Systems Specialist",
+    },
+    "Agent-2": {
+        "x": -308,
+        "y": 480,
+        "description": "Architecture & Design Specialist",
+    },
+    "Agent-3": {
+        "x": -1269,
+        "y": 1001,
+        "description": "Infrastructure & DevOps Specialist",
+    },
+    "Agent-4": {
+        "x": -308,
+        "y": 1000,
+        "description": "Quality Assurance Specialist (CAPTAIN)",
+    },
+    "Agent-5": {
+        "x": 652,
+        "y": 421,
+        "description": "Business Intelligence Specialist",
+    },
+    "Agent-6": {
+        "x": 1612,
+        "y": 419,
+        "description": "Coordination & Communication Specialist",
+    },
+    "Agent-7": {
+        "x": 653,
+        "y": 940,
+        "description": "Web Development Specialist",
+    },
+    "Agent-8": {
+        "x": 1611,
+        "y": 941,
+        "description": "SSOT & System Integration Specialist",
+    },
+}

--- a/src/services/handlers/utility_handler.py
+++ b/src/services/handlers/utility_handler.py
@@ -11,22 +11,24 @@ Author: Agent-7 - Web Development Specialist
 License: MIT
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
+
+from ...agent_registry import COORDINATES
 
 
 class UtilityHandler:
     """
     Handles utility commands for messaging CLI.
-    
+
     Manages utility functions like listing agents, coordinates, and history.
     """
-    
+
     def __init__(self):
         """Initialize utility handler."""
         self.agent_list = []
-        self.coordinates = {}
+        self.coordinates = COORDINATES
         self.history = []
-    
+
     def handle_utility_commands(self, args) -> bool:
         """Handle utility-related commands."""
         try:
@@ -42,31 +44,34 @@ class UtilityHandler:
                 print("Agent-7: Web Development")
                 print("Agent-8: SSOT & System Integration")
                 return True
-                
+
             if args.coordinates:
                 print("Agent Coordinates:")
                 print("=" * 40)
-                print("Agent coordinates loaded from configuration")
-                print("Use --agent to send messages to specific agents")
+                for agent, data in COORDINATES.items():
+                    print(
+                        f"{agent}: ({data['x']}, {data['y']}) - "
+                        f"{data['description']}"
+                    )
                 return True
-                
+
             if args.history:
                 print("Message History:")
                 print("=" * 40)
                 print("No message history available yet.")
                 return True
-                
+
         except Exception as e:
             print(f"Error handling utility command: {e}")
             return False
-        
+
         return False
-    
+
     def list_agents(self) -> List[str]:
         """Get list of available agents."""
         return [
             "Agent-1: Integration & Core Systems",
-            "Agent-2: Architecture & Design", 
+            "Agent-2: Architecture & Design",
             "Agent-3: Infrastructure & DevOps",
             "Agent-4: Strategic Oversight & Emergency Intervention",
             "Agent-5: Business Intelligence",
@@ -74,40 +79,31 @@ class UtilityHandler:
             "Agent-7: Web Development",
             "Agent-8: SSOT & System Integration"
         ]
-    
+
     def get_coordinates(self) -> Dict[str, Any]:
         """Get agent coordinates."""
-        return {
-            "Agent-1": {"x": -100, "y": 1000},
-            "Agent-2": {"x": -200, "y": 1000},
-            "Agent-3": {"x": -300, "y": 1000},
-            "Agent-4": {"x": -400, "y": 1000},
-            "Agent-5": {"x": -500, "y": 1000},
-            "Agent-6": {"x": -600, "y": 1000},
-            "Agent-7": {"x": -700, "y": 1000},
-            "Agent-8": {"x": -800, "y": 1000}
-        }
-    
+        return COORDINATES
+
     def get_history(self) -> List[Dict[str, Any]]:
         """Get message history."""
         return self.history
-    
+
     def add_to_history(self, message: Dict[str, Any]):
         """Add message to history."""
         self.history.append(message)
-        
+
         # Keep only last 100 messages
         if len(self.history) > 100:
             self.history = self.history[-100:]
-    
+
     def clear_history(self):
         """Clear message history."""
         self.history = []
-    
+
     def get_utility_status(self) -> Dict[str, Any]:
         """Get utility handler status."""
         return {
             "agent_count": len(self.list_agents()),
-            "coordinate_count": len(self.get_coordinates()),
+            "coordinate_count": len(COORDINATES),
             "history_count": len(self.history)
         }

--- a/src/services/messaging_handlers_engine.py
+++ b/src/services/messaging_handlers_engine.py
@@ -10,107 +10,130 @@ Created: 2025-01-27
 Purpose: Modular engine for messaging CLI handlers
 """
 
-import json
 import logging
 from typing import Any, Dict, List, Optional
-from .messaging_handlers_models import CoordinateConfig, CLICommand, CommandResult, RecipientType, SenderType, UnifiedMessagePriority, UnifiedMessageTag, UnifiedMessageType
+from ..agent_registry import COORDINATES
+from .messaging_handlers_models import (
+    CoordinateConfig,
+    CLICommand,
+    CommandResult,
+)
 
 
 class MessagingHandlersEngine:
     """Core engine for messaging CLI handlers operations."""
-    
+
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         """Initialize the messaging handlers engine."""
         self.config = config or {}
         self.logger = logging.getLogger(__name__)
-        self.coordinates: Dict[str, CoordinateConfig] = {}
-        self._load_coordinates()
-    
-    def _load_coordinates(self) -> None:
-        """Load agent coordinates from configuration."""
-        try:
-            # Simplified coordinate loading
-            self.coordinates = {
-                "Agent-1": CoordinateConfig("Agent-1", -30, 1000, "Agent-1 coordinates"),
-                "Agent-2": CoordinateConfig("Agent-2", -30, 1000, "Agent-2 coordinates"),
-                "Agent-3": CoordinateConfig("Agent-3", -30, 1000, "Agent-3 coordinates"),
-                "Agent-4": CoordinateConfig("Agent-4", -30, 1000, "Agent-4 coordinates"),
-                "Agent-5": CoordinateConfig("Agent-5", -30, 1000, "Agent-5 coordinates"),
-                "Agent-6": CoordinateConfig("Agent-6", -30, 1000, "Agent-6 coordinates"),
-                "Agent-7": CoordinateConfig("Agent-7", -30, 1000, "Agent-7 coordinates"),
-                "Agent-8": CoordinateConfig("Agent-8", -30, 1000, "Agent-8 coordinates"),
-            }
-        except Exception as e:
-            self.logger.warning(f"Could not load coordinates: {e}")
-    
-    def get_agent_coordinates(self, agent_id: str) -> Optional[CoordinateConfig]:
+
+    def get_agent_coordinates(
+        self, agent_id: str
+    ) -> Optional[CoordinateConfig]:
         """Get coordinates for a specific agent."""
-        return self.coordinates.get(agent_id)
-    
+        data = COORDINATES.get(agent_id)
+        if not data:
+            return None
+        return CoordinateConfig(
+            agent_id,
+            data["x"],
+            data["y"],
+            data.get("description", f"{agent_id} coordinates"),
+        )
+
     def list_agents(self) -> List[str]:
         """List all available agents."""
-        return list(self.coordinates.keys())
-    
+        return list(COORDINATES.keys())
+
     def validate_command(self, command: CLICommand) -> CommandResult:
         """Validate a CLI command."""
         try:
             if not command.command:
-                return CommandResult(False, "Command is required", error="Missing command")
-            
+                return CommandResult(
+                    False, "Command is required", error="Missing command"
+                )
+
             if command.command == "send" and not command.message:
-                return CommandResult(False, "Message is required for send command", error="Missing message")
-            
+                return CommandResult(
+                    False,
+                    "Message is required for send command",
+                    error="Missing message",
+                )
+
             if command.command == "send" and not command.agent:
-                return CommandResult(False, "Agent is required for send command", error="Missing agent")
-            
+                return CommandResult(
+                    False,
+                    "Agent is required for send command",
+                    error="Missing agent",
+                )
+
             return CommandResult(True, "Command validated successfully")
         except Exception as e:
-            return CommandResult(False, f"Command validation failed: {e}", error=str(e))
-    
+            return CommandResult(
+                False,
+                f"Command validation failed: {e}",
+                error=str(e),
+            )
+
     def process_command(self, command: CLICommand) -> CommandResult:
         """Process a CLI command."""
         try:
             validation_result = self.validate_command(command)
             if not validation_result.success:
                 return validation_result
-            
+
             if command.command == "coordinates":
                 return self._handle_coordinates_command()
-            elif command.command == "list_agents":
+            if command.command == "list_agents":
                 return self._handle_list_agents_command()
-            elif command.command == "send":
+            if command.command == "send":
                 return self._handle_send_command(command)
-            else:
-                return CommandResult(False, f"Unknown command: {command.command}", error="Invalid command")
+            return CommandResult(
+                False,
+                f"Unknown command: {command.command}",
+                error="Invalid command",
+            )
         except Exception as e:
-            return CommandResult(False, f"Command processing failed: {e}", error=str(e))
-    
+            return CommandResult(
+                False,
+                f"Command processing failed: {e}",
+                error=str(e),
+            )
+
     def _handle_coordinates_command(self) -> CommandResult:
         """Handle coordinates command."""
         coords_data = {
             agent_id: {
-                "x": coord.x,
-                "y": coord.y,
-                "description": coord.description
+                "x": data["x"],
+                "y": data["y"],
+                "description": data.get("description", ""),
             }
-            for agent_id, coord in self.coordinates.items()
+            for agent_id, data in COORDINATES.items()
         }
         return CommandResult(True, "Coordinates retrieved", data=coords_data)
-    
+
     def _handle_list_agents_command(self) -> CommandResult:
         """Handle list agents command."""
         agents = self.list_agents()
-        return CommandResult(True, f"Available agents: {', '.join(agents)}", data={"agents": agents})
-    
+        return CommandResult(
+            True,
+            f"Available agents: {', '.join(agents)}",
+            data={"agents": agents},
+        )
+
     def _handle_send_command(self, command: CLICommand) -> CommandResult:
         """Handle send command."""
         # Simplified send command handling
-        return CommandResult(True, f"Message sent to {command.agent}: {command.message}")
-    
+        return CommandResult(
+            True,
+            f"Message sent to {command.agent}: {command.message}",
+        )
+
     def get_system_status(self) -> Dict[str, Any]:
         """Get system status."""
         return {
-            "total_agents": len(self.coordinates),
+            "total_agents": len(COORDINATES),
             "available_commands": ["coordinates", "list_agents", "send"],
-            "system_health": "operational"
+            "system_health": "operational",
         }

--- a/tests/test_coordinates_registry.py
+++ b/tests/test_coordinates_registry.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("."))
+
+from src.agent_registry import COORDINATES  # noqa: E402
+from src.services.handlers.utility_handler import UtilityHandler  # noqa: E402
+from src.services.messaging_handlers_engine import (  # noqa: E402
+    MessagingHandlersEngine,
+)
+
+
+def test_utility_handler_coordinates():
+    handler = UtilityHandler()
+    assert handler.get_coordinates() == COORDINATES
+
+
+def test_messaging_engine_coordinates():
+    engine = MessagingHandlersEngine()
+    for agent_id, data in COORDINATES.items():
+        coord = engine.get_agent_coordinates(agent_id)
+        assert coord is not None
+        assert coord.x == data["x"]
+        assert coord.y == data["y"]
+        assert coord.description == data.get("description", "")


### PR DESCRIPTION
## Summary
- add shared `COORDINATES` mapping to `agent_registry`
- refactor `UtilityHandler` and `MessagingHandlersEngine` to source coordinates from the registry
- verify coordinate registry usage with new tests

## Testing
- `flake8 src/services/handlers/utility_handler.py src/services/messaging_handlers_engine.py src/agent_registry.py tests/test_coordinates_registry.py`
- `pytest tests/test_coordinates_registry.py -q`
- `pytest -q` *(fails: IndentationError and other issues in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bad80c07a88329a099d865a42686aa