### PR TITLE
fix: centralize logger usage across messaging components

### DIFF
--- a/src/core/enhanced_integration/coordinators/enhanced_integration_coordinator.py
+++ b/src/core/enhanced_integration/coordinators/enhanced_integration_coordinator.py
@@ -15,7 +15,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 from datetime import datetime
-import logging
 
 from ..integration_models import (
     EnhancedOptimizationConfig, IntegrationStatus, create_default_optimization_config,
@@ -24,18 +23,20 @@ from ..integration_models import (
 from ..engines.integration_task_engine import IntegrationTaskEngine
 from ..engines.integration_performance_engine import IntegrationPerformanceEngine
 
-# Import system components with fallback
+from src.utils.logger import get_logger
+
 try:
-    from ...unified_logging_system import get_logger
     from ...unified_validation_system import validate_required_fields
     from ...vector_database_enhanced_integration import EnhancedVectorDatabaseIntegration
 except ImportError:
     # Fallback implementations
-    def get_logger(name): return logging.getLogger(name)
     def validate_required_fields(*args): return True
     class EnhancedVectorDatabaseIntegration:
-        def __init__(self, *args, **kwargs): pass
-        def optimize_performance(self): return {}
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def optimize_performance(self):
+            return {}
 
 
 class EnhancedIntegrationCoordinator:

--- a/src/core/messaging_optimizer_engines.py
+++ b/src/core/messaging_optimizer_engines.py
@@ -15,17 +15,12 @@ import asyncio
 import time
 from typing import Any, Dict, List
 from queue import Queue, Empty
-import logging
 
 from .messaging_optimizer_models import (
     MessagingConfig, MessagingMetrics, OptimizationResult
 )
 
-# Import systems with fallback
-try:
-    from .unified_logging_system import get_logger
-except ImportError:
-    def get_logger(name): return logging.getLogger(name)
+from src.utils.logger import get_logger
 
 
 class BatchProcessor:

--- a/src/core/messaging_optimizer_orchestrator.py
+++ b/src/core/messaging_optimizer_orchestrator.py
@@ -15,7 +15,6 @@ import asyncio
 import time
 from typing import Any, Dict, List, Optional
 from queue import Queue
-import logging
 
 from .messaging_optimizer_models import (
     MessagingConfig, MessagingMetrics, OptimizationResult, 
@@ -26,11 +25,7 @@ from .messaging_optimizer_engines import (
     ConnectionPoolEngine, MetricsEngine
 )
 
-# Import systems with fallback
-try:
-    from .unified_logging_system import get_logger
-except ImportError:
-    def get_logger(name): return logging.getLogger(name)
+from src.utils.logger import get_logger
 
 
 class MessagingOptimizationOrchestrator:

--- a/src/services/unified_messaging_imports.py
+++ b/src/services/unified_messaging_imports.py
@@ -10,14 +10,7 @@ License: MIT
 """
 
 # Core unified system imports
-import logging
-
-try:
-    from src.core.unified_logging_system import get_logger
-except ImportError:
-    # Fallback if unified logging system not available
-    def get_logger(name: str) -> logging.Logger:
-        return logging.getLogger(name)
+from src.utils.logger import get_logger
 
 def get_timestamp():
     return datetime.now().isoformat()
@@ -53,11 +46,8 @@ from .models.messaging_models import (
 
 # Utility functions for common patterns
 def get_messaging_logger(name: str = __name__) -> logging.Logger:
-    """Get logger with unified logging system fallback."""
-    try:
-        return get_logger(name)
-    except:
-        return logging.getLogger(name)
+    """Get messaging logger using unified logging system."""
+    return get_logger(name)
 
 def load_coordinates_from_json():
     """Load agent coordinates from JSON file with error handling."""


### PR DESCRIPTION
## Summary
- replace scattered `get_logger` definitions with imports from `src.utils.logger`
- drop fallback logger implementations to enforce a single source of truth
- confirm touched files remain under 300 lines

## Testing
- `pre-commit run --files src/services/unified_messaging_imports.py src/core/messaging_optimizer_engines.py src/core/messaging_optimizer_orchestrator.py src/core/enhanced_integration/coordinators/enhanced_integration_coordinator.py` *(fails: InvalidManifestError)*
- `pytest` *(fails: 19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bad875477883298b9f39ac4eda5ac8