### PR TITLE
feat: centralize agent coordinates

### DIFF
--- a/src/services/agent_registry.py
+++ b/src/services/agent_registry.py
@@ -3,6 +3,50 @@
 from typing import Any, Dict, List
 
 
+COORDINATES: Dict[str, Dict[str, Any]] = {
+    "Agent-1": {
+        "x": -1269,
+        "y": 481,
+        "description": "Integration & Core Systems Specialist",
+    },
+    "Agent-2": {
+        "x": -308,
+        "y": 480,
+        "description": "Architecture & Design Specialist",
+    },
+    "Agent-3": {
+        "x": -1269,
+        "y": 1001,
+        "description": "Infrastructure & DevOps Specialist",
+    },
+    "Agent-4": {
+        "x": -308,
+        "y": 1000,
+        "description": "Quality Assurance Specialist (CAPTAIN)",
+    },
+    "Agent-5": {
+        "x": 652,
+        "y": 421,
+        "description": "Business Intelligence Specialist",
+    },
+    "Agent-6": {
+        "x": 1612,
+        "y": 419,
+        "description": "Coordination & Communication Specialist",
+    },
+    "Agent-7": {
+        "x": 653,
+        "y": 940,
+        "description": "Web Development Specialist",
+    },
+    "Agent-8": {
+        "x": 1611,
+        "y": 941,
+        "description": "SSOT & System Integration Specialist",
+    },
+}
+
+
 def format_agent_list(agents: List[str]) -> Dict[str, Any]:
     """Return standardized response data for a list of agents.
 

--- a/src/services/handlers/utility_handler.py
+++ b/src/services/handlers/utility_handler.py
@@ -13,6 +13,8 @@ License: MIT
 
 from typing import Any, Dict, List, Optional
 
+from ..agent_registry import COORDINATES
+
 
 class UtilityHandler:
     """
@@ -24,7 +26,6 @@ class UtilityHandler:
     def __init__(self):
         """Initialize utility handler."""
         self.agent_list = []
-        self.coordinates = {}
         self.history = []
     
     def handle_utility_commands(self, args) -> bool:
@@ -46,7 +47,9 @@ class UtilityHandler:
             if args.coordinates:
                 print("Agent Coordinates:")
                 print("=" * 40)
-                print("Agent coordinates loaded from configuration")
+                for agent_id, coords in COORDINATES.items():
+                    x, y = coords["x"], coords["y"]
+                    print(f"{agent_id}: ({x}, {y})")
                 print("Use --agent to send messages to specific agents")
                 return True
                 
@@ -77,16 +80,7 @@ class UtilityHandler:
     
     def get_coordinates(self) -> Dict[str, Any]:
         """Get agent coordinates."""
-        return {
-            "Agent-1": {"x": -100, "y": 1000},
-            "Agent-2": {"x": -200, "y": 1000},
-            "Agent-3": {"x": -300, "y": 1000},
-            "Agent-4": {"x": -400, "y": 1000},
-            "Agent-5": {"x": -500, "y": 1000},
-            "Agent-6": {"x": -600, "y": 1000},
-            "Agent-7": {"x": -700, "y": 1000},
-            "Agent-8": {"x": -800, "y": 1000}
-        }
+        return COORDINATES
     
     def get_history(self) -> List[Dict[str, Any]]:
         """Get message history."""

--- a/src/services/messaging_handlers_engine.py
+++ b/src/services/messaging_handlers_engine.py
@@ -13,7 +13,7 @@ Purpose: Modular engine for messaging CLI handlers
 import logging
 from typing import Any, Dict, List, Optional
 
-from .agent_registry import format_agent_list
+from .agent_registry import COORDINATES, format_agent_list
 from .messaging_handlers_models import CLICommand, CommandResult, CoordinateConfig
 
 
@@ -30,32 +30,14 @@ class MessagingHandlersEngine:
     def _load_coordinates(self) -> None:
         """Load agent coordinates from configuration."""
         try:
-            # Simplified coordinate loading
             self.coordinates = {
-                "Agent-1": CoordinateConfig(
-                    "Agent-1", -30, 1000, "Agent-1 coordinates"
-                ),
-                "Agent-2": CoordinateConfig(
-                    "Agent-2", -30, 1000, "Agent-2 coordinates"
-                ),
-                "Agent-3": CoordinateConfig(
-                    "Agent-3", -30, 1000, "Agent-3 coordinates"
-                ),
-                "Agent-4": CoordinateConfig(
-                    "Agent-4", -30, 1000, "Agent-4 coordinates"
-                ),
-                "Agent-5": CoordinateConfig(
-                    "Agent-5", -30, 1000, "Agent-5 coordinates"
-                ),
-                "Agent-6": CoordinateConfig(
-                    "Agent-6", -30, 1000, "Agent-6 coordinates"
-                ),
-                "Agent-7": CoordinateConfig(
-                    "Agent-7", -30, 1000, "Agent-7 coordinates"
-                ),
-                "Agent-8": CoordinateConfig(
-                    "Agent-8", -30, 1000, "Agent-8 coordinates"
-                ),
+                agent_id: CoordinateConfig(
+                    agent_id,
+                    coord["x"],
+                    coord["y"],
+                    coord.get("description", f"{agent_id} coordinates"),
+                )
+                for agent_id, coord in COORDINATES.items()
             }
         except Exception as e:
             self.logger.warning(f"Could not load coordinates: {e}")

--- a/tests/messaging/test_agent_registry.py
+++ b/tests/messaging/test_agent_registry.py
@@ -1,6 +1,8 @@
 """Tests for agent registry utilities."""
 
-from src.services.agent_registry import format_agent_list
+from src.services.agent_registry import COORDINATES, format_agent_list
+from src.services.handlers.utility_handler import UtilityHandler
+from src.services.messaging_handlers_engine import MessagingHandlersEngine
 
 
 def test_format_agent_list_returns_standard_structure():
@@ -10,3 +12,17 @@ def test_format_agent_list_returns_standard_structure():
     assert result["data"]["agents"] == ["Agent-1", "Agent-2"]
     assert result["data"]["agent_count"] == 2
     assert "Available agents" in result["message"]
+
+
+def test_coordinates_mapping_is_accessible():
+    handler = UtilityHandler()
+    assert handler.get_coordinates() == COORDINATES
+
+
+def test_engine_uses_registry_coordinates():
+    engine = MessagingHandlersEngine()
+    for agent_id, coords in COORDINATES.items():
+        coord = engine.get_agent_coordinates(agent_id)
+        assert coord is not None
+        assert coord.x == coords["x"]
+        assert coord.y == coords["y"]


### PR DESCRIPTION
## Summary
- add shared COORDINATES mapping to agent registry
- consume shared coordinates in UtilityHandler and MessagingHandlersEngine
- test registry integration with handlers

## Testing
- `pytest tests/messaging/test_agent_registry.py` *(fails: IndentationError in tests/messaging/conftest.py)*
- `flake8 src/services/agent_registry.py src/services/handlers/utility_handler.py src/services/messaging_handlers_engine.py tests/messaging/test_agent_registry.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad9fda9588329be15853c092727c5