### PR TITLE
feat: centralize agent registry

### DIFF
--- a/src/services/handlers/command_handler.py
+++ b/src/services/handlers/command_handler.py
@@ -15,6 +15,7 @@ import time
 from typing import Any, Dict, List
 
 from ..agent_registry import format_agent_list
+from ..utils.agent_registry import list_agents
 
 
 class CommandHandler:
@@ -57,16 +58,14 @@ class CommandHandler:
             if command == "coordinates":
                 result = await self._handle_coordinates_command(coordinate_handler)
             elif command == "list_agents":
-                result = await coordinate_handler.load_coordinates_async()
-                if result.get("success", False):
-                    agents = list(result["coordinates"].keys())
-                    formatted = format_agent_list(agents)
-                    print(
-                        f"\n🤖 Available Agents ({formatted['data']['agent_count']}):"
-                    )
-                    for agent in formatted["data"]["agents"]:
-                        print(f"  - {agent}")
-                    result = formatted
+                agents = list_agents()
+                formatted = format_agent_list(agents)
+                print(
+                    f"\n🤖 Available Agents ({formatted['data']['agent_count']}):"
+                )
+                for agent in formatted["data"]["agents"]:
+                    print(f"  - {agent}")
+                result = formatted
             elif command == "send_message":
                 result = await self._handle_send_message_command(
                     args, message_handler, service
@@ -144,16 +143,7 @@ class CommandHandler:
     ) -> Dict[str, Any]:
         """Handle bulk message command."""
         try:
-            # Get all agent coordinates
-            coordinate_handler = args.get("coordinate_handler")
-            if not coordinate_handler:
-                return {"success": False, "error": "Coordinate handler not provided"}
-
-            coords_result = await coordinate_handler.load_coordinates_async()
-            if not coords_result.get("success", False):
-                return coords_result
-
-            agents = list(coords_result["coordinates"].keys())
+            agents = list_agents()
             results = []
 
             for agent in agents:

--- a/src/services/handlers/utility_handler.py
+++ b/src/services/handlers/utility_handler.py
@@ -13,6 +13,8 @@ License: MIT
 
 from typing import Any, Dict, List, Optional
 
+from ..utils.agent_registry import AGENTS, list_agents
+
 
 class UtilityHandler:
     """
@@ -33,14 +35,9 @@ class UtilityHandler:
             if args.list_agents:
                 print("Available Agents:")
                 print("=" * 40)
-                print("Agent-1: Integration & Core Systems")
-                print("Agent-2: Architecture & Design")
-                print("Agent-3: Infrastructure & DevOps")
-                print("Agent-4: Strategic Oversight & Emergency Intervention")
-                print("Agent-5: Business Intelligence")
-                print("Agent-6: Coordination & Communication")
-                print("Agent-7: Web Development")
-                print("Agent-8: SSOT & System Integration")
+                for agent_id in list_agents():
+                    desc = AGENTS[agent_id]["description"]
+                    print(f"{agent_id}: {desc}")
                 return True
                 
             if args.coordinates:
@@ -65,28 +62,12 @@ class UtilityHandler:
     def list_agents(self) -> List[str]:
         """Get list of available agents."""
         return [
-            "Agent-1: Integration & Core Systems",
-            "Agent-2: Architecture & Design", 
-            "Agent-3: Infrastructure & DevOps",
-            "Agent-4: Strategic Oversight & Emergency Intervention",
-            "Agent-5: Business Intelligence",
-            "Agent-6: Coordination & Communication",
-            "Agent-7: Web Development",
-            "Agent-8: SSOT & System Integration"
+            f"{agent_id}: {info['description']}" for agent_id, info in AGENTS.items()
         ]
     
     def get_coordinates(self) -> Dict[str, Any]:
         """Get agent coordinates."""
-        return {
-            "Agent-1": {"x": -100, "y": 1000},
-            "Agent-2": {"x": -200, "y": 1000},
-            "Agent-3": {"x": -300, "y": 1000},
-            "Agent-4": {"x": -400, "y": 1000},
-            "Agent-5": {"x": -500, "y": 1000},
-            "Agent-6": {"x": -600, "y": 1000},
-            "Agent-7": {"x": -700, "y": 1000},
-            "Agent-8": {"x": -800, "y": 1000}
-        }
+        return {agent_id: info["coords"] for agent_id, info in AGENTS.items()}
     
     def get_history(self) -> List[Dict[str, Any]]:
         """Get message history."""

--- a/src/services/messaging_handlers_engine.py
+++ b/src/services/messaging_handlers_engine.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 
 from .agent_registry import format_agent_list
 from .messaging_handlers_models import CLICommand, CommandResult, CoordinateConfig
+from .utils.agent_registry import AGENTS, list_agents
 
 
 class MessagingHandlersEngine:
@@ -30,32 +31,14 @@ class MessagingHandlersEngine:
     def _load_coordinates(self) -> None:
         """Load agent coordinates from configuration."""
         try:
-            # Simplified coordinate loading
             self.coordinates = {
-                "Agent-1": CoordinateConfig(
-                    "Agent-1", -30, 1000, "Agent-1 coordinates"
-                ),
-                "Agent-2": CoordinateConfig(
-                    "Agent-2", -30, 1000, "Agent-2 coordinates"
-                ),
-                "Agent-3": CoordinateConfig(
-                    "Agent-3", -30, 1000, "Agent-3 coordinates"
-                ),
-                "Agent-4": CoordinateConfig(
-                    "Agent-4", -30, 1000, "Agent-4 coordinates"
-                ),
-                "Agent-5": CoordinateConfig(
-                    "Agent-5", -30, 1000, "Agent-5 coordinates"
-                ),
-                "Agent-6": CoordinateConfig(
-                    "Agent-6", -30, 1000, "Agent-6 coordinates"
-                ),
-                "Agent-7": CoordinateConfig(
-                    "Agent-7", -30, 1000, "Agent-7 coordinates"
-                ),
-                "Agent-8": CoordinateConfig(
-                    "Agent-8", -30, 1000, "Agent-8 coordinates"
-                ),
+                agent_id: CoordinateConfig(
+                    agent_id,
+                    info["coords"]["x"],
+                    info["coords"]["y"],
+                    f"{agent_id} coordinates",
+                )
+                for agent_id, info in AGENTS.items()
             }
         except Exception as e:
             self.logger.warning(f"Could not load coordinates: {e}")
@@ -66,7 +49,7 @@ class MessagingHandlersEngine:
 
     def list_agents(self) -> List[str]:
         """List all available agents."""
-        return list(self.coordinates.keys())
+        return list_agents()
 
     def validate_command(self, command: CLICommand) -> CommandResult:
         """Validate a CLI command."""

--- a/src/services/messaging_utils.py
+++ b/src/services/messaging_utils.py
@@ -9,7 +9,12 @@ Author: Agent-1 (Integration & Core Systems Specialist)
 License: MIT
 """
 
+from typing import Any, Dict, List, Optional
 
+from src.utils.logger import get_logger
+
+from .models.messaging_models import UnifiedMessage
+from .utils.agent_registry import AGENTS, list_agents
 
 
 class MessagingUtils:
@@ -17,34 +22,38 @@ class MessagingUtils:
 
     def __init__(
         self,
-        agents: Dict[str, Dict[str, Any]],
         inbox_paths: Dict[str, str],
         messages: List[UnifiedMessage],
+        agents: Optional[Dict[str, Dict[str, Any]]] = None,
     ):
         """Initialize utility service."""
-        self.agents = agents
+        self.agents = agents or AGENTS
         self.inbox_paths = inbox_paths
         self.messages = messages
 
-    def list_agents(self):
+    def list_agents(self) -> None:
         """List all available agents."""
         get_logger(__name__).info("📋 AVAILABLE AGENTS:")
         get_logger(__name__).info("=" * 50)
-        for agent_id, info in self.agents.items():
+        for agent_id in list_agents():
+            info = self.agents[agent_id]
             get_logger(__name__).info(f"🤖 {agent_id}: {info['description']}")
             get_logger(__name__).info(f"   📍 Coordinates: {info['coords']}")
-            get_logger(__name__).info(f"   📬 Inbox: {self.inbox_paths.get(agent_id, 'N/A')}")
+            get_logger(__name__).info(
+                f"   📬 Inbox: {self.inbox_paths.get(agent_id, 'N/A')}"
+            )
             get_logger(__name__).info()
 
-    def show_coordinates(self):
+    def show_coordinates(self) -> None:
         """Show agent coordinates."""
         get_logger(__name__).info("📍 AGENT COORDINATES:")
         get_logger(__name__).info("=" * 30)
-        for agent_id, info in self.agents.items():
+        for agent_id in list_agents():
+            info = self.agents[agent_id]
             get_logger(__name__).info(f"🤖 {agent_id}: {info['coords']}")
         get_logger(__name__).info()
 
-    def show_message_history(self):
+    def show_message_history(self) -> None:
         """Show message history."""
         get_logger(__name__).info("📜 MESSAGE HISTORY:")
         get_logger(__name__).info("=" * 30)

--- a/src/services/utils/agent_registry.py
+++ b/src/services/utils/agent_registry.py
@@ -1,0 +1,18 @@
+"""Centralized agent registry and helpers."""
+from typing import Any, Dict, List
+
+AGENTS: Dict[str, Dict[str, Any]] = {
+    "Agent-1": {"description": "Integration & Core Systems", "coords": {"x": -1269, "y": 421}},
+    "Agent-2": {"description": "Architecture & Design", "coords": {"x": -308, "y": 421}},
+    "Agent-3": {"description": "Infrastructure & DevOps", "coords": {"x": -1269, "y": 1001}},
+    "Agent-4": {"description": "Strategic Oversight", "coords": {"x": -308, "y": 1000}},
+    "Agent-5": {"description": "Business Intelligence", "coords": {"x": 652, "y": 421}},
+    "Agent-6": {"description": "Coordination & Communication", "coords": {"x": 1612, "y": 419}},
+    "Agent-7": {"description": "Web Development", "coords": {"x": 653, "y": 940}},
+    "Agent-8": {"description": "SSOT & System Integration", "coords": {"x": 1611, "y": 941}},
+}
+
+
+def list_agents() -> List[str]:
+    """Return a sorted list of agent identifiers."""
+    return sorted(AGENTS.keys())

--- a/tests/messaging/test_agent_registry.py
+++ b/tests/messaging/test_agent_registry.py
@@ -1,6 +1,7 @@
 """Tests for agent registry utilities."""
 
 from src.services.agent_registry import format_agent_list
+from src.services.utils.agent_registry import AGENTS, list_agents
 
 
 def test_format_agent_list_returns_standard_structure():
@@ -10,3 +11,8 @@ def test_format_agent_list_returns_standard_structure():
     assert result["data"]["agents"] == ["Agent-1", "Agent-2"]
     assert result["data"]["agent_count"] == 2
     assert "Available agents" in result["message"]
+
+
+def test_list_agents_matches_registry_keys():
+    agents = list_agents()
+    assert agents == sorted(AGENTS.keys())


### PR DESCRIPTION
## Summary
- add shared agent registry with `list_agents`
- refactor handlers and utilities to consume the shared agent list
- cover registry with unit tests

## Testing
- `python -m py_compile src/services/utils/agent_registry.py src/services/messaging_utils.py src/services/handlers/utility_handler.py src/services/messaging_handlers_engine.py src/services/handlers/command_handler.py tests/messaging/test_agent_registry.py`
- `pytest tests/messaging/test_agent_registry.py` *(fails: IndentationError in tests/messaging/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bada5782448329a6b8d4fbe5da4729