### PR TITLE
fix: prioritize overnight handler

### DIFF
--- a/src/services/messaging_cli.py
+++ b/src/services/messaging_cli.py
@@ -15,6 +15,7 @@ from .messaging_cli_handlers import (
     handle_message_commands,
     handle_onboarding_commands,
     handle_utility_commands,
+    handle_overnight_commands,
 )
 
 
@@ -71,7 +72,10 @@ def main():
     """Main entry point for messaging CLI."""
     parser = create_enhanced_parser()
     args = parser.parse_args()
-    
+
+    if handle_overnight_commands(args):
+        return
+
     # Handle utility commands first
     if handle_utility_commands(args):
         return

--- a/tests/test_messaging_cli_parser.py
+++ b/tests/test_messaging_cli_parser.py
@@ -1,0 +1,34 @@
+import pathlib
+import sys
+from unittest.mock import ANY, patch
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.services.messaging_cli import create_enhanced_parser, main
+
+
+def test_overnight_flag_parsed():
+    """Parser sets overnight flag when provided."""
+    parser = create_enhanced_parser()
+    args = parser.parse_args(["--overnight"])
+    assert args.overnight is True
+
+
+@patch("src.services.messaging_cli.handle_message_commands")
+@patch("src.services.messaging_cli.handle_onboarding_commands")
+@patch("src.services.messaging_cli.handle_contract_commands")
+@patch("src.services.messaging_cli.handle_utility_commands")
+@patch("src.services.messaging_cli.handle_overnight_commands")
+def test_overnight_handler_precedence(overnight, utility, contract, onboarding, message):
+    """Overnight commands are handled before other handlers."""
+    overnight.return_value = True
+    with patch.object(sys, "argv", ["prog", "--overnight"]):
+        main()
+    overnight.assert_called_once()
+    utility.assert_not_called()
+    contract.assert_not_called()
+    onboarding.assert_not_called()
+    message.assert_not_called()


### PR DESCRIPTION
## Summary
- call `handle_overnight_commands` before other messaging CLI handlers
- import `handle_overnight_commands` in the CLI
- add parser tests for the overnight flag and handler precedence

## Testing
- `pytest tests/test_messaging_cli_parser.py -q` *(fails: IndentationError in src/utils/logger.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bae53e3d3483299e4c417997d92a09