### PR TITLE
Add overnight flag tests and ensure registry-based agent listing

### DIFF
--- a/src/services/messaging_cli.py
+++ b/src/services/messaging_cli.py
@@ -15,6 +15,7 @@ from .messaging_cli_handlers import (
     handle_message_commands,
     handle_onboarding_commands,
     handle_utility_commands,
+    handle_overnight_commands,
 )
 
 
@@ -71,7 +72,11 @@ def main():
     """Main entry point for messaging CLI."""
     parser = create_enhanced_parser()
     args = parser.parse_args()
-    
+
+    # Handle overnight commands
+    if handle_overnight_commands(args):
+        return
+
     # Handle utility commands first
     if handle_utility_commands(args):
         return

--- a/tests/messaging/test_agent_registry.py
+++ b/tests/messaging/test_agent_registry.py
@@ -1,5 +1,8 @@
 """Tests for agent registry utilities."""
 
+import sys
+
+from src.services import messaging_cli
 from src.services.handlers.utility_handler import UtilityHandler
 from src.services.messaging_handlers_engine import MessagingHandlersEngine
 from src.services.utils.agent_registry import AGENTS, list_agents
@@ -26,3 +29,13 @@ def test_engine_uses_registry_coordinates():
         assert coord is not None
         assert coord.x == coords["x"]
         assert coord.y == coords["y"]
+
+
+def test_cli_lists_agents_from_registry(monkeypatch, capsys):
+    """CLI --list-agents should use agent registry."""
+    monkeypatch.setattr(sys, "argv", ["messaging_cli", "--list-agents"])
+    messaging_cli.main()
+    captured = capsys.readouterr()
+    for agent_id in list_agents():
+        text = f"{agent_id}: {AGENTS[agent_id]['description']}"
+        assert text in captured.out

--- a/tests/messaging/test_overnight_cli.py
+++ b/tests/messaging/test_overnight_cli.py
@@ -1,0 +1,22 @@
+"""Tests for overnight flag in messaging CLI."""
+
+import sys
+from pathlib import Path
+import subprocess
+
+from src.services import messaging_cli
+
+
+def test_overnight_flag_runs_overnight_system(monkeypatch):
+    """Ensure --overnight dispatches the overnight system script."""
+    called = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["messaging_cli", "--overnight"])
+
+    messaging_cli.main()
+
+    assert Path(called["cmd"][1]).name == "overnight_autonomous_system.py"


### PR DESCRIPTION
## Summary
- handle `--overnight` flag in messaging CLI
- test overnight dispatch via mocked subprocess
- verify `--list-agents` uses `agent_registry`

## Testing
- `pre-commit run --files src/services/messaging_cli.py tests/messaging/test_agent_registry.py tests/messaging/test_overnight_cli.py` *(fails: InvalidManifestError: Expected one of conda, coursier, dart, docker, docker_image, dotnet, fail, golang, haskell, julia, lua, node, perl, pygrep, python, r, ruby, rust, script, swift, system but got: 'python_venv')*
- `pytest tests/messaging/test_overnight_cli.py tests/messaging/test_agent_registry.py` *(fails: IndentationError: unexpected indent in tests/messaging/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bae54d4c0c8329ac1f02bea276e5f3