### PR TITLE
fix: use shared message validation

### DIFF
--- a/src/services/messaging_core.py
+++ b/src/services/messaging_core.py
@@ -30,6 +30,7 @@ from .models.messaging_models import (
     UnifiedRecipientType
 )
 from .message_identity_clarification import format_message_with_identity_clarification
+from .utils.messaging_validation_utils import MessagingValidationUtils
 
 
 class UnifiedMessagingCore:
@@ -89,17 +90,14 @@ class UnifiedMessagingCore:
             raise
 
     def validate_message(self, message: UnifiedMessage) -> bool:
-        """Validate message - simplified."""
+        """Validate message using shared validation utilities."""
         try:
-            if not message.content or len(message.content.strip()) == 0:
-                self.logger.error("Message content cannot be empty")
-                return False
-
-            if len(message.content) > 10000:  # 10k character limit
-                self.logger.error("Message content too long")
-                return False
-
-            return True
+            result = MessagingValidationUtils.validate_message_structure(message)
+            for warning in result.get("warnings", []):
+                self.logger.warning(warning)
+            for error in result.get("errors", []):
+                self.logger.error(error)
+            return result.get("valid", False)
         except Exception as e:
             self.logger.error(f"Error validating message: {e}")
             return False

--- a/src/services/simple_messaging_utils.py
+++ b/src/services/simple_messaging_utils.py
@@ -10,19 +10,30 @@ Author: Agent-6 - Coordination & Communication Specialist
 License: MIT
 """
 
+import logging
 from datetime import datetime
-from typing import Dict, List, Any
+from typing import Any, Dict, List
+
+from .models.messaging_models import UnifiedMessage
+from .utils.messaging_validation_utils import MessagingValidationUtils
 
 
 class SimpleMessagingUtils:
     """Simple messaging utilities."""
-    
+
     def __init__(self):
         self.message_log: List[Dict] = []
-    
+        self.logger = logging.getLogger(__name__)
+
     def validate_message(self, message: str) -> bool:
-        """Validate a message."""
-        return len(message.strip()) > 0 and len(message) < 1000
+        """Validate a message using shared validation utilities."""
+        temp = UnifiedMessage(content=message, sender="system", recipient="temp")
+        result = MessagingValidationUtils.validate_message_structure(temp)
+        for warning in result.get("warnings", []):
+            self.logger.warning(warning)
+        for error in result.get("errors", []):
+            self.logger.error(error)
+        return result.get("valid", False)
     
     def format_message(self, sender: str, recipient: str, content: str) -> str:
         """Format a message."""


### PR DESCRIPTION
## Summary
- refactor messaging_core to leverage MessagingValidationUtils
- centralize validation in simple_messaging_utils with unified logging

## Testing
- `pre-commit run --files src/services/messaging_core.py src/services/simple_messaging_utils.py` *(fails: InvalidManifestError: language 'python_venv')*
- `pytest` *(fails: multiple import errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc65dab2548329aac510edbcb19d07