### PR TITLE
feat: add cursor task monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Added
 - Shared `load_simple_config` helper for agent vector integration modules.
+- Database access layer for Cursor agent tasks.
+- Terminal completion monitor cross-checking Cursor task signals.
 
 ## [2.1.0] - 2025-09-01
 ### 🚀 Major Release: 100% V2 Compliance Achievement

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ AutoDream OS is a modular, V2 standards compliant platform for building agent-dr
 - **Refactored middleware pipeline** split into SRP modules under `src/services/middleware`
 - **Unified workspace management** via `UnifiedWorkspaceSystem`
 - **Base engine abstraction** centralizing initialization, status reporting, and cleanup
+- **Cursor task database integration** for terminal completion monitoring
 
 ## Middleware Execution Order
 Middleware chains process packets sequentially in the order that middleware

--- a/src/services/cursor_db.py
+++ b/src/services/cursor_db.py
@@ -1,0 +1,33 @@
+import os
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+class CursorTaskRepository:
+    """Database access layer for reading agent task records."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path or os.getenv("CURSOR_DB_PATH", "cursor_tasks.db")
+        self.db_user = os.getenv("CURSOR_DB_USER")
+        self.db_password = os.getenv("CURSOR_DB_PASSWORD")
+
+    def _get_connection(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def get_tasks_by_agent(self, agent_id: str) -> List[Dict[str, Any]]:
+        """Return all task records for a given agent."""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        try:
+            cursor.execute(
+                "SELECT task_id, agent_id, signal FROM agent_tasks WHERE agent_id = ?",
+                (agent_id,),
+            )
+            rows = cursor.fetchall()
+        finally:
+            cursor.close()
+            conn.close()
+        return [
+            {"task_id": row[0], "agent_id": row[1], "signal": row[2]}
+            for row in rows
+        ]

--- a/src/services/terminal_completion_monitor.py
+++ b/src/services/terminal_completion_monitor.py
@@ -1,0 +1,19 @@
+from typing import Iterable, Dict, Set
+
+from .cursor_db import CursorTaskRepository
+
+
+class TerminalCompletionMonitor:
+    """Cross-checks terminal signals against Cursor task entries."""
+
+    def __init__(self, repo: CursorTaskRepository) -> None:
+        self.repo = repo
+
+    def check_signals(self, agent_id: str, detected_signals: Iterable[str]) -> Dict[str, Set[str]]:
+        """Compare detected signals with DB records and return mismatches."""
+        tasks = self.repo.get_tasks_by_agent(agent_id)
+        expected = {task["signal"] for task in tasks}
+        detected = set(detected_signals)
+        unexpected = detected - expected
+        missing = expected - detected
+        return {"unexpected": unexpected, "missing": missing}

--- a/tests/test_terminal_completion_monitor.py
+++ b/tests/test_terminal_completion_monitor.py
@@ -1,0 +1,31 @@
+import sqlite3
+from pathlib import Path
+
+from src.services.cursor_db import CursorTaskRepository
+from src.services.terminal_completion_monitor import TerminalCompletionMonitor
+
+
+def setup_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        "CREATE TABLE agent_tasks (task_id TEXT, agent_id TEXT, signal TEXT)"
+    )
+    cursor.executemany(
+        "INSERT INTO agent_tasks VALUES (?, ?, ?)",
+        [("t1", "agent1", "sig1"), ("t2", "agent1", "sig2")],
+    )
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+
+def test_check_signals_flags_mismatches(tmp_path, monkeypatch):
+    db_file = tmp_path / "cursor.db"
+    setup_db(db_file)
+    monkeypatch.setenv("CURSOR_DB_PATH", str(db_file))
+    repo = CursorTaskRepository()
+    monitor = TerminalCompletionMonitor(repo)
+    result = monitor.check_signals("agent1", ["sig1", "sig3"])
+    assert result["unexpected"] == {"sig3"}
+    assert result["missing"] == {"sig2"}


### PR DESCRIPTION
## Summary
- add CursorTaskRepository for reading agent tasks from env-configured database
- cross-check terminal signals against stored tasks and flag mismatches
- document cursor task monitoring in README and changelog

## Testing
- `flake8 --max-line-length 100 --extend-ignore E203,W503,E501 src/services/cursor_db.py src/services/terminal_completion_monitor.py tests/test_terminal_completion_monitor.py`
- `python -m pytest tests/test_terminal_completion_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd751645788329a11e7a8430239b62