### PR TITLE
docs: remove period from commit message example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ This repository is primarily a **Python** project. Unless explicitly noted, all 
 
 ## Workflow
 - Commit messages must follow the convention:
-  `feat: short description` | `fix: short description` | `docs: short description`.
+  `feat: short description` | `fix: short description` | `docs: short description`
 - Pull requests must pass code review and CI checks before merge.
 - Split large features into smaller, incremental PRs.
 


### PR DESCRIPTION
## Summary
- remove trailing period from commit message convention example in AGENTS.md

## Testing
- `pre-commit run --files AGENTS.md` *(fails: InvalidConfigError)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'src', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bd85016b748329a7f85735b4ae0387