### PR TITLE
docs: add quickstart demo examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The project includes comprehensive TDD tests and smoke tests for validation (see
 - **Documentation**: ✅ Comprehensive Coverage
 
 ## Usage Examples
+See [quickstart demo](examples/quickstart_demo/) for a minimal agent workflow and dashboard.
 ### Basic Coordinate Operations
 ```python
 from src.services.messaging import CoordinateManager
@@ -244,10 +245,9 @@ examples/ # examples and demos
 - Provide CLI entrypoints and smoke tests for new modules
 
 ## Links
-- [Examples](examples/)
+- [Examples](examples/) – includes [quickstart demo](examples/quickstart_demo/)
 - [Tests](tests/)
 - [Configuration](config/)
-
 ## Achievements
 ### What's Been Accomplished
 - 180+ lines of duplicate code eliminated

--- a/examples/quickstart_demo/README.md
+++ b/examples/quickstart_demo/README.md
@@ -10,8 +10,8 @@ This directory contains minimal examples to help you explore AutoDream OS.
 Run the scripts directly:
 
 ```bash
-python workflow_demo.py
-python dashboard_demo.py
+python examples/quickstart_demo/workflow_demo.py
+python examples/quickstart_demo/dashboard_demo.py
 ```
 
 These examples are self-contained and intended as starting points for your own experiments.

--- a/examples/quickstart_demo/README.md
+++ b/examples/quickstart_demo/README.md
@@ -1,0 +1,17 @@
+# Quickstart Demo
+
+This directory contains minimal examples to help you explore AutoDream OS.
+
+## Files
+
+- `workflow_demo.py` – shows a simple agent workflow.
+- `dashboard_demo.py` – prints a text-based agent status dashboard.
+
+Run the scripts directly:
+
+```bash
+python workflow_demo.py
+python dashboard_demo.py
+```
+
+These examples are self-contained and intended as starting points for your own experiments.

--- a/examples/quickstart_demo/dashboard_demo.py
+++ b/examples/quickstart_demo/dashboard_demo.py
@@ -1,0 +1,28 @@
+"""Text-based dashboard demo for AutoDream OS.
+
+Shows how agent status might be displayed."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def get_agent_status() -> Dict[str, str]:
+    """Return a mapping of agent names to status strings."""
+    return {
+        "Agent-1": "online",
+        "Agent-2": "idle",
+        "Agent-3": "offline",
+    }
+
+
+def display_dashboard() -> None:
+    """Display a simple dashboard of agent statuses."""
+    status = get_agent_status()
+    print("Agent Status Dashboard")
+    for name, state in status.items():
+        print(f"{name}: {state}")
+
+
+if __name__ == "__main__":
+    display_dashboard()

--- a/examples/quickstart_demo/workflow_demo.py
+++ b/examples/quickstart_demo/workflow_demo.py
@@ -1,0 +1,28 @@
+"""Quickstart agent workflow demo.
+
+This script demonstrates a minimal agent workflow using AutoDream OS services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Agent:
+    """Simple agent representation used for demonstration purposes."""
+
+    name: str
+
+    def greet(self) -> str:
+        """Return a greeting message."""
+        return f"Hello from {self.name}!"
+
+
+def run_demo() -> None:
+    """Run the workflow demo."""
+    agent = Agent(name="DemoAgent")
+    print(agent.greet())
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/examples/quickstart_demo/workflow_demo.py
+++ b/examples/quickstart_demo/workflow_demo.py
@@ -1,6 +1,6 @@
 """Quickstart agent workflow demo.
 
-This script demonstrates a minimal agent workflow using AutoDream OS services."""
+This script demonstrates a minimal, self-contained agent representation."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- add `examples/quickstart_demo` with workflow and dashboard demos
- reference quickstart demo in main README

## Testing
- `pre-commit run --files examples/quickstart_demo/README.md examples/quickstart_demo/workflow_demo.py examples/quickstart_demo/dashboard_demo.py README.md` *(snapshot hook missing ProjectScanner, skipped)*
- `pytest` *(fails: NameError and ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9f136c1083298a2cb951b976cce6