### PR TITLE
feat: use enum for agent statuses in demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Changed
 - Consolidated captain documentation into `docs/guides/captain_handbook.md`.
 - Updated `AGENTS.md` to emphasize Python-first guidelines and exempt the monitoring component from language restrictions.
+- Refactored dashboard demo to use Enum-based agent statuses for type safety.
 ### Removed
 - Removed obsolete `urgent_agent_activation.py` and `ai_ml_cli.py` after confirming no in-repo usage.
 - Deleted redundant `docs/CAPTAIN_HANDBOOK.md` and `docs/guides/CAPTAIN_AGENT_4_OPERATIONAL_HANDBOOK.md`.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ It streamlines agent orchestration, speeds prototyping, and enables reliable dep
 - **Refactored middleware pipeline** split into SRP modules under `src/services/middleware`
 - **Unified workspace management** via `UnifiedWorkspaceSystem`
 - **Base engine abstraction** centralizing initialization, status reporting, and cleanup
-- **Overnight consistency enhancements** with rotating validation prompts and optional QA agent
-  delivering completion signals
+- **Overnight consistency enhancements** with rotating validation prompts and QA agent support
   ([spec](docs/specifications/OVERNIGHT_CONSISTENCY_ENHANCEMENTS_PRD.md))
+- **Example dashboard** demonstrates Enum-based agent statuses for clarity
 ## Middleware Execution Order
 Middleware chains process packets sequentially in the order that middleware
 components are listed. Each component receives the `DataPacket` returned by the

--- a/examples/quickstart_demo/dashboard_demo.py
+++ b/examples/quickstart_demo/dashboard_demo.py
@@ -5,14 +5,23 @@ Shows how agent status might be displayed."""
 from __future__ import annotations
 
 from typing import Dict
+from enum import Enum
 
 
-def get_agent_status() -> Dict[str, str]:
-    """Return a mapping of agent names to status strings."""
+class AgentStatus(Enum):
+    """Represents the possible statuses of an agent."""
+
+    ONLINE = "online"
+    IDLE = "idle"
+    OFFLINE = "offline"
+
+
+def get_agent_status() -> Dict[str, AgentStatus]:
+    """Return a mapping of agent names to their statuses."""
     return {
-        "Agent-1": "online",
-        "Agent-2": "idle",
-        "Agent-3": "offline",
+        "Agent-1": AgentStatus.ONLINE,
+        "Agent-2": AgentStatus.IDLE,
+        "Agent-3": AgentStatus.OFFLINE,
     }
 
 
@@ -21,7 +30,7 @@ def display_dashboard() -> None:
     status = get_agent_status()
     print("Agent Status Dashboard")
     for name, state in status.items():
-        print(f"{name}: {state}")
+        print(f"{name}: {state.value}")
 
 
 if __name__ == "__main__":

--- a/tests/test_dashboard_demo.py
+++ b/tests/test_dashboard_demo.py
@@ -1,0 +1,25 @@
+"""Tests for the dashboard demo using AgentStatus enum."""
+
+from examples.quickstart_demo.dashboard_demo import (
+    AgentStatus,
+    display_dashboard,
+    get_agent_status,
+)
+
+
+def test_get_agent_status_mapping() -> None:
+    """Agent status mapping uses enum values."""
+    status = get_agent_status()
+    assert status["Agent-1"] is AgentStatus.ONLINE
+    assert status["Agent-2"] is AgentStatus.IDLE
+    assert status["Agent-3"] is AgentStatus.OFFLINE
+
+
+def test_display_dashboard_output(capsys) -> None:
+    """Dashboard prints human-readable statuses."""
+    display_dashboard()
+    captured = capsys.readouterr().out
+    assert "Agent-1: online" in captured
+    assert "Agent-2: idle" in captured
+    assert "Agent-3: offline" in captured
+


### PR DESCRIPTION
## Summary
- replace string literals with AgentStatus enum in dashboard demo
- document enum-based statuses in README
- add tests verifying dashboard demo output

## Testing
- `pre-commit run --files examples/quickstart_demo/dashboard_demo.py tests/test_dashboard_demo.py CHANGELOG.md README.md project_analysis.json test_analysis.json chatgpt_project_context.json` *(failed: Unable to import ProjectScanner)*
- `pytest` *(errors: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bda346a3848329ba81b5d19fdfa648