### PR TITLE
fix: centralize test artifact cleanup

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+"""Test package for AutoDream.Os."""
+
+__all__: list[str] = []
+

--- a/tests/submodules/cleanup.py
+++ b/tests/submodules/cleanup.py
@@ -1,15 +1,26 @@
-"""Utilities for cleaning up test artifacts."""
+"""Utilities for cleaning up test artifacts.
 
-<<<<<<< HEAD
-=======
-from tests.testing_config import RESULTS_DIR, COVERAGE_DIR
+This module provides helpers to clear out files generated during test runs. It relies on
+directory locations defined in :mod:`tests.testing_config` to maintain a single source of
+truth for test artifacts.
+"""
 
->>>>>>> origin/codex/catalog-functions-in-utils-directories
+from tests.testing_config import COVERAGE_DIR, RESULTS_DIR
+
 
 def cleanup_artifacts() -> None:
-    """Remove files generated during test runs."""
+    """Remove files generated during test runs.
+
+    The function iterates over the configured results and coverage directories, deleting
+    any files present while leaving directory structures intact.
+    """
+
     for directory in (RESULTS_DIR, COVERAGE_DIR):
         if directory.exists():
             for item in directory.iterdir():
                 if item.is_file():
                     item.unlink()
+
+
+__all__ = ["cleanup_artifacts"]
+

--- a/tests/test_cleanup_artifacts.py
+++ b/tests/test_cleanup_artifacts.py
@@ -1,0 +1,35 @@
+"""Tests for the :mod:`tests.submodules.cleanup` module."""
+
+import pytest
+
+from tests.submodules.cleanup import cleanup_artifacts
+from tests.testing_config import COVERAGE_DIR, RESULTS_DIR
+
+
+@pytest.fixture()
+def artifact_dirs() -> None:
+    """Create temporary files in the results and coverage directories."""
+
+    for directory in (RESULTS_DIR, COVERAGE_DIR):
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "temp.txt").write_text("data", encoding="utf-8")
+    yield
+    for directory in (RESULTS_DIR, COVERAGE_DIR):
+        if directory.exists():
+            for item in directory.iterdir():
+                if item.is_file():
+                    item.unlink()
+            directory.rmdir()
+
+
+def test_cleanup_artifacts_removes_files(artifact_dirs: None) -> None:
+    """Ensure cleanup removes files from configured directories."""
+
+    for directory in (RESULTS_DIR, COVERAGE_DIR):
+        assert any(directory.iterdir())
+
+    cleanup_artifacts()
+
+    for directory in (RESULTS_DIR, COVERAGE_DIR):
+        assert list(directory.iterdir()) == []
+

--- a/tests/testing_config.py
+++ b/tests/testing_config.py
@@ -1,0 +1,16 @@
+"""Centralized configuration for tests.
+
+This module defines directory locations used during testing to store intermediate artifacts.
+By keeping these paths here, we maintain a single source of truth for test configuration.
+"""
+
+from pathlib import Path
+
+
+BASE_TEST_DIR: Path = Path(__file__).resolve().parent
+RESULTS_DIR: Path = BASE_TEST_DIR / "results"
+COVERAGE_DIR: Path = BASE_TEST_DIR / "coverage"
+
+
+__all__ = ["BASE_TEST_DIR", "RESULTS_DIR", "COVERAGE_DIR"]
+


### PR DESCRIPTION
## Summary
- resolve merge conflict in test artifact cleanup utility
- centralize test paths in `tests/testing_config`
- add unit test verifying artifact cleanup

## Testing
- `pytest tests/test_cleanup_artifacts.py -q`
- `pre-commit run --files tests/submodules/cleanup.py tests/testing_config.py tests/test_cleanup_artifacts.py tests/__init__.py` *(fails: Unable to import ProjectScanner)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc4e4916c8329aa3fa92e715673d2